### PR TITLE
Clarify OpenID Connect (OIDC) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Open Distro for Elasticsearch Security is an Elasticsearch plugin that offers en
 * Active Directory / LDAP
 * Kerberos / SPNEGO
 * JSON web token (JWT)
-* OpenID
+* OpenID Connect (OIDC)
 * SAML
 * Document-level security
 * Field-level security


### PR DESCRIPTION
This plugin supports the modern OpenID Connect (OIDC) protocol, not the older XML-based OpenID 2.0 protocol. This PR updates the README to clarify this.

Ideally, references in code would also be updated to refer to “OIDC” instead of just “OpenID”, but that’s likely to be a breaking change.