### PR TITLE
Handle attributes when impersonating user

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/internal/InternalAuthenticationBackend.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/internal/InternalAuthenticationBackend.java
@@ -35,6 +35,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
@@ -88,6 +89,17 @@ public class InternalAuthenticationBackend implements AuthenticationBackend, Aut
             user.addRoles(roles);
         }
         
+        final Settings customAttributes = cfg.getAsSettings(user.getName() + ".attributes");
+        HashMap<String, String> attributeMap = new HashMap<String, String>();
+
+        if(customAttributes != null) {
+            for(String attributeName: customAttributes.names()) {
+                attributeMap.put("attr.internal."+attributeName, customAttributes.get(attributeName));
+            }
+        }
+
+        user.addAttributes(attributeMap);
+
         return true;
     }
     

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/HttpIntegrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/HttpIntegrationTests.java
@@ -248,6 +248,7 @@ public class HttpIntegrationTests extends SingleClusterTest {
             res = rh.executeGetRequest("/_opendistro/_security/authinfo", new BasicHeader("opendistro_security_impersonate_as","knuddel"), encodeBasicHeader("worf", "worf"));
             Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
             Assert.assertTrue(res.getBody().contains("name=knuddel"));
+            Assert.assertTrue(res.getBody().contains("attr.internal.test1"));
             Assert.assertFalse(res.getBody().contains("worf"));
             
             res = rh.executeGetRequest("/_opendistro/_security/authinfo", new BasicHeader("opendistro_security_impersonate_as","nonexists"), encodeBasicHeader("worf", "worf"));

--- a/src/test/resources/internal_users.yml
+++ b/src/test/resources/internal_users.yml
@@ -106,6 +106,8 @@ logstash:
   
 knuddel:
   hash: _imponly_
+  attributes:
+    test1: test2
 
 twitter:
   hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m


### PR DESCRIPTION
After impersonating a user using the `opendistro_security_impersonate_as` header, all of my document-level-security rules that relied on user attributes exploded.

Additionally, the attributes were not visible on a query to `_opendistro/_security/authinfo` - user name, roles, etc... all looked right, but `custom_attribute_names` was empty.

This pull request includes a unit test that checks for this behavior, along with a fix so that user attributes are handled the same way roles are on impersonation.

Closes #22.