### PR TITLE
extended proxy authenticator to pass additional attributes via header

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
@@ -78,6 +78,7 @@ import com.amazon.opendistroforelasticsearch.security.http.HTTPBasicAuthenticato
 import com.amazon.opendistroforelasticsearch.security.http.HTTPClientCertAuthenticator;
 import com.amazon.opendistroforelasticsearch.security.http.HTTPProxyAuthenticator;
 import com.amazon.opendistroforelasticsearch.security.http.XFFResolver;
+import com.amazon.opendistroforelasticsearch.security.http.proxy.HTTPExtendedProxyAuthenticator;
 import com.amazon.opendistroforelasticsearch.security.ssl.util.Utils;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.HTTPHelper;
@@ -213,6 +214,7 @@ public class BackendRegistry implements ConfigurationChangeListener {
 
         authImplMap.put("basic_h", HTTPBasicAuthenticator.class.getName());
         authImplMap.put("proxy_h", HTTPProxyAuthenticator.class.getName());
+        authImplMap.put("extended-proxy_h", HTTPExtendedProxyAuthenticator.class.getName());
         authImplMap.put("clientcert_h", HTTPClientCertAuthenticator.class.getName());
         authImplMap.put("kerberos_h", "com.amazon.dlic.auth.http.kerberos.HTTPSpnegoAuthenticator");
         authImplMap.put("jwt_h", "com.amazon.dlic.auth.http.jwt.HTTPJwtAuthenticator");

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/http/proxy/HTTPExtendedProxyAuthenticator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/http/proxy/HTTPExtendedProxyAuthenticator.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015-2018 _floragunn_ GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Portions Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.http.proxy;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map.Entry;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestRequest;
+
+import com.amazon.opendistroforelasticsearch.security.http.HTTPProxyAuthenticator;
+import com.amazon.opendistroforelasticsearch.security.user.AuthCredentials;
+import com.google.common.base.Joiner;
+
+public class HTTPExtendedProxyAuthenticator extends HTTPProxyAuthenticator{
+
+    private static final String ATTR_PROXY = "attr.proxy.";
+    private static final String ATTR_PROXY_USERNAME = "attr.proxy.username";
+    protected final Logger log = LogManager.getLogger(this.getClass());
+    private volatile Settings settings;
+
+    public HTTPExtendedProxyAuthenticator(Settings settings, final Path configPath) {
+        super(settings, configPath);
+        this.settings = settings;
+    }
+
+    @Override
+    public AuthCredentials extractCredentials(final RestRequest request, ThreadContext context) {
+    	AuthCredentials credentials = super.extractCredentials(request, context);
+    	if(credentials == null) {
+    	    return null;
+    	}
+        
+        String attrHeaderPrefix = settings.get("attr_header_prefix");
+        if(Strings.isNullOrEmpty(attrHeaderPrefix)) {
+            log.debug("attr_header_prefix is null. Skipping additional attribute extraction");
+            return credentials;
+        } else if(log.isDebugEnabled()) {
+            log.debug("attrHeaderPrefix {}", attrHeaderPrefix);
+        }
+        
+        credentials.addAttribute(ATTR_PROXY_USERNAME, credentials.getUsername());
+        attrHeaderPrefix = attrHeaderPrefix.toLowerCase();
+        for (Entry<String, List<String>> entry : request.getHeaders().entrySet()) {
+            String key = entry.getKey().toLowerCase();
+            if(key.startsWith(attrHeaderPrefix)) {
+                key = ATTR_PROXY + key.substring(attrHeaderPrefix.length());
+                credentials.addAttribute(key, Joiner.on(",").join(entry.getValue().iterator()));
+                if(log.isTraceEnabled()) {
+                    log.trace("Found user custom attribute '{}'", key);
+                }
+            }
+        }
+        return credentials.markComplete();
+    }
+
+    @Override
+    public boolean reRequestAuthentication(final RestChannel channel, AuthCredentials creds) {
+        return false;
+    }
+
+    @Override
+    public String getType() {
+        return "extended-proxy";
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ModuleType.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ModuleType.java
@@ -43,6 +43,7 @@ import com.amazon.opendistroforelasticsearch.security.auth.internal.NoOpAuthoriz
 import com.amazon.opendistroforelasticsearch.security.http.HTTPBasicAuthenticator;
 import com.amazon.opendistroforelasticsearch.security.http.HTTPClientCertAuthenticator;
 import com.amazon.opendistroforelasticsearch.security.http.HTTPProxyAuthenticator;
+import com.amazon.opendistroforelasticsearch.security.http.proxy.HTTPExtendedProxyAuthenticator;
 import com.amazon.opendistroforelasticsearch.security.ssl.transport.PrincipalExtractor;
 import com.amazon.opendistroforelasticsearch.security.transport.InterClusterRequestEvaluator;
 
@@ -63,6 +64,7 @@ public enum ModuleType implements Serializable {
 	NOOP_AUTHORIZATION_BACKEND("Noop authorization backend", NoOpAuthorizationBackend.class.getName(), Boolean.FALSE),
 	HTTP_BASIC_AUTHENTICATOR("HTTP Basic Authenticator", HTTPBasicAuthenticator.class.getName(), Boolean.FALSE),
 	HTTP_PROXY_AUTHENTICATOR("HTTP Proxy Authenticator", HTTPProxyAuthenticator.class.getName(), Boolean.FALSE),
+    HTTP_EXT_PROXY_AUTHENTICATOR("HTTP Extended Proxy Authenticator", HTTPExtendedProxyAuthenticator.class.getName(), Boolean.FALSE),
 	HTTP_CLIENTCERT_AUTHENTICATOR("HTTP Client Certificate Authenticator", HTTPClientCertAuthenticator.class.getName(), Boolean.FALSE),
 	CUSTOM_HTTP_AUTHENTICATOR("Custom HTTP authenticator", null, Boolean.TRUE),
 	CUSTOM_AUTHENTICATION_BACKEND("Custom authentication backend", null, Boolean.TRUE),

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/http/proxy/HTTPExtendedProxyAuthenticatorTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/http/proxy/HTTPExtendedProxyAuthenticatorTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2015-2018 _floragunn_ GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Portions Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.opendistroforelasticsearch.security.http.proxy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.rest.RestRequest;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.amazon.opendistroforelasticsearch.security.http.proxy.HTTPExtendedProxyAuthenticator;
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import com.amazon.opendistroforelasticsearch.security.user.AuthCredentials;
+
+public class HTTPExtendedProxyAuthenticatorTest {
+
+    private HTTPExtendedProxyAuthenticator authenticator;
+    private ThreadContext context = new ThreadContext(Settings.EMPTY);
+    private Map<String, List<String>> headers = new HashMap<>();
+    private Settings settings;
+
+    @Before
+    public void setup() {
+        context.putTransient(ConfigConstants.OPENDISTRO_SECURITY_XFF_DONE, Boolean.TRUE);
+        settings = Settings.builder()
+                .put("user_header","user")
+                .build();
+        authenticator = new HTTPExtendedProxyAuthenticator(settings, null);
+    }
+
+    @Test
+    public void testGetType() {
+        assertEquals("extended-proxy", authenticator.getType());
+    }
+
+    @Test(expected = ElasticsearchSecurityException.class)
+    public void testThrowsExceptionWhenMissingXFFDone() {
+        authenticator = new HTTPExtendedProxyAuthenticator(Settings.EMPTY, null);
+        authenticator.extractCredentials(new TestRestRequest(),  new ThreadContext(Settings.EMPTY));
+    }
+
+    @Test
+    public void testReturnsNullWhenUserHeaderIsUnconfigured() {
+        authenticator = new HTTPExtendedProxyAuthenticator(Settings.EMPTY, null);
+        assertNull(authenticator.extractCredentials(new TestRestRequest(), context));
+    }
+
+    @Test
+    public void testReturnsNullWhenUserHeaderIsMissing() {
+        
+        assertNull(authenticator.extractCredentials(new TestRestRequest(), context));
+    }
+    @Test
+    
+    public void testReturnsCredentials() {
+        headers.put("user", new ArrayList<>());
+        headers.put("proxy_uid", new ArrayList<>());
+        headers.put("proxy_other", new ArrayList<>());
+        headers.get("user").add("aValidUser");
+        headers.get("proxy_uid").add("123");
+        headers.get("proxy_uid").add("456");
+        headers.get("proxy_other").add("someothervalue");
+        
+        settings = Settings.builder().put(settings).put("attr_header_prefix","proxy_").build();
+        authenticator = new HTTPExtendedProxyAuthenticator(settings,null);
+        AuthCredentials creds = authenticator.extractCredentials(new TestRestRequest(headers), context);
+        assertNotNull(creds);
+        assertEquals("aValidUser", creds.getUsername());
+        assertEquals("123,456", creds.getAttributes().get("attr.proxy.uid"));
+        assertEquals("someothervalue", creds.getAttributes().get("attr.proxy.other"));
+        assertTrue(creds.isComplete());
+    }
+
+    static class TestRestRequest extends RestRequest {
+        
+        public TestRestRequest() {
+            super(NamedXContentRegistry.EMPTY, new HashMap<>(), "", new HashMap<>());
+        }
+        public TestRestRequest(Map<String, List<String>> headers) {
+            super(NamedXContentRegistry.EMPTY, new HashMap<>(), "", headers);
+        }
+        public TestRestRequest(NamedXContentRegistry xContentRegistry, Map<String, String> params, String path,
+                Map<String, List<String>> headers) {
+            super(xContentRegistry, params, path, headers);
+        }
+
+        @Override
+        public Method method() {
+            return null;
+        }
+
+        @Override
+        public String uri() {
+            return null;
+        }
+
+        @Override
+        public boolean hasContent() {
+            return false;
+        }
+
+        @Override
+        protected BytesReference innerContent() {
+            return null;
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR introduces and extended proxy authenticator to allow proxies to pass additional user attributes that can be consumed when using document level security.  Configured like:
```
    http:
      xff:
        enabled: true
        remoteIpHeader: 'x-forwarded-for'
        trustedProxies: '.*'
        internalProxies: '.*'
    authc:
      authentication_domain_proxy:
        enabled: true
        order: 0
        http_authenticator:
          challenge: false
          type: extended-proxy
          config:
            user_header: 'x-proxy-remote-user'
            attr_header_prefix: 'x-proxy-ext-'
        authentication_backend:
          type: noop
```
This allows a trusted proxy to provide request headers:
```
x-proxy-ext-namespace: foo
x-proxy-ext-namespace: bar
x-proxy-ext-bu: makemoney
```
that are made available as user attributes:
```
attr.proxy.namespace: foo,bar
attr.proxy.bu: makemoney
```