### PR TITLE
Predefined roles for alerting.

### DIFF
--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -2,7 +2,6 @@ _meta:
   type: "roles"
   config_version: 2
 
-
 # Allows users to view alerts
 alerting_view_alerts:
   readonly: true

--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -22,7 +22,7 @@ alerting_crud_alerts:
 alerting_full_access:
   readonly: true
   indices:
-    '?opendistro-alerting*':
+    '?opendistro-alerting-config':
       '*':
         - CRUD
     '?opendistro-alerting-alert*':

--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -1,3 +1,31 @@
 _meta:
   type: "roles"
   config_version: 2
+
+
+# Allows users to view alerts
+alerting_view_alerts:
+  readonly: true
+  indices:
+    '?opendistro-alerting-alert*':
+      '*':
+        - READ
+
+# Allows users to view and acknowledge alerts
+alerting_crud_alerts:
+  readonly: true
+  indices:
+    '?opendistro-alerting-alert*':
+      '*':
+        - CRUD
+
+# Allows users to use all alerting functionality
+alerting_full_access:
+  readonly: true
+  indices:
+    '?opendistro-alerting*':
+      '*':
+        - CRUD
+    '?opendistro-alerting-alert*':
+      '*':
+        - CRUD


### PR DESCRIPTION
This change defines 3 new default read only roles to easily allow integration with the [opendistro alerting plugin](https://github.com/opendistro-for-elasticsearch/alerting)

The three roles are as follows:
- **alerting_view_alerts**: Allows a user to view alerts. No monitors or destinations, also does not allow users of this role to acknowledge alerts.
- **alerting_crud_alerts**: Allows a user to view and acknowledge alerts. User cannot view monitors or destinations.
- **alerting_full_access**: Provides full functionality of the alerting plugin.

Testing done manually using a single user for each role.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._