### PR TITLE
Revert "Predefined roles for alerting."

### DIFF
--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -1,30 +1,3 @@
 _meta:
   type: "roles"
   config_version: 2
-
-# Allows users to view alerts
-alerting_view_alerts:
-  readonly: true
-  indices:
-    '?opendistro-alerting-alert*':
-      '*':
-        - READ
-
-# Allows users to view and acknowledge alerts
-alerting_crud_alerts:
-  readonly: true
-  indices:
-    '?opendistro-alerting-alert*':
-      '*':
-        - CRUD
-
-# Allows users to use all alerting functionality
-alerting_full_access:
-  readonly: true
-  indices:
-    '?opendistro-alerting-config':
-      '*':
-        - CRUD
-    '?opendistro-alerting-alert*':
-      '*':
-        - CRUD


### PR DESCRIPTION
Reverts opendistro-for-elasticsearch/security#88

- Reverting due to incompatible yml format