### PR TITLE
Alerting roles fix

### DIFF
--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -4,27 +4,28 @@ _meta:
 
 # Allows users to view alerts
 alerting_view_alerts:
-  readonly: true
-  indices:
-    '?opendistro-alerting-alert*':
-      '*':
-        - READ
+  reserved: true
+  index_permissions:
+    - index_patterns:
+      - ".opendistro-alerting-alert*"
+      allowed_actions:
+        - read 
 
 # Allows users to view and acknowledge alerts
 alerting_crud_alerts:
-  readonly: true
-  indices:
-    '?opendistro-alerting-alert*':
-      '*':
-        - CRUD
+  reserved: true
+  index_permissions:
+    - index_patterns:
+      - ".opendistro-alerting-alert*"
+      allowed_actions:
+       - crud 
 
 # Allows users to use all alerting functionality
 alerting_full_access:
-  readonly: true
-  indices:
-    '?opendistro-alerting-config':
-      '*':
-        - CRUD
-    '?opendistro-alerting-alert*':
-      '*':
-        - CRUD
+  reserved: true
+  index_permissions:
+    - index_patterns:
+      - ".opendistro-alerting-config"
+      - ".opendistro-alerting-alert*"
+      allowed_actions:
+        - crud 

--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -2,7 +2,6 @@ _meta:
   type: "roles"
   config_version: 2
 
-
 # Allows users to view alerts
 alerting_view_alerts:
   readonly: true

--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -22,7 +22,7 @@ alerting_crud_alerts:
 alerting_full_access:
   readonly: true
   indices:
-    '?opendistro-alerting*':
+    '?opendistro-alerting-config':
       '*':
         - CRUD
     '?opendistro-alerting-alert*':

--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -1,3 +1,31 @@
 _meta:
   type: "roles"
   config_version: 2
+
+
+# Allows users to view alerts
+alerting_view_alerts:
+  readonly: true
+  indices:
+    '?opendistro-alerting-alert*':
+      '*':
+        - READ
+
+# Allows users to view and acknowledge alerts
+alerting_crud_alerts:
+  readonly: true
+  indices:
+    '?opendistro-alerting-alert*':
+      '*':
+        - CRUD
+
+# Allows users to use all alerting functionality
+alerting_full_access:
+  readonly: true
+  indices:
+    '?opendistro-alerting*':
+      '*':
+        - CRUD
+    '?opendistro-alerting-alert*':
+      '*':
+        - CRUD


### PR DESCRIPTION
Fix for alerting roles since with security plugin v1.0 the format has changed. The roles still have the same permissions as [this pr](https://github.com/opendistro-for-elasticsearch/security/pull/88).

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._