### PR TITLE
Predefined roles for alerting ODFE 0.10

### DIFF
--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -183,3 +183,30 @@ own_index:
     '${user_name}':
       '*':
         - INDICES_ALL
+
+# Allows users to view alerts
+alerting_view_alerts:
+  readonly: true
+  indices:
+    '?opendistro-alerting-alert*':
+      '*':
+        - READ
+
+# Allows users to view and acknowledge alerts
+alerting_crud_alerts:
+  readonly: true
+  indices:
+    '?opendistro-alerting-alert*':
+      '*':
+        - CRUD
+
+# Allows users to use all alerting functionality
+alerting_full_access:
+  readonly: true
+  indices:
+    '?opendistro-alerting-config':
+      '*':
+        - CRUD
+    '?opendistro-alerting-alert*':
+      '*':
+        - CRUD


### PR DESCRIPTION
# Info
This change defines 3 new default read only roles to easily allow integration with the opendistro alerting plugin

The three roles are as follows:

1. **alerting_view_alerts**: Allows a user to view alerts. No monitors or destinations, also does not allow users of this role to acknowledge alerts.
1. **alerting_crud_alerts**: Allows a user to view and acknowledge alerts. User cannot view monitors or destinations.
1. **alerting_full_access**: Provides full functionality of the alerting plugin.

# Tests
```
[WARNING] Tests run: 11, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 175.457 s - in com.amazon.opendistroforelasticsearch.security.IndexIntegrationTests
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 99, Failures: 0, Errors: 0, Skipped: 4
[INFO] 
[INFO] 
[INFO] --- maven-jar-plugin:3.1.0:jar (default-jar) @ opendistro_security ---
[INFO] Building jar: /Users/lucaswin/Desktop/github/backend-security/security/target/opendistro_security-0.10.0.0.jar
[INFO] 
[INFO] --- git-commit-id-plugin:2.2.3:validateRevision (validate-the-git-infos) @ opendistro_security ---
[INFO] 
[INFO] --- maven-jar-plugin:3.1.0:test-jar (default) @ opendistro_security ---
[INFO] Building jar: /Users/lucaswin/Desktop/github/backend-security/security/target/opendistro_security-0.10.0.0-tests.jar
[INFO] 
[INFO] --- maven-install-plugin:2.4:install (default-install) @ opendistro_security ---
[INFO] Installing /Users/lucaswin/Desktop/github/backend-security/security/target/opendistro_security-0.10.0.0.jar to /Users/lucaswin/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/0.10.0.0/opendistro_security-0.10.0.0.jar
[INFO] Installing /Users/lucaswin/Desktop/github/backend-security/security/pom.xml to /Users/lucaswin/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/0.10.0.0/opendistro_security-0.10.0.0.pom
[INFO] Installing /Users/lucaswin/Desktop/github/backend-security/security/target/opendistro_security-0.10.0.0-tests.jar to /Users/lucaswin/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/0.10.0.0/opendistro_security-0.10.0.0-tests.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12:56 min
[INFO] Finished at: 2019-08-13T11:53:10-07:00
[INFO] ------------------------------------------------------------------------
```

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._