### PR TITLE
Fix security configuration naming on security/OpenDistroSecurityPlugin.java and securi…

### DIFF
--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -3,7 +3,7 @@
 description=Provide access control related features for Elasticsearch 7
 #
 # 'version': plugin's version
-version=1.0.0.2
+version=1.0.0.3
 #
 # 'name': the plugin name
 name=opendistro_security

--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
   <parent>
     <groupId>com.amazon.opendistroforelasticsearch</groupId>
     <artifactId>opendistro_security_parent</artifactId>
-    <version>1.0.0.2</version>
+    <version>1.0.0.3</version>
   </parent>
 
   <artifactId>opendistro_security</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0.2</version>
+  <version>1.0.0.3</version>
   <name>Open Distro Security for Elasticsearch</name>
   <description>Open Distro For Elasticsearch Security</description>
   <inceptionYear>2015</inceptionYear>
@@ -52,7 +52,7 @@
   </licenses>
 
   <properties>
-    <opendistro_security_advanceda_modules.version>1.0.0.2</opendistro_security_advanceda_modules.version>
+    <opendistro_security_advanceda_modules.version>1.0.0.3</opendistro_security_advanceda_modules.version>
     <elasticsearch.version>7.0.1</elasticsearch.version>
 
     <!-- deps -->
@@ -76,7 +76,7 @@
     <url>https://github.com/opendistro-for-elasticsearch/security</url>
     <connection>scm:git:git@github.com:opendistro-for-elasticsearch/security.git</connection>
     <developerConnection>scm:git:git@github.com:opendistro-for-elasticsearch/security.git</developerConnection>
-    <tag>v1.0.0.2</tag>
+    <tag>v1.0.0.3</tag>
   </scm>
 
   <issueManagement>
@@ -366,7 +366,7 @@
                 <dependency>
                     <groupId>com.amazon.opendistroforelasticsearch</groupId>
                     <artifactId>opendistro_security_advanced_modules</artifactId>
-                    <version>1.0.0.2</version>
+                    <version>1.0.0.3</version>
                     <exclusions>
                         <exclusion>
                             <artifactId>jna</artifactId>

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -943,7 +943,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_USER_ENABLED, false, Property.NodeScope, Property.Filtered));
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED, false, Property.NodeScope, Property.Filtered));
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_ALLOW_NOW_IN_DLS, false, Property.NodeScope, Property.Filtered));
-            settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_CONFIG_MODIFICATION, false, Property.NodeScope, Property.Filtered));
+            settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, false, Property.NodeScope, Property.Filtered));
         }
         
         return settings;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
@@ -235,5 +235,5 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_USER_ENABLED = "opendistro_security.unsupported.inject_user.enabled";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED = "opendistro_security.unsupported.inject_user.admin.enabled";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_ALLOW_NOW_IN_DLS = "opendistro_security.unsupported.allow_now_in_dls";
-    public static final String OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_CONFIG_MODIFICATION = "opendistro_security.unsupported.restapi.allow_config_modification";
+    public static final String OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION = "opendistro_security.unsupported.restapi.allow_securityconfig_modification";
 }


### PR DESCRIPTION
…ty/support/ConfigConstants.java

Unit Test Results
[INFO] Results:
[INFO]
[WARNING] Tests run: 174, Failures: 0, Errors: 0, Skipped: 22
[INFO]
[INFO]
[INFO] --- maven-jar-plugin:3.1.1:jar (default-jar) @ opendistro_security ---
[INFO] Building jar: /Users/ticheng/OpenDistro/tc-security-plugin-0814/security/target/opendistro_security-1.0.0.2.jar
[INFO]
[INFO] --- git-commit-id-plugin:2.2.6:validateRevision (validate-the-git-infos) @ opendistro_security ---
[INFO]
[INFO] --- maven-jar-plugin:3.1.1:test-jar (default) @ opendistro_security ---
[INFO] Building jar: /Users/ticheng/OpenDistro/tc-security-plugin-0814/security/target/opendistro_security-1.0.0.2-tests.jar
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ opendistro_security ---
[INFO] Installing /Users/ticheng/OpenDistro/tc-security-plugin-0814/security/target/opendistro_security-1.0.0.2.jar to /Users/ticheng/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/1.0.0.2/opendistro_security-1.0.0.2.jar
[INFO] Installing /Users/ticheng/OpenDistro/tc-security-plugin-0814/security/pom.xml to /Users/ticheng/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/1.0.0.2/opendistro_security-1.0.0.2.pom
[INFO] Installing /Users/ticheng/OpenDistro/tc-security-plugin-0814/security/target/opendistro_security-1.0.0.2-tests.jar to /Users/ticheng/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/1.0.0.2/opendistro_security-1.0.0.2-tests.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS