### PR TITLE
Fix security configuration naming on OD-0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
   <parent>
     <groupId>com.amazon.opendistroforelasticsearch</groupId>
     <artifactId>opendistro_security_parent</artifactId>
-    <version>0.9.0.1</version>
+    <version>0.9.0.2</version>
   </parent>
 
   <artifactId>opendistro_security</artifactId>
   <packaging>jar</packaging>
-  <version>0.9.0.1</version>
+  <version>0.9.0.2</version>
   <name>Open Distro Security for Elasticsearch</name>
   <description>Open Distro For Elasticsearch Security</description>
   <inceptionYear>2015</inceptionYear>
@@ -52,8 +52,8 @@
   </licenses>
 
   <properties>
-    <opendistro_security_ssl.version>0.9.0.1</opendistro_security_ssl.version>
-    <opendistro_security_advanced_modules.version>0.9.0.1</opendistro_security_advanced_modules.version>
+    <opendistro_security_ssl.version>0.9.0.2</opendistro_security_ssl.version>
+    <opendistro_security_advanced_modules.version>0.9.0.2</opendistro_security_advanced_modules.version>
     <elasticsearch.version>6.7.1</elasticsearch.version>
     
     <!-- deps -->
@@ -76,7 +76,7 @@
     <url>https://github.com/opendistro-for-elasticsearch/security</url>
     <connection>scm:git:git@github.com:opendistro-for-elasticsearch/security.git</connection>
     <developerConnection>scm:git:git@github.com:opendistro-for-elasticsearch/security.git</developerConnection>
-    <tag>0.9.0.1</tag>
+    <tag>0.9.0.2</tag>
   </scm>
 
   <issueManagement>

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
@@ -249,6 +249,6 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_USER_ENABLED = "opendistro_security.unsupported.inject_user.enabled";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED = "opendistro_security.unsupported.inject_user.admin.enabled";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_ALLOW_NOW_IN_DLS = "opendistro_security.unsupported.allow_now_in_dls";
-    public static final String OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION = "opendistro_security.unsupported.restapi.allow_Securityconfig_modification";
+    public static final String OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION = "opendistro_security.unsupported.restapi.allow_securityconfig_modification";
 
 }


### PR DESCRIPTION
Run unit test result:
[INFO] Results:
[INFO]
[WARNING] Tests run: 99, Failures: 0, Errors: 0, Skipped: 4
[INFO]
[INFO]
[INFO] --- maven-jar-plugin:3.1.0:jar (default-jar) @ opendistro_security ---
[INFO] Building jar: /home/Opendistro/tc-security-0.9/security/target/opendistro_security-0.9.0.1.jar
[INFO]
[INFO] --- git-commit-id-plugin:2.2.3:validateRevision (validate-the-git-infos) @ opendistro_security ---
[INFO]
[INFO] --- maven-jar-plugin:3.1.0:test-jar (default) @ opendistro_security ---
[INFO] Building jar: /home/Opendistro/tc-security-0.9/security/target/opendistro_security-0.9.0.1-tests.jar
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ opendistro_security ---
[INFO] Installing /home/Opendistro/tc-security-0.9/security/target/opendistro_security-0.9.0.1.jar to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/0.9.0.1/opendistro_security-0.9.0.1.jar
[INFO] Installing /home/Opendistro/tc-security-0.9/security/pom.xml to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/0.9.0.1/opendistro_security-0.9.0.1.pom
[INFO] Installing /home/Opendistro/tc-security-0.9/security/target/opendistro_security-0.9.0.1-tests.jar to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/0.9.0.1/opendistro_security-0.9.0.1-tests.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------