### PR TITLE
Fix security configuration on OD-1.1

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -943,7 +943,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_USER_ENABLED, false, Property.NodeScope, Property.Filtered));
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED, false, Property.NodeScope, Property.Filtered));
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_ALLOW_NOW_IN_DLS, false, Property.NodeScope, Property.Filtered));
-            settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_CONFIG_MODIFICATION, false, Property.NodeScope, Property.Filtered));
+            settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, false, Property.NodeScope, Property.Filtered));
         }
         
         return settings;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
@@ -235,5 +235,5 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_USER_ENABLED = "opendistro_security.unsupported.inject_user.enabled";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED = "opendistro_security.unsupported.inject_user.admin.enabled";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_ALLOW_NOW_IN_DLS = "opendistro_security.unsupported.allow_now_in_dls";
-    public static final String OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_CONFIG_MODIFICATION = "opendistro_security.unsupported.restapi.allow_config_modification";
+    public static final String OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION = "opendistro_security.unsupported.restapi.allow_securityconfig_modification";
 }


### PR DESCRIPTION
Run unit test result:
[INFO] Results:
[INFO]
[WARNING] Tests run: 174, Failures: 0, Errors: 0, Skipped: 22
[INFO]
[INFO]
[INFO] --- maven-jar-plugin:3.1.1:jar (default-jar) @ opendistro_security ---
[INFO] Building jar: /root/Opendistro/tc-security-plugin-1.1/security/target/opendistro_security-1.1.0.0.jar
[INFO]
[INFO] --- git-commit-id-plugin:2.2.6:validateRevision (validate-the-git-infos) @ opendistro_security ---
[INFO]
[INFO] --- maven-jar-plugin:3.1.1:test-jar (default) @ opendistro_security ---
[INFO] Building jar: /root/Opendistro/tc-security-plugin-1.1/security/target/opendistro_security-1.1.0.0-tests.jar
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ opendistro_security ---
[INFO] Installing /root/Opendistro/tc-security-plugin-1.1/security/target/opendistro_security-1.1.0.0.jar to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/1.1.0.0/opendistro_security-1.1.0.0.jar
[INFO] Installing /root/Opendistro/tc-security-plugin-1.1/security/pom.xml to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/1.1.0.0/opendistro_security-1.1.0.0.pom
[INFO] Installing /root/Opendistro/tc-security-plugin-1.1/security/target/opendistro_security-1.1.0.0-tests.jar to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/1.1.0.0/opendistro_security-1.1.0.0-tests.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------