### PR TITLE
Fix security configuration naming on OD-0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
   <parent>
     <groupId>com.amazon.opendistroforelasticsearch</groupId>
     <artifactId>opendistro_security_parent</artifactId>
-    <version>0.10.0.0</version>
+    <version>0.10.0.1</version>
   </parent>
 
   <artifactId>opendistro_security</artifactId>
   <packaging>jar</packaging>
-  <version>0.10.0.0</version>
+  <version>0.10.0.1</version>
   <name>Open Distro Security for Elasticsearch</name>
   <description>Open Distro For Elasticsearch Security</description>
   <inceptionYear>2015</inceptionYear>
@@ -52,8 +52,8 @@
   </licenses>
 
   <properties>
-    <opendistro_security_ssl.version>0.10.0.0</opendistro_security_ssl.version>
-    <opendistro_security_advanced_modules.version>0.10.0.0</opendistro_security_advanced_modules.version>
+    <opendistro_security_ssl.version>0.10.0.1</opendistro_security_ssl.version>
+    <opendistro_security_advanced_modules.version>0.10.0.1</opendistro_security_advanced_modules.version>
     <elasticsearch.version>6.8.1</elasticsearch.version>
     
     <!-- deps -->
@@ -76,7 +76,7 @@
     <url>https://github.com/opendistro-for-elasticsearch/security</url>
     <connection>scm:git:git@github.com:opendistro-for-elasticsearch/security.git</connection>
     <developerConnection>scm:git:git@github.com:opendistro-for-elasticsearch/security.git</developerConnection>
-    <tag>0.10.0.0</tag>
+    <tag>0.10.0.1</tag>
   </scm>
 
   <issueManagement>

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
@@ -249,6 +249,6 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_USER_ENABLED = "opendistro_security.unsupported.inject_user.enabled";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED = "opendistro_security.unsupported.inject_user.admin.enabled";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_ALLOW_NOW_IN_DLS = "opendistro_security.unsupported.allow_now_in_dls";
-    public static final String OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION = "opendistro_security.unsupported.restapi.allow_Securityconfig_modification";
+    public static final String OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION = "opendistro_security.unsupported.restapi.allow_securityconfig_modification";
 
 }


### PR DESCRIPTION
Unit test results:
[INFO] Results:
[INFO]
[WARNING] Tests run: 99, Failures: 0, Errors: 0, Skipped: 4
[INFO]
[INFO]
[INFO] --- maven-jar-plugin:3.1.0:jar (default-jar) @ opendistro_security ---
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/3.2.0/maven-archiver-3.2.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/3.2.0/maven-archiver-3.2.0.pom (4.3 kB at 718 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.0/maven-shared-utils-3.2.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.0/maven-shared-utils-3.2.0.pom (4.9 kB at 1.2 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/3.5/plexus-archiver-3.5.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/3.5/plexus-archiver-3.5.pom (4.8 kB at 401 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/5.0/plexus-5.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/5.0/plexus-5.0.pom (21 kB at 4.3 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/3.0.0/plexus-io-3.0.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/3.0.0/plexus-io-3.0.0.pom (4.5 kB at 1.1 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.14/commons-compress-1.14.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.14/commons-compress-1.14.pom (13 kB at 2.6 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/iq80/snappy/snappy/0.4/snappy-0.4.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/iq80/snappy/snappy/0.4/snappy-0.4.pom (15 kB at 2.9 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/tukaani/xz/1.6/xz-1.6.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/tukaani/xz/1.6/xz-1.6.pom (1.9 kB at 238 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/3.2.0/maven-archiver-3.2.0.jar
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.0/maven-shared-utils-3.2.0.jar
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/3.0.0/plexus-io-3.0.0.jar
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/3.5/plexus-archiver-3.5.jar
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.14/commons-compress-1.14.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/3.2.0/maven-archiver-3.2.0.jar (24 kB at 3.4 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/iq80/snappy/snappy/0.4/snappy-0.4.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/iq80/snappy/snappy/0.4/snappy-0.4.jar (58 kB at 2.1 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/tukaani/xz/1.6/xz-1.6.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/3.0.0/plexus-io-3.0.0.jar (74 kB at 2.2 MB/s)
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/3.5/plexus-archiver-3.5.jar (187 kB at 3.9 MB/s)
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.14/commons-compress-1.14.jar (530 kB at 7.9 MB/s)
Downloaded from central: https://repo.maven.apache.org/maven2/org/tukaani/xz/1.6/xz-1.6.jar (103 kB at 1.5 MB/s)
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.0/maven-shared-utils-3.2.0.jar (165 kB at 2.3 MB/s)
[INFO] Building jar: /home/Opendistro/tc-security-0.10/security/target/opendistro_security-0.10.0.0.jar
[INFO]
[INFO] --- git-commit-id-plugin:2.2.3:validateRevision (validate-the-git-infos) @ opendistro_security ---
[INFO]
[INFO] --- maven-jar-plugin:3.1.0:test-jar (default) @ opendistro_security ---
[INFO] Building jar: /home/Opendistro/tc-security-0.10/security/target/opendistro_security-0.10.0.0-tests.jar
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ opendistro_security ---
[INFO] Installing /home/Opendistro/tc-security-0.10/security/target/opendistro_security-0.10.0.0.jar to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/0.10.0.0/opendistro_security-0.10.0.0.jar
[INFO] Installing /home/Opendistro/tc-security-0.10/security/pom.xml to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/0.10.0.0/opendistro_security-0.10.0.0.pom
[INFO] Installing /home/Opendistro/tc-security-0.10/security/target/opendistro_security-0.10.0.0-tests.jar to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/0.10.0.0/opendistro_security-0.10.0.0-tests.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------