### PR TITLE
Add the ability to block indices and index patterns to admin only.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
   <parent>
     <groupId>com.amazon.opendistroforelasticsearch</groupId>
     <artifactId>opendistro_security_parent</artifactId>
-    <version>1.1.0.0</version>
+    <version>1.1.0.1</version>
   </parent>
 
   <artifactId>opendistro_security</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0.0</version>
+  <version>1.1.0.1</version>
   <name>Open Distro Security for Elasticsearch</name>
   <description>Open Distro For Elasticsearch Security</description>
   <inceptionYear>2015</inceptionYear>
@@ -52,7 +52,7 @@
   </licenses>
 
   <properties>
-    <opendistro_security_advanceda_modules.version>1.1.0.0</opendistro_security_advanceda_modules.version>
+    <opendistro_security_advanceda_modules.version>1.1.0.1</opendistro_security_advanceda_modules.version>
     <elasticsearch.version>7.1.1</elasticsearch.version>
 
     <!-- deps -->
@@ -76,7 +76,7 @@
     <url>https://github.com/opendistro-for-elasticsearch/security</url>
     <connection>scm:git:git@github.com:opendistro-for-elasticsearch/security.git</connection>
     <developerConnection>scm:git:git@github.com:opendistro-for-elasticsearch/security.git</developerConnection>
-    <tag>1.1.0.0</tag>
+    <tag>1.1.0.1</tag>
   </scm>
 
   <issueManagement>
@@ -366,7 +366,7 @@
                 <dependency>
                     <groupId>com.amazon.opendistroforelasticsearch</groupId>
                     <artifactId>opendistro_security_advanced_modules</artifactId>
-                    <version>1.1.0.0</version>
+                    <version>1.1.0.1</version>
                     <exclusions>
                         <exclusion>
                             <artifactId>jna</artifactId>

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -948,7 +948,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_USER_ENABLED, false, Property.NodeScope, Property.Filtered));
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED, false, Property.NodeScope, Property.Filtered));
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_ALLOW_NOW_IN_DLS, false, Property.NodeScope, Property.Filtered));
-            settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_CONFIG_MODIFICATION, false, Property.NodeScope, Property.Filtered));
+            settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, false, Property.NodeScope, Property.Filtered));
         }
         
         return settings;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -949,8 +949,6 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED, false, Property.NodeScope, Property.Filtered));
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_ALLOW_NOW_IN_DLS, false, Property.NodeScope, Property.Filtered));
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_CONFIG_MODIFICATION, false, Property.NodeScope, Property.Filtered));
-
-
         }
         
         return settings;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -819,6 +819,11 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
         
         settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_SSL_ONLY, false, Property.NodeScope, Property.Filtered));
 
+        // Index blocking settings
+        settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_ENABLED_KEY, ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_ENABLED_DEFAULT, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.listSetting(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_KEY, ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT, Function.identity(), Property.NodeScope, Property.Filtered));
+        settings.add(Setting.listSetting(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDEX_PATTERN_KEY, ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDEX_PATTERN_DEFAULT, Function.identity(), Property.NodeScope, Property.Filtered));
+
         if(!sslOnly) {
             settings.add(Setting.listSetting(ConfigConstants.OPENDISTRO_SECURITY_AUTHCZ_ADMIN_DN, Collections.emptyList(), Function.identity(), Property.NodeScope)); //not filtered here
     
@@ -944,6 +949,8 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED, false, Property.NodeScope, Property.Filtered));
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_ALLOW_NOW_IN_DLS, false, Property.NodeScope, Property.Filtered));
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_CONFIG_MODIFICATION, false, Property.NodeScope, Property.Filtered));
+
+
         }
         
         return settings;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilter.java
@@ -148,7 +148,7 @@ public class OpenDistroSecurityFilter implements ActionFilter {
                     && !action.startsWith("internal:transport/proxy");
 
             if (user != null) {
-                org.apache.logging.log4j.ThreadContext.put("user", user.getName());    
+                org.apache.logging.log4j.ThreadContext.put("user", user.getName());
             }
                         
             if(actionTrace.isTraceEnabled()) {
@@ -266,7 +266,11 @@ public class OpenDistroSecurityFilter implements ActionFilter {
             } else {
                 auditLog.logMissingPrivileges(action, request, task);
                 log.debug("no permissions for {}", pres.getMissingPrivileges());
-                listener.onFailure(new ElasticsearchSecurityException("no permissions for " + pres.getMissingPrivileges()+" and "+user, RestStatus.FORBIDDEN));
+                if (pres.getMissingPrivileges().contains(ConfigConstants.BLOCKED)) {
+                    listener.onFailure(new ElasticsearchSecurityException("This index is reserved for members of [all_access] role only.", RestStatus.FORBIDDEN));
+                    return;
+                }
+                listener.onFailure(new ElasticsearchSecurityException("no permissions for " + pres.getMissingPrivileges()+ " and "+user, RestStatus.FORBIDDEN));
                 return;
             }
         } catch (Throwable e) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
@@ -72,7 +72,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.tasks.Task;
@@ -96,7 +95,7 @@ import com.amazon.opendistroforelasticsearch.security.user.User;
 public class PrivilegesEvaluator implements DCFListener {
 
 
-    final String[] alertingIndexDeniedActionPatternsList = new ArrayList<String>() {
+    final String[] blockIndexActionPatternsList = new ArrayList<String>() {
         {
             add("indices:data/write*");
             add("indices:data/read*");
@@ -216,7 +215,7 @@ public class PrivilegesEvaluator implements DCFListener {
         if (settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_ENABLED_KEY, ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_ENABLED_DEFAULT)) {
             final List<String> indexNames = settings.getAsList(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_KEY, ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT);
             final Collection indexPatterns = settings.getAsList(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDEX_PATTERN_KEY, ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDEX_PATTERN_DEFAULT);
-            final boolean deniedAction = WildcardMatcher.matchAny(alertingIndexDeniedActionPatternsList, action0);
+            final boolean deniedAction = WildcardMatcher.matchAny(blockIndexActionPatternsList, action0);
             // Check if this is an action that should be denied.
             if (deniedAction) {
                 // Check if we are touching an index in the index pattern or index directly and if so reject.

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
@@ -236,4 +236,16 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED = "opendistro_security.unsupported.inject_user.admin.enabled";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_ALLOW_NOW_IN_DLS = "opendistro_security.unsupported.allow_now_in_dls";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_CONFIG_MODIFICATION = "opendistro_security.unsupported.restapi.allow_config_modification";
+
+
+
+    // Index blocking settings
+    public static final String OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_ENABLED_KEY = "opendistro_security.admin_only_indices";
+    public static final Boolean OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_ENABLED_DEFAULT = true;
+    public static final String OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_KEY = "opendistro_security.alerting_config_index";
+    public static final List<String> OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT = Arrays.asList(".opendistro-alerting-config", ".opendistro-ism-config");
+    public static final String OPENDISTRO_SECURITY_ROLE_BLOCKED_INDEX_PATTERN_KEY = "opendistro_security.alerting_alerts_index";
+    public static final List<String> OPENDISTRO_SECURITY_ROLE_BLOCKED_INDEX_PATTERN_DEFAULT = Arrays.asList(".opendistro-alerting-alert*", ".opendistro-ism-managed-index-history*");
+
+    public static final String BLOCKED = "BLOCKED";
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
@@ -247,4 +247,5 @@ public class ConfigConstants {
     public static final List<String> OPENDISTRO_SECURITY_ROLE_BLOCKED_INDEX_PATTERN_DEFAULT = Arrays.asList(".opendistro-alerting-alert*", ".opendistro-ism-managed-index-history*");
 
     public static final String BLOCKED = "BLOCKED";
+    public static final String OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION = "opendistro_security.unsupported.restapi.allow_securityconfig_modification";
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
@@ -238,7 +238,6 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_CONFIG_MODIFICATION = "opendistro_security.unsupported.restapi.allow_config_modification";
 
 
-
     // Index blocking settings
     public static final String OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_ENABLED_KEY = "opendistro_security.admin_only_indices";
     public static final Boolean OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_ENABLED_DEFAULT = true;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/alerting/BlockedIndexIntegrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/alerting/BlockedIndexIntegrationTests.java
@@ -1,0 +1,325 @@
+package com.amazon.opendistroforelasticsearch.security.alerting;
+
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import com.amazon.opendistroforelasticsearch.security.test.DynamicSecurityConfig;
+import com.amazon.opendistroforelasticsearch.security.test.SingleClusterTest;
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.rest.RestStatus;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BlockedIndexIntegrationTests extends SingleClusterTest {
+
+    /**********************************************************
+     * Test index access with no index created
+     **********************************************************/
+
+    // Tests indicies:admin/create permission
+    @Test
+    public void testNonAccessCreateIndex() throws Exception {
+        // Setup settings
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config.yml").setSecurityRoles("roles.yml").setSecurityInternalUsers("internal_users.yml"), Settings.EMPTY, true);
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        // Try to create index
+        String indexSettings = "{\n" +
+                "    \"settings\" : {\n" +
+                "        \"index\" : {\n" +
+                "            \"number_of_shards\" : 3, \n" +
+                "            \"number_of_replicas\" : 2 \n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        RestHelper.HttpResponse response = rh.executePutRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0), indexSettings, encodeBasicHeader("alertinguser", "alertinguser"));
+
+        Assert.assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+        Assert.assertTrue(response.getBody().contains("This index is reserved for members of [all_access] role only."));
+    }
+
+    @Test
+    public void testNonAccessCreateIndexInPattern() throws Exception {
+        // Setup settings
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config.yml").setSecurityRoles("roles.yml").setSecurityInternalUsers("internal_users.yml"), Settings.EMPTY, true);
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        // Try to create index
+        String indexSettings = "{\n" +
+                "    \"settings\" : {\n" +
+                "        \"index\" : {\n" +
+                "            \"number_of_shards\" : 3, \n" +
+                "            \"number_of_replicas\" : 2 \n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+
+        String indexName = ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDEX_PATTERN_DEFAULT.get(0).substring(0, ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDEX_PATTERN_DEFAULT.get(0).length() - 1);
+
+        RestHelper.HttpResponse response = rh.executePutRequest(indexName + "foobar", indexSettings, encodeBasicHeader("alertinguser", "alertinguser"));
+
+        Assert.assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+        Assert.assertTrue(response.getBody().contains("This index is reserved for members of [all_access] role only."));
+    }
+
+    // Tests indices:data/write permission
+    @Test
+    public void testNonAccessCreateDocument() throws Exception {
+        // Setup settings
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config.yml").setSecurityRoles("roles.yml").setSecurityInternalUsers("internal_users.yml"), Settings.EMPTY, true);
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        // Try to create index
+        String doc = "{\"foo\": \"bar\"}";
+        RestHelper.HttpResponse response = rh.executePostRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0) + "/_doc", doc, encodeBasicHeader("alertinguser", "alertinguser"));
+
+        Assert.assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+        Assert.assertTrue(response.getBody().contains("This index is reserved for members of [all_access] role only."));
+    }
+
+    // Tests indices:data/read permission
+    @Test
+    public void testNonAccessQueryNoIndex() throws Exception {
+         // Setup settings
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config.yml").setSecurityRoles("roles.yml").setSecurityInternalUsers("internal_users.yml"), Settings.EMPTY, true);
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        String query = QueryBuilders.matchAllQuery().toString();
+
+        RestHelper.HttpResponse response = rh.executePostRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0) + "/_doc", query, encodeBasicHeader("alertinguser", "alertinguser"));
+
+        Assert.assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+        Assert.assertTrue(response.getBody().contains("This index is reserved for members of [all_access] role only."));
+    }
+
+    /**********************************************************
+     * Test index access with index created
+     **********************************************************/
+    // Tests indices:data/write permission
+    @Test
+    public void testNonAccessGetWithIndex() throws Exception {
+        // Setup settings
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config.yml").setSecurityRoles("roles.yml").setSecurityInternalUsers("internal_users.yml"), Settings.EMPTY, true);
+
+        try (TransportClient tc = getInternalTransportClient()) {
+            tc.admin().indices().create(new CreateIndexRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0))).actionGet();
+            tc.index(new IndexRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0)).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).id("document1").source("{ \"foo\": \"bar\" }", XContentType.JSON)).actionGet();
+        }
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        RestHelper.HttpResponse response = rh.executeGetRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0) + "/_doc/document1", encodeBasicHeader("alertinguser", "alertinguser"));
+
+        Assert.assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+        Assert.assertTrue(response.getBody().contains("This index is reserved for members of [all_access] role only."));
+    }
+
+    // Tests indices:admin/delete permission
+    @Test
+    public void testNonAccessDeleteWithIndex() throws Exception {
+        // Setup settings
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config.yml").setSecurityRoles("roles.yml").setSecurityInternalUsers("internal_users.yml"), Settings.EMPTY, true);
+
+        try (TransportClient tc = getInternalTransportClient()) {
+            tc.admin().indices().create(new CreateIndexRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0))).actionGet();
+            tc.index(new IndexRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0)).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).id("document1").source("{ \"foo\": \"bar\" }", XContentType.JSON)).actionGet();
+        }
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        // Try to delete document
+        RestHelper.HttpResponse deleteDocResponse = rh.executeDeleteRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0) + "/_doc/document1", encodeBasicHeader("alertinguser", "alertinguser"));
+
+        Assert.assertTrue(deleteDocResponse.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+        Assert.assertTrue(deleteDocResponse.getBody().contains("This index is reserved for members of [all_access] role only."));
+
+        // Try to delete index
+        RestHelper.HttpResponse deleteIndexResponse = rh.executeDeleteRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0), encodeBasicHeader("alertinguser", "alertinguser"));
+
+        Assert.assertTrue(deleteIndexResponse.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+        Assert.assertTrue(deleteIndexResponse.getBody().contains("This index is reserved for members of [all_access] role only."));
+    }
+
+    // Tests indices:admin/mapping/put
+    @Test
+    public void testNonAccessUpdateMappingsWithIndex() throws Exception {
+        // Setup settings
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config.yml").setSecurityRoles("roles.yml").setSecurityInternalUsers("internal_users.yml"), Settings.EMPTY, true);
+
+        try (TransportClient tc = getInternalTransportClient()) {
+
+            String mappings = "\"properties\": {" +
+                    "\"user_name\": {" +
+                    "\"type\": \"text\"" +
+                    "}}";
+            tc.admin().indices().create(new CreateIndexRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0)).mapping("_doc", mappings, XContentType.JSON)).actionGet();
+            tc.index(new IndexRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0)).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).id("document1").source("{ \"username\": \"foobar\" }", XContentType.JSON)).actionGet();
+        }
+
+        String newMappings = "{\"properties\": {" +
+                "\"user_name\": {" +
+                "\"type\": \"text\"" +
+                "}}}";
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        RestHelper.HttpResponse response = rh.executePutRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0) + "/_mapping", newMappings, encodeBasicHeader("alertinguser", "alertinguser"));
+
+        Assert.assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+        Assert.assertTrue(response.getBody().contains("This index is reserved for members of [all_access] role only."));
+    }
+
+    // Tests indices:admin/settings/update
+    @Test
+    public void testNonAccessUpdateIndexSettingsWithIndex() throws Exception {
+        // Setup settings
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config.yml").setSecurityRoles("roles.yml").setSecurityInternalUsers("internal_users.yml"), Settings.EMPTY, true);
+
+        try (TransportClient tc = getInternalTransportClient()) {
+
+            String indexSettings = "{\n" +
+                    "        \"index\" : {\n" +
+                    "            \"number_of_shards\" : 3, \n" +
+                    "            \"number_of_replicas\" : 2 \n" +
+                    "        }\n" +
+                    "}";
+            tc.admin().indices().create(new CreateIndexRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0)).settings(indexSettings, XContentType.JSON)).actionGet();
+            tc.index(new IndexRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0)).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).id("document1").source("{ \"username\": \"foobar\" }", XContentType.JSON)).actionGet();
+        }
+
+        String newIndexSettings = "{\n" +
+                "    \"index\" : {\n" +
+                "        \"number_of_replicas\" : 10\n" +
+                "    }\n" +
+                "}";
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        RestHelper.HttpResponse response = rh.executePutRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0) + "/_settings", newIndexSettings, encodeBasicHeader("alertinguser", "alertinguser"));
+
+        Assert.assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+        Assert.assertTrue(response.getBody().contains("This index is reserved for members of [all_access] role only."));
+    }
+
+    // Tests indices:admin/close*
+    @Test
+    public void testNonAccessCloseIndexWithIndex() throws Exception {
+        // Setup settings
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config.yml").setSecurityRoles("roles.yml").setSecurityInternalUsers("internal_users.yml"), Settings.EMPTY, true);
+
+        try (TransportClient tc = getInternalTransportClient()) {
+            tc.admin().indices().create(new CreateIndexRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0))).actionGet();
+        }
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        RestHelper.HttpResponse response = rh.executePostRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0) + "/_close", "", encodeBasicHeader("alertinguser", "alertinguser"));
+
+        Assert.assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+        Assert.assertTrue(response.getBody().contains("This index is reserved for members of [all_access] role only."));
+    }
+
+    // Tests indices:admin/aliases
+    @Test
+    public void testNonAccessAliasWithIndex() throws Exception {
+        // Setup settings
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config.yml").setSecurityRoles("roles.yml").setSecurityInternalUsers("internal_users.yml"), Settings.EMPTY, true);
+
+        try (TransportClient tc = getInternalTransportClient()) {
+            tc.admin().indices().create(new CreateIndexRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0))).actionGet();
+        }
+
+        String alias = "{\"actions\" : [\n" +
+                "{ \"add\" : { \"index\" : \"" + ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0) + "\", \"alias\" : \"foobar\" } }\n" +
+                "]}";
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        RestHelper.HttpResponse response = rh.executePostRequest("_aliases", alias, encodeBasicHeader("alertinguser", "alertinguser"));
+
+        Assert.assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+        Assert.assertTrue(response.getBody().contains("This index is reserved for members of [all_access] role only."));
+    }
+
+    // Tests indices:data/read permission
+    @Test
+    public void testNonAccessQueryWithIndex() throws Exception {
+        // Setup settings
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config.yml").setSecurityRoles("roles.yml").setSecurityInternalUsers("internal_users.yml"), Settings.EMPTY, true);
+
+        try (TransportClient tc = getInternalTransportClient()) {
+            tc.admin().indices().create(new CreateIndexRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0))).actionGet();
+        }
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        String query = QueryBuilders.matchAllQuery().toString();
+
+        RestHelper.HttpResponse response = rh.executePostRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0) + "/_doc", query, encodeBasicHeader("alertinguser", "alertinguser"));
+
+        Assert.assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+        Assert.assertTrue(response.getBody().contains("This index is reserved for members of [all_access] role only."));
+    }
+
+    // Tests indices:data/read permission
+    @Test
+    public void testNonAccessQueryWithIndexPattern() throws Exception {
+        // Setup settings
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config.yml").setSecurityRoles("roles.yml").setSecurityInternalUsers("internal_users.yml"), Settings.EMPTY, true);
+
+        try (TransportClient tc = getInternalTransportClient()) {
+            String indexName = ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDEX_PATTERN_DEFAULT.get(0).substring(0, ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDEX_PATTERN_DEFAULT.get(0).length() - 1);
+            tc.admin().indices().create(new CreateIndexRequest(indexName + "foobar")).actionGet();
+        }
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        String query = QueryBuilders.matchAllQuery().toString();
+
+        RestHelper.HttpResponse response = rh.executePostRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDEX_PATTERN_DEFAULT.get(0) + "/_doc", query, encodeBasicHeader("alertinguser", "alertinguser"));
+
+        Assert.assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+        Assert.assertTrue(response.getBody().contains("This index is reserved for members of [all_access] role only."));
+    }
+
+    @Test
+    public void testNonAccessQueryAlias() throws Exception {
+        // Setup settings
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config.yml").setSecurityRoles("roles.yml").setSecurityInternalUsers("internal_users.yml"), Settings.EMPTY, true);
+
+        try (TransportClient tc = getInternalTransportClient()) {
+            tc.admin().indices().create(new CreateIndexRequest(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0))).actionGet();
+            tc.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(IndicesAliasesRequest.AliasActions.add().index(ConfigConstants.OPENDISTRO_SECURITY_ROLE_BLOCKED_INDICES_DEFAULT.get(0)).alias("foobar"))).actionGet();
+        }
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        String query = QueryBuilders.matchAllQuery().toString();
+
+        RestHelper.HttpResponse response = rh.executePostRequest("foobar/_doc", query, encodeBasicHeader("alertinguser", "alertinguser"));
+
+        Assert.assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+        Assert.assertTrue(response.getBody().contains("This index is reserved for members of [all_access] role only."));
+    }
+
+}

--- a/src/test/resources/internal_users.yml
+++ b/src/test/resources/internal_users.yml
@@ -322,3 +322,17 @@ userwithblankpasswd:
 env.replace@example.comp.com:
   hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
   #password is: nagilum
+alertinguser:
+  hash: "$2y$12$qrYK8aALJd7a7Wblm2Jtoe8fEiCtTCE5tMoqG7Vp2194A4L35S4RK"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "User that has access to alerting index only"
+all_accessuser:
+  hash: "$2y$12$dq8uThZJCtAASPY5iuGbxeUOU/TBqElaeCurrxHTv3D00ca/CJKTi"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "User that has all_access role."

--- a/src/test/resources/roles.yml
+++ b/src/test/resources/roles.yml
@@ -1003,3 +1003,29 @@ env_test:
     - '${env.INDEXNAME3}'
     allowed_actions:
     - "*"
+# Allows users to view alerts
+alerting_view_alerts:
+  reserved: true
+  index_permissions:
+    - index_patterns:
+        - ".opendistro-alerting-alert*"
+      allowed_actions:
+        - read
+# Allows users to view and acknowledge alerts
+alerting_crud_alerts:
+  reserved: true
+  index_permissions:
+    - index_patterns:
+        - ".opendistro-alerting-alert*"
+      allowed_actions:
+        - crud
+# Allows users to use all alerting functionality
+alerting_full_access:
+  reserved: true
+  index_permissions:
+    - index_patterns:
+        - ".opendistro-alerting-config"
+        - ".opendistro-alerting-alert*"
+      allowed_actions:
+        - crud
+        - "OPENDISTRO_SECURITY_CREATE_INDEX"

--- a/src/test/resources/roles_mapping.yml
+++ b/src/test/resources/roles_mapping.yml
@@ -367,3 +367,9 @@ twitter:
 env_test:
   users:
     - env.replace@example.comp.com
+alerting_full_access:
+  users:
+    - "alertinguser"
+all_access:
+  users:
+    - "all_accessuser"


### PR DESCRIPTION
# Information
As part of certain plugins [alerting](https://github.com/opendistro-for-elasticsearch/alerting) and [index management](https://github.com/opendistro-for-elasticsearch/index-management) for example, we create jobs that run in the background and are using the transport client which bypasses security. In order to avoid users from using these features and gaining access to data in the cluster that they should not be able to have access too we should block the config indices.

This change does the following:
1. Allows to enable / disable the ability to restrict indices to the `all_access` role.
2. Allows for 1 or more indices to require the `all_access` role.
3. Allows for 1 or more index patterns to require the `all_access` role.

Additional integration tests are part of this PR that test this feature.

By default we block alerting and index management indices via this mechanism.

# Build output
```
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 187, Failures: 0, Errors: 0, Skipped: 6
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  13:59 min
[INFO] Finished at: 2019-08-19T16:35:06-07:00
[INFO] ------------------------------------------------------------------------
```

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._