### PR TITLE
Initialize opendistro index if injected user enabled

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
@@ -95,6 +95,7 @@ public class BackendRegistry implements DCFListener {
     private Multimap<String, ClientBlockRegistry<String>> authBackendClientBlockRegistries;
 
     private volatile boolean initialized;
+    private volatile boolean injectedUserEnabled = false;
     private final AdminDNs adminDns;
     private final XFFResolver xffResolver;
     private volatile boolean anonymousAuthEnabled = false;
@@ -185,7 +186,10 @@ public class BackendRegistry implements DCFListener {
 
 
         this.ttlInMin = settings.getAsInt(ConfigConstants.OPENDISTRO_SECURITY_CACHE_TTL_MINUTES, 60);
-                
+
+        // This is going to be defined in the elasticsearch.yml, so it's best suited to be initialized once.
+        this.injectedUserEnabled = esSettings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_USER_ENABLED,false);
+
         createCaches();
     }
 
@@ -222,7 +226,7 @@ public class BackendRegistry implements DCFListener {
         authBackendClientBlockRegistries = dcm.getAuthBackendClientBlockRegistries();
 
         //Open Distro Security no default authc
-        initialized = !restAuthDomains.isEmpty() || anonymousAuthEnabled;
+        initialized = !restAuthDomains.isEmpty() || anonymousAuthEnabled  || injectedUserEnabled;
     }
 
     public User authenticate(final TransportRequest request, final String sslPrincipal, final Task task, final String action) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/InitializationIntegrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/InitializationIntegrationTests.java
@@ -93,6 +93,23 @@ public class InitializationIntegrationTests extends SingleClusterTest {
     }
 
     @Test
+    public void testInitWithInjectedUser() throws Exception {
+
+        final Settings settings = Settings.builder()
+                .putList("path.repo", repositoryPath.getRoot().getAbsolutePath())
+                .put("opendistro_security.unsupported.inject_user.enabled", true)
+                .build();
+
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config_disable_all.yml"), settings, true);
+
+        RestHelper rh = nonSslRestHelper();
+
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executePutRequest(".opendistro_security/config/0", "{}", encodeBasicHeader("___", "")).getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executePutRequest(".opendistro_security/sg/config", "{}", encodeBasicHeader("___", "")).getStatusCode());
+
+    }
+
+    @Test
     public void testWhoAmI() throws Exception {
         setup(Settings.EMPTY, new DynamicSecurityConfig().setSecurityInternalUsers("internal_empty.yml")
                 .setSecurityRoles("roles_deny.yml"), Settings.EMPTY, true);

--- a/src/test/resources/config_disable_all.yml
+++ b/src/test/resources/config_disable_all.yml
@@ -1,0 +1,42 @@
+---
+_meta:
+  type: "config"
+  config_version: 2
+config:
+  dynamic:
+    filtered_alias_mode: "warn"
+    disable_rest_auth: false
+    disable_intertransport_auth: false
+    respect_request_indices_options: false
+    license: null
+    kibana:
+      multitenancy_enabled: true
+      server_username: "kibanaserver"
+      index: ".kibana"
+    http:
+      anonymous_auth_enabled: false
+      xff:
+        enabled: false
+        internalProxies: "192\\.168\\.0\\.10|192\\.168\\.0\\.11"
+        remoteIpHeader: "x-forwarded-for"
+
+
+    authc:
+      authentication_domain_basic_internal:
+        http_enabled: false
+        transport_enabled: true
+        order: 0
+        http_authenticator:
+          challenge: true
+          type: "basic"
+          config: {}
+        authentication_backend:
+          type: "intern"
+          config: {}
+        description: "Migrated from v6"
+    authz: {}
+    do_not_fail_on_forbidden: false
+    multi_rolespan_enabled: false
+    hosts_resolver_mode: "ip-only"
+    transport_userrname_attribute: null
+


### PR DESCRIPTION
Currently, if you disable basic auth and anonymous auth, open distro index in uninitialized. This is a real problem when we have just an injected_user enabled. In a case like this, doing any API call would return a 503 - internal service error, with a cryptic message of "OpenDistro Index not Initialized". We would like to initialize the index if injected_user is enabled. This way, even if the authentication fails, you will get something that makes sense, like a 401 UNAUTHORIZED with a message of Authentication Finally failed.

Ran tests -> 

[WARNING] Tests run: 11, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 106.662 s - in com.amazon.opendistroforelasticsearch.security.IndexIntegrationTests
[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 175, Failures: 0, Errors: 0, Skipped: 6
[INFO]
[INFO]
[INFO] --- maven-jar-plugin:3.1.1:jar (default-jar) @ opendistro_security ---
[INFO] Building jar: /Users/nprashar/ws/security/target/opendistro_security-1.1.0.1.jar
[INFO]
[INFO] --- git-commit-id-plugin:2.2.6:validateRevision (validate-the-git-infos) @ opendistro_security ---
[INFO]
[INFO] --- maven-jar-plugin:3.1.1:test-jar (default) @ opendistro_security ---
[INFO] Building jar: /Users/nprashar/ws/security/target/opendistro_security-1.1.0.1-tests.jar
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ opendistro_security ---
[INFO] Installing /Users/nprashar/ws/security/target/opendistro_security-1.1.0.1.jar to /Users/nprashar/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/1.1.0.1/opendistro_security-1.1.0.1.jar
[INFO] Installing /Users/nprashar/ws/security/pom.xml to /Users/nprashar/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/1.1.0.1/opendistro_security-1.1.0.1.pom
[INFO] Installing /Users/nprashar/ws/security/target/opendistro_security-1.1.0.1-tests.jar to /Users/nprashar/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/1.1.0.1/opendistro_security-1.1.0.1-tests.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 11:29 min
[INFO] Finished at: 2019-08-28T14:14:54-07:00
[INFO] ------------------------------------------------------------------------