### PR TITLE
Protected Index Kibana Fix 1.0

### DIFF
--- a/securityconfig/elasticsearch.yml.example
+++ b/securityconfig/elasticsearch.yml.example
@@ -196,3 +196,14 @@ opendistro_security.audit.type: internal_elasticsearch
 # Disable Open Distro Security
 # WARNING: This can expose your configuration (including passwords) to the public.
 #opendistro_security.disabled: false
+
+
+# Protected indices are even more secure than normal indices. These indices require a role to access like any other index, but they require an additional role
+# to be visible, listed in the opendistro_security.protected_indices.roles setting.
+# Enable protected indices
+# opendistro_security.protected_indices.enabled: true
+# Specify a list of roles a user must be member of to touch any protected index.
+# opendistro_security.protected_indices.roles: ['all_access']
+# Specify a list of indices to mark as protected. These indices will only be visible / mutable by members of the above setting, in addition to needing permission to the index via a normal role.
+# opendistro_security.protected_indices.indices: ['.opendistro-alerting-config', '.opendistro-ism-*']
+

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -471,7 +471,8 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
                             Objects.requireNonNull(cs),
                             Objects.requireNonNull(auditLog),
                             Objects.requireNonNull(ciol),
-                            Objects.requireNonNull(complianceConfig));
+                            Objects.requireNonNull(complianceConfig),
+                            Objects.requireNonNull(evaluator));
             if(log.isDebugEnabled()) {
                 log.debug("FLS/DLS enabled for index {}", indexService.index().getName());
             }
@@ -544,7 +545,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
                 assert complianceConfig==null:"compliance config must be null here";
                 
                 indexModule.setSearcherWrapper(indexService -> new OpenDistroSecurityIndexSearcherWrapper(indexService, settings, Objects
-                        .requireNonNull(adminDns)));
+                        .requireNonNull(adminDns), Objects.requireNonNull(evaluator)));
             }
 
             indexModule.addSearchOperationListener(new SearchOperationListener() {
@@ -818,6 +819,11 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
         settings.addAll(super.getSettings());
         
         settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_SSL_ONLY, false, Property.NodeScope, Property.Filtered));
+
+        // Protected index settings
+        settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ENABLED_KEY, ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ENABLED_DEFAULT, Property.NodeScope, Property.Filtered, Property.Final));
+        settings.add(Setting.listSetting(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_KEY, ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_DEFAULT, Function.identity(), Property.NodeScope, Property.Filtered, Property.Final));
+        settings.add(Setting.listSetting(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ROLES_KEY, ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ROLES_DEFAULT, Function.identity(), Property.NodeScope, Property.Filtered, Property.Final));
 
         if(!sslOnly) {
             settings.add(Setting.listSetting(ConfigConstants.OPENDISTRO_SECURITY_AUTHCZ_ADMIN_DN, Collections.emptyList(), Function.identity(), Property.NodeScope)); //not filtered here

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilter.java
@@ -123,7 +123,6 @@ public class OpenDistroSecurityFilter implements ActionFilter {
 
     private <Request extends ActionRequest, Response extends ActionResponse> void apply0(Task task, final String action, Request request,
             ActionListener<Response> listener, ActionFilterChain<Request, Response> chain) {
-        
         try {
 
             if(threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_ORIGIN) == null) {
@@ -148,7 +147,7 @@ public class OpenDistroSecurityFilter implements ActionFilter {
                     && !action.startsWith("internal:transport/proxy");
 
             if (user != null) {
-                org.apache.logging.log4j.ThreadContext.put("user", user.getName());    
+                org.apache.logging.log4j.ThreadContext.put("user", user.getName());
             }
                         
             if(actionTrace.isTraceEnabled()) {
@@ -266,7 +265,7 @@ public class OpenDistroSecurityFilter implements ActionFilter {
             } else {
                 auditLog.logMissingPrivileges(action, request, task);
                 log.debug("no permissions for {}", pres.getMissingPrivileges());
-                listener.onFailure(new ElasticsearchSecurityException("no permissions for " + pres.getMissingPrivileges()+" and "+user, RestStatus.FORBIDDEN));
+                listener.onFailure(new ElasticsearchSecurityException("no permissions for " + pres.getMissingPrivileges()+ " and "+user, RestStatus.FORBIDDEN));
                 return;
             }
         } catch (Throwable e) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/OpenDistroProtectedIndexAccessEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/OpenDistroProtectedIndexAccessEvaluator.java
@@ -36,8 +36,14 @@ public class OpenDistroProtectedIndexAccessEvaluator {
 
         final List<String> indexDeniedActionPatterns = new ArrayList<String>();
         indexDeniedActionPatterns.add("indices:data/write*");
-        indexDeniedActionPatterns.add("indices:admin/*");
-        indexDeniedActionPatterns.add("cluster:admin/snapshot/*");
+        indexDeniedActionPatterns.add("indices:admin/delete*");
+        indexDeniedActionPatterns.add("indices:admin/mapping/delete*");
+        indexDeniedActionPatterns.add("indices:admin/mapping/put*");
+        indexDeniedActionPatterns.add("indices:admin/freeze*");
+        indexDeniedActionPatterns.add("indices:admin/settings/update*");
+        indexDeniedActionPatterns.add("indices:admin/aliases");
+        indexDeniedActionPatterns.add("indices:admin/close*");
+        indexDeniedActionPatterns.add("cluster:admin/snapshot/restore*");
         this.deniedActionPatterns = indexDeniedActionPatterns.toArray(new String[0]);
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/OpenDistroProtectedIndexAccessEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/OpenDistroProtectedIndexAccessEvaluator.java
@@ -1,0 +1,86 @@
+package com.amazon.opendistroforelasticsearch.security.privileges;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog;
+import com.amazon.opendistroforelasticsearch.security.resolver.IndexResolverReplacer;
+import com.amazon.opendistroforelasticsearch.security.securityconf.SecurityRoles;
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.RealtimeRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.Task;
+
+public class OpenDistroProtectedIndexAccessEvaluator {
+
+    protected final Logger log = LogManager.getLogger(this.getClass());
+
+    private final AuditLog auditLog;
+    private final Collection<String> indexPatterns;
+    private final Collection<String> allowedRoles;
+    private final Boolean protectedIndexEnabled;
+    private final String[] deniedActionPatterns;
+
+
+    public OpenDistroProtectedIndexAccessEvaluator(final Settings settings, AuditLog auditLog) {
+        this.indexPatterns = settings.getAsList(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_KEY, ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_DEFAULT);
+        this.allowedRoles = settings.getAsList(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ROLES_KEY, ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ROLES_DEFAULT);
+        this.protectedIndexEnabled = settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ENABLED_KEY, ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ENABLED_DEFAULT);
+        this.auditLog = auditLog;
+
+        final List<String> indexDeniedActionPatterns = new ArrayList<String>();
+        indexDeniedActionPatterns.add("indices:data/write*");
+        indexDeniedActionPatterns.add("indices:admin/*");
+        indexDeniedActionPatterns.add("cluster:admin/snapshot/*");
+        this.deniedActionPatterns = indexDeniedActionPatterns.toArray(new String[0]);
+    }
+
+    public PrivilegesEvaluatorResponse evaluate(final ActionRequest request, final Task task, final String action, final IndexResolverReplacer.Resolved requestedResolved,
+                                                final PrivilegesEvaluatorResponse presponse, final SecurityRoles securityRoles) {
+        if (!protectedIndexEnabled) {
+            return presponse;
+        }
+        if (WildcardMatcher.matchAny(indexPatterns, requestedResolved.getAllIndices())
+                && WildcardMatcher.matchAny(deniedActionPatterns, action)
+                && !WildcardMatcher.matchAny(allowedRoles, securityRoles.getRoleNames())) {
+            auditLog.logMissingPrivileges(action, request, task);
+            log.warn(action + " for '{}' index/indices is not allowed for a regular user", indexPatterns);
+            presponse.allowed = false;
+            return presponse.markComplete();
+        }
+
+        if (requestedResolved.isLocalAll()
+                && WildcardMatcher.matchAny(deniedActionPatterns, action)
+                && !WildcardMatcher.matchAny(allowedRoles, securityRoles.getRoleNames())) {
+            auditLog.logMissingPrivileges(action, request, task);
+            log.warn(action + " for '_all' indices is not allowed for a regular user");
+            presponse.allowed = false;
+            return presponse.markComplete();
+        }
+        if((WildcardMatcher.matchAny(indexPatterns, requestedResolved.getAllIndices())
+                || requestedResolved.isLocalAll())
+                && !WildcardMatcher.matchAny(allowedRoles, securityRoles.getRoleNames())) {
+
+            if(request instanceof SearchRequest) {
+                ((SearchRequest)request).requestCache(Boolean.FALSE);
+                if(log.isDebugEnabled()) {
+                    log.debug("Disable search request cache for this request");
+                }
+            }
+
+            if(request instanceof RealtimeRequest) {
+                ((RealtimeRequest) request).realtime(Boolean.FALSE);
+                if(log.isDebugEnabled()) {
+                    log.debug("Disable realtime for this request");
+                }
+            }
+        }
+        return presponse;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
@@ -235,5 +235,14 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_USER_ENABLED = "opendistro_security.unsupported.inject_user.enabled";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED = "opendistro_security.unsupported.inject_user.admin.enabled";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_ALLOW_NOW_IN_DLS = "opendistro_security.unsupported.allow_now_in_dls";
+
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION = "opendistro_security.unsupported.restapi.allow_securityconfig_modification";
+
+    // Protected indices settings
+    public static final String OPENDISTRO_SECURITY_PROTECTED_INDICES_ENABLED_KEY = "opendistro_security.protected_indices.enabled";
+    public static final Boolean OPENDISTRO_SECURITY_PROTECTED_INDICES_ENABLED_DEFAULT = false;
+    public static final String OPENDISTRO_SECURITY_PROTECTED_INDICES_KEY = "opendistro_security.protected_indices.indices";
+    public static final List<String> OPENDISTRO_SECURITY_PROTECTED_INDICES_DEFAULT = Collections.emptyList();
+    public static final String OPENDISTRO_SECURITY_PROTECTED_INDICES_ROLES_KEY = "opendistro_security.protected_indices.roles";
+    public static final List<String> OPENDISTRO_SECURITY_PROTECTED_INDICES_ROLES_DEFAULT = Collections.emptyList();
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ReflectionHelper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ReflectionHelper.java
@@ -140,7 +140,7 @@ public class ReflectionHelper {
             final Class<?> clazz = Class.forName("com.amazon.opendistroforelasticsearch.security.configuration.OpenDistroSecurityFlsDlsIndexSearcherWrapper");
             final Constructor<?> ret = clazz.getConstructor(IndexService.class,
                     Settings.class, AdminDNs.class, ClusterService.class, AuditLog.class,
-                    ComplianceIndexingOperationListener.class, ComplianceConfig.class);
+                    ComplianceIndexingOperationListener.class, ComplianceConfig.class, PrivilegesEvaluator.class);
             addLoadedModule(clazz);
             return ret;
         } catch (final Throwable e) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/protected_indices/ProtectedIndicesTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/protected_indices/ProtectedIndicesTests.java
@@ -1,0 +1,910 @@
+package com.amazon.opendistroforelasticsearch.security.protected_indices;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import com.amazon.opendistroforelasticsearch.security.test.DynamicSecurityConfig;
+import com.amazon.opendistroforelasticsearch.security.test.SingleClusterTest;
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper;
+import org.apache.http.Header;
+import org.apache.http.HttpStatus;
+import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.rest.RestStatus;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+public class ProtectedIndicesTests extends SingleClusterTest {
+
+    private static final List<String> listOfIndexesToTest = Arrays.asList("logs1", "logs2", "logs3", "no_match");
+    private static final List<String> listOfIndexPatternsToTest = Arrays.asList("*logs*", "logs*", "*lo*");
+    private static final List<String> protectedIndexRoles = Arrays.asList("protected_index_role1", "protected_index_role2");
+    private static final String matchAllQuery = "{\n\"query\": {\"match_all\": {}}}";
+    // This user is mapped to all_access, but is not mapped to any protectedIndexRoles
+    private static final String indexAccessNoRoleUser = "indexAccessNoRoleUser";
+    private static final Header indexAccessNoRoleUserHeader = encodeBasicHeader(indexAccessNoRoleUser, indexAccessNoRoleUser);
+    private static final String generalErrorMessage = String.format("no permissions for [] and User [name=%s, roles=[], requestedTenant=null]", indexAccessNoRoleUser);
+    // This user is mapped to all_access and protected_index_role1
+    private static final String protectedIndexUser = "protectedIndexUser";
+    private static final Header protectedIndexUserHeader = encodeBasicHeader(protectedIndexUser, protectedIndexUser);
+
+    /**
+     * Setup settings loading custom config, users, roles and mappings.
+     * Set the protected indices and protected indices roles.
+     * Enable protected indices.
+     *
+     * @throws Exception
+     */
+    public void setupSettingsEnabled() throws Exception {
+        // Setup settings
+        Settings protectedIndexSettings = Settings.builder()
+                .put(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ENABLED_KEY, true)
+                .putList(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_KEY, listOfIndexesToTest)
+                .putList(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ROLES_KEY, protectedIndexRoles)
+                .build();
+        setup(Settings.EMPTY,
+                new DynamicSecurityConfig()
+                        .setConfig("config_protected_indices.yml")
+                        .setSecurityRoles("roles_protected_indices.yml")
+                        .setSecurityInternalUsers("internal_users_protected_indices.yml")
+                        .setSecurityRolesMapping("roles_mapping_protected_indices.yml"),
+                protectedIndexSettings,
+                true);
+    }
+
+    public void setupSettingsIndexPatterns() throws Exception {
+        // Setup settings
+        Settings protectedIndexSettings = Settings.builder()
+                .put(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ENABLED_KEY, true)
+                .putList(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_KEY, listOfIndexPatternsToTest)
+                .putList(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ROLES_KEY, protectedIndexRoles)
+                .build();
+        setup(Settings.EMPTY,
+                new DynamicSecurityConfig()
+                        .setConfig("config_protected_indices.yml")
+                        .setSecurityRoles("roles_protected_indices.yml")
+                        .setSecurityInternalUsers("internal_users_protected_indices.yml")
+                        .setSecurityRolesMapping("roles_mapping_protected_indices.yml"),
+                protectedIndexSettings,
+                true);
+    }
+
+    /**
+     * Setup settings loading custom config, users, roles and mappings.
+     * Set the protected indices and protected indices roles.
+     * Disable protected indices.
+     *
+     * @throws Exception
+     */
+    public void setupSettingsDisabled() throws Exception {
+        // Setup settings
+        Settings protectedIndexSettings = Settings.builder()
+                .put(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ENABLED_KEY, false)
+                .putList(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_KEY, listOfIndexesToTest)
+                .putList(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ROLES_KEY, protectedIndexRoles)
+                .build();
+        setup(Settings.EMPTY,
+                new DynamicSecurityConfig()
+                        .setConfig("config_protected_indices.yml")
+                        .setSecurityRoles("roles_protected_indices.yml")
+                        .setSecurityInternalUsers("internal_users_protected_indices.yml")
+                        .setSecurityRolesMapping("roles_mapping_protected_indices.yml"),
+                protectedIndexSettings,
+                true);
+    }
+
+    public void setupSettingsEnabledSnapshot() throws Exception {
+        final Settings settings = Settings.builder()
+                .putList("path.repo", repositoryPath.getRoot().getAbsolutePath())
+                .put(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ENABLED_KEY, true)
+                .putList(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_KEY, listOfIndexesToTest)
+                .putList(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ROLES_KEY, protectedIndexRoles)
+                .build();
+
+        setup(Settings.EMPTY, new DynamicSecurityConfig()
+                .setConfig("config_protected_indices.yml")
+                .setSecurityRoles("roles_protected_indices.yml")
+                .setSecurityInternalUsers("internal_users_protected_indices.yml")
+                .setSecurityRolesMapping("roles_mapping_protected_indices.yml"),
+                settings,
+                true);
+    }
+
+    /**
+     * Creates a set of test indices and indexes one document into each index.
+     *
+     * @throws Exception
+     */
+    public void createTestIndicesAndDocs() {
+        try (TransportClient tc = getInternalTransportClient()) {
+            for (String index : listOfIndexesToTest) {
+                tc.admin().indices().create(new CreateIndexRequest(index)).actionGet();
+                tc.index(new IndexRequest(index).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).id("document1").source("{ \"foo\": \"bar\" }", XContentType.JSON)).actionGet();
+            }
+        }
+    }
+
+    public void createSnapshots() {
+        try (TransportClient tc = getInternalTransportClient()) {
+            for (String index : listOfIndexesToTest) {
+                tc.admin().cluster().putRepository(new PutRepositoryRequest(index).type("fs").settings(Settings.builder().put("location", repositoryPath.getRoot().getAbsolutePath() + "/" + index))).actionGet();
+                tc.admin().cluster().createSnapshot(new CreateSnapshotRequest(index, index + "_1").indices(index).includeGlobalState(true).waitForCompletion(true)).actionGet();
+            }
+        }
+    }
+
+    /************************************************************************************************
+     * Tests with a user who has all index permissions but is not member of the protectedIndexRoles
+     ***********************************************************************************************/
+
+    // Test data search
+    @Test
+    public void testNoSearchResults() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        // Test direct index query.
+        for (String index : listOfIndexesToTest) {
+            RestHelper.HttpResponse response = rh.executePostRequest(index + "/_search", matchAllQuery, indexAccessNoRoleUserHeader);
+            XContentParser xcp = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getBody());
+            SearchResponse searchResponse = SearchResponse.fromXContent(xcp);
+            // confirm good response.
+            assertTrue(searchResponse.status() == RestStatus.OK);
+            // confirm no search hits.
+            assertTrue(searchResponse.getHits().getHits().length == 0);
+            // confirm no failed shards.
+            assertTrue(searchResponse.getFailedShards() == 0);
+            // confirm data was actually queried
+            assertTrue(searchResponse.getSuccessfulShards() == 5);
+        }
+
+        // Test index pattern
+        for (String indexPattern : listOfIndexPatternsToTest) {
+            RestHelper.HttpResponse response = rh.executePostRequest(indexPattern + "/_search", matchAllQuery, indexAccessNoRoleUserHeader);
+            XContentParser xcp = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getBody());
+            SearchResponse searchResponse = SearchResponse.fromXContent(xcp);
+            // confirm good response.
+            assertTrue(searchResponse.status() == RestStatus.OK);
+            // confirm no search hits.
+            assertTrue(searchResponse.getHits().getHits().length == 0);
+            // confirm no failed shards.
+            assertTrue(searchResponse.getFailedShards() == 0);
+            // confirm data was actually queried
+            assertTrue(searchResponse.getSuccessfulShards() == 15);
+        }
+    }
+
+    @Test
+    public void testSearchWithSettingDisabled() throws Exception {
+        setupSettingsDisabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        // Test direct index query.
+        for (String index : listOfIndexesToTest) {
+            RestHelper.HttpResponse response = rh.executePostRequest(index + "/_search", matchAllQuery, protectedIndexUserHeader);
+            XContentParser xcp = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getBody());
+            SearchResponse searchResponse = SearchResponse.fromXContent(xcp);
+            // confirm good response.
+            assertTrue(searchResponse.status() == RestStatus.OK);
+            // confirm search hits.
+            assertTrue(searchResponse.getHits().getHits().length == 1);
+            // confirm no failed shards.
+            assertTrue(searchResponse.getFailedShards() == 0);
+            // confirm data was actually queried
+            assertTrue(searchResponse.getSuccessfulShards() == 5);
+        }
+
+        // Test index pattern
+        for (String indexPattern : listOfIndexPatternsToTest) {
+            RestHelper.HttpResponse response = rh.executePostRequest(indexPattern + "/_search", matchAllQuery, protectedIndexUserHeader);
+            XContentParser xcp = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getBody());
+            SearchResponse searchResponse = SearchResponse.fromXContent(xcp);
+            // confirm good response.
+            assertTrue(searchResponse.status() == RestStatus.OK);
+            // confirm search hits.
+            assertTrue(searchResponse.getHits().getHits().length == 3);
+            // confirm no failed shards.
+            assertTrue(searchResponse.getFailedShards() == 0);
+            // confirm data was actually queried
+            assertTrue(searchResponse.getSuccessfulShards() == 15);
+        }
+    }
+
+    @Test
+    public void testNoResultsAlias() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        int i = 0;
+        try (TransportClient tc = getInternalTransportClient()) {
+            for (String index : listOfIndexesToTest) {
+                IndicesAliasesRequest request = new IndicesAliasesRequest();
+                IndicesAliasesRequest.AliasActions aliasAction =
+                        new IndicesAliasesRequest.AliasActions(IndicesAliasesRequest.AliasActions.Type.ADD)
+                                .index(index)
+                                .alias("alias" + i);
+                request.addAliasAction(aliasAction);
+                tc.admin().indices().aliases(request).actionGet();
+                i++;
+            }
+        }
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (int aliasNumber = 0; aliasNumber < i; aliasNumber++) {
+            RestHelper.HttpResponse response = rh.executePostRequest("alias" + aliasNumber + "/_search", matchAllQuery, indexAccessNoRoleUserHeader);
+            XContentParser xcp = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getBody());
+            SearchResponse searchResponse = SearchResponse.fromXContent(xcp);
+            // confirm good response.
+            assertTrue(searchResponse.status() == RestStatus.OK);
+            // confirm no search hits.
+            assertTrue(searchResponse.getHits().getHits().length == 0);
+            // confirm no failed shards.
+            assertTrue(searchResponse.getFailedShards() == 0);
+            // confirm data was actually queried
+            assertTrue(searchResponse.getSuccessfulShards() == 5);
+        }
+    }
+
+    // Test indices:admin/create
+    @Test
+    public void testNoAccessCreateIndex() throws Exception {
+        setupSettingsEnabled();
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        String indexSettings = "{\n" +
+                "    \"settings\" : {\n" +
+                "        \"index\" : {\n" +
+                "            \"number_of_shards\" : 3, \n" +
+                "            \"number_of_replicas\" : 2 \n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        for (String index : listOfIndexesToTest) {
+            RestHelper.HttpResponse response = rh.executePutRequest(index, indexSettings, indexAccessNoRoleUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+            assertTrue(response.getBody().contains(generalErrorMessage));
+        }
+    }
+
+
+    @Test
+    public void testCreateIndexNoAccessPatternSettings() throws Exception {
+        setupSettingsIndexPatterns();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String pattern : listOfIndexPatternsToTest) {
+            String index = pattern.replace("*", "1");
+            RestHelper.HttpResponse response = rh.executePutRequest(index, "", indexAccessNoRoleUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+            assertTrue(response.getBody().contains(generalErrorMessage));
+        }
+    }
+
+    // Test indices:admin/create
+    @Test
+    public void testNoAccessCreateIndexDisabled() throws Exception {
+        setupSettingsDisabled();
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        String indexSettings = "{\n" +
+                "    \"settings\" : {\n" +
+                "        \"index\" : {\n" +
+                "            \"number_of_shards\" : 3, \n" +
+                "            \"number_of_replicas\" : 2 \n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        for (String index : listOfIndexesToTest) {
+            RestHelper.HttpResponse response = rh.executePutRequest(index, indexSettings, indexAccessNoRoleUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.OK.getStatus());
+        }
+    }
+
+    // Test indices:data/write
+    @Test
+    public void testNonAccessCreateDocument() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            // Try to create documents
+            String doc = "{\"foo\": \"bar\"}";
+            RestHelper.HttpResponse response = rh.executePostRequest(index + "/_doc", doc, indexAccessNoRoleUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+            assertTrue(response.getBody().contains(generalErrorMessage));
+        }
+    }
+
+    @Test
+    public void testNonAccessCreateDocumentPatternSetting() throws Exception {
+        setupSettingsIndexPatterns();
+
+        try (TransportClient tc = getInternalTransportClient()) {
+            for (String pattern : listOfIndexPatternsToTest) {
+                String index = pattern.replace("*", "1");
+                tc.admin().indices().create(new CreateIndexRequest(index)).actionGet();
+            }
+        }
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String pattern : listOfIndexPatternsToTest) {
+            // Try to create documents
+            String doc = "{\"foo\": \"bar\"}";
+            String index = pattern.replace("*", "1");
+            RestHelper.HttpResponse response = rh.executePostRequest(index + "/_doc", doc, indexAccessNoRoleUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+            assertTrue(response.getBody().contains(generalErrorMessage));
+        }
+    }
+
+    // Test indices:data/write
+    @Test
+    public void testNonAccessCreateDocumentDisabled() throws Exception {
+        setupSettingsDisabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            // Try to create documents
+            String doc = "{\"foo\": \"bar\"}";
+            RestHelper.HttpResponse response = rh.executePostRequest(index + "/_doc", doc, indexAccessNoRoleUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.CREATED.getStatus());
+        }
+    }
+
+    @Test
+    public void testNonAccessDeleteDocument() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            // Try to delete documents
+            RestHelper.HttpResponse response = rh.executeDeleteRequest(index + "/_doc/document1", indexAccessNoRoleUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+            assertTrue(response.getBody().contains(generalErrorMessage));
+        }
+    }
+
+    @Test
+    public void testNonAccessDeleteDocumentDisabled() throws Exception {
+        setupSettingsDisabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            // Try to delete documents
+            RestHelper.HttpResponse response = rh.executeDeleteRequest(index + "/_doc/document1", indexAccessNoRoleUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.OK.getStatus());
+        }
+    }
+
+    // Test indices:admin/delete
+    @Test
+    public void testNonAccessDeleteIndex() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            // Try to delete documents
+            RestHelper.HttpResponse response = rh.executeDeleteRequest(index, indexAccessNoRoleUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+            assertTrue(response.getBody().contains(generalErrorMessage));
+        }
+    }
+
+    // Test indices:admin/delete
+    @Test
+    public void testNonAccessDeleteIndexDisabled() throws Exception {
+        setupSettingsDisabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            // Try to delete documents
+            RestHelper.HttpResponse response = rh.executeDeleteRequest(index, indexAccessNoRoleUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.OK.getStatus());
+        }
+    }
+
+    // Tests indices:admin/mapping/put
+    @Test
+    public void testNonAccessUpdateMappings() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        String newMappings = "{\"properties\": {" +
+                "\"user_name\": {" +
+                "\"type\": \"text\"" +
+                "}}}";
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            RestHelper.HttpResponse response = rh.executePutRequest(index + "/_mapping", newMappings, indexAccessNoRoleUserHeader);
+
+            assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+            assertTrue(response.getBody().contains(generalErrorMessage));
+        }
+    }
+
+    // Tests indices:admin/mapping/put
+    @Test
+    public void testNonAccessUpdateMappingsDisabled() throws Exception {
+        setupSettingsDisabled();
+        createTestIndicesAndDocs();
+
+        String newMappings = "{\"properties\": {" +
+                "\"user_name\": {" +
+                "\"type\": \"text\"" +
+                "}}}";
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            RestHelper.HttpResponse response = rh.executePutRequest(index + "/_mapping", newMappings, indexAccessNoRoleUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.OK.getStatus());
+        }
+    }
+
+    // Tests indices:admin/close
+    @Test
+    public void testNonAccessCloseIndex() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            RestHelper.HttpResponse response = rh.executePostRequest(index + "/_close", "", indexAccessNoRoleUserHeader);
+
+            assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+            assertTrue(response.getBody().contains(generalErrorMessage));
+        }
+    }
+
+    // Tests indices:admin/open
+    @Test
+    public void testNonAccessOpenIndex() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            RestHelper.HttpResponse response = rh.executePostRequest(index + "/_open", "", indexAccessNoRoleUserHeader);
+
+            assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+            assertTrue(response.getBody().contains(generalErrorMessage));
+        }
+    }
+
+    // Tests indices:admin/aliases
+    @Test
+    public void testNonAccessAliasOperations() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        // Test create alias
+        String aliasTemplate = "{\"actions\" : [{ \"add\" : { \"index\" : \"%s\", \"alias\" : \"foobar\" } }]}";
+        for (String index : listOfIndexesToTest) {
+
+            RestHelper.HttpResponse response = rh.executePostRequest("_aliases", String.format(aliasTemplate, index), indexAccessNoRoleUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+            assertTrue(response.getBody().contains(generalErrorMessage));
+        }
+
+        // Test remove alias
+        aliasTemplate = "{\"actions\" : [{ \"remove\" : { \"index\" : \"%s\", \"alias\" : \"foobar\" } }]}";
+        for (String index : listOfIndexesToTest) {
+
+            RestHelper.HttpResponse response = rh.executePostRequest("_aliases", String.format(aliasTemplate, index), indexAccessNoRoleUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+            assertTrue(response.getBody().contains(generalErrorMessage));
+        }
+
+        // Test remove index
+        aliasTemplate = "{\"actions\" : [{ \"remove_index\" : { \"index\" : \"%s\"} }]}";
+        for (String index : listOfIndexesToTest) {
+
+            RestHelper.HttpResponse response = rh.executePostRequest("_aliases", String.format(aliasTemplate, index), indexAccessNoRoleUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+            assertTrue(response.getBody().contains(generalErrorMessage));
+        }
+    }
+
+    // Tests indicies:admin/settings/update permission
+    @Test
+    public void testNonAccessUpdateIndexSettings() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        String indexSettings = "{\n" +
+                "    \"settings\" : {\n" +
+                "        \"index\" : {\n" +
+                "            \"number_of_shards\" : 30, \n" +
+                "            \"number_of_replicas\" : 20 \n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        for (String index : listOfIndexesToTest) {
+            RestHelper.HttpResponse response = rh.executePutRequest(index + "/_settings", indexSettings, indexAccessNoRoleUserHeader);
+
+            assertTrue(response.getStatusCode() == RestStatus.FORBIDDEN.getStatus());
+            assertTrue(response.getBody().contains(generalErrorMessage));
+        }
+    }
+
+    /************************************************************************************************
+     * Tests with a user who has all index permissions and is a member of the protectedIndexRoles
+     ***********************************************************************************************/
+
+    // Test data search
+    @Test
+    public void testSearchResults() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        // Test direct index query.
+        for (String index : listOfIndexesToTest) {
+            RestHelper.HttpResponse response = rh.executePostRequest(index + "/_search", matchAllQuery, protectedIndexUserHeader);
+            XContentParser xcp = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getBody());
+            SearchResponse searchResponse = SearchResponse.fromXContent(xcp);
+            // confirm good response.
+            assertTrue(searchResponse.status() == RestStatus.OK);
+            // confirm search hits.
+            assertTrue(searchResponse.getHits().getHits().length == 1);
+            // confirm no failed shards.
+            assertTrue(searchResponse.getFailedShards() == 0);
+            // confirm data was actually queried
+            assertTrue(searchResponse.getSuccessfulShards() == 5);
+        }
+
+        // Test index pattern
+        for (String indexPattern : listOfIndexPatternsToTest) {
+            RestHelper.HttpResponse response = rh.executePostRequest(indexPattern + "/_search", matchAllQuery, protectedIndexUserHeader);
+            XContentParser xcp = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getBody());
+            SearchResponse searchResponse = SearchResponse.fromXContent(xcp);
+            // confirm good response.
+            assertTrue(searchResponse.status() == RestStatus.OK);
+            // confirm search hits.
+            assertTrue(searchResponse.getHits().getHits().length == 3);
+            // confirm no failed shards.
+            assertTrue(searchResponse.getFailedShards() == 0);
+            // confirm data was actually queried
+            assertTrue(searchResponse.getSuccessfulShards() == 15);
+        }
+    }
+
+    @Test
+    public void testResultsAlias() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        int i = 0;
+        try (TransportClient tc = getInternalTransportClient()) {
+            for (String index : listOfIndexesToTest) {
+                IndicesAliasesRequest request = new IndicesAliasesRequest();
+                IndicesAliasesRequest.AliasActions aliasAction =
+                        new IndicesAliasesRequest.AliasActions(IndicesAliasesRequest.AliasActions.Type.ADD)
+                                .index(index)
+                                .alias("alias" + i);
+                request.addAliasAction(aliasAction);
+                tc.admin().indices().aliases(request).actionGet();
+                i++;
+            }
+        }
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (int aliasNumber = 0; aliasNumber < i; aliasNumber++) {
+            RestHelper.HttpResponse response = rh.executePostRequest("alias" + aliasNumber + "/_search", matchAllQuery, protectedIndexUserHeader);
+
+            XContentParser xcp = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getBody());
+            SearchResponse searchResponse = SearchResponse.fromXContent(xcp);
+            // confirm good response.
+            assertTrue(searchResponse.status() == RestStatus.OK);
+            // confirm search hits.
+            assertTrue(searchResponse.getHits().getHits().length == 1);
+            // confirm no failed shards.
+            assertTrue(searchResponse.getFailedShards() == 0);
+            // confirm data was actually queried
+            assertTrue(searchResponse.getSuccessfulShards() == 5);
+        }
+    }
+
+    // Test indices:admin/create
+    @Test
+    public void testCreateIndex() throws Exception {
+        setupSettingsEnabled();
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        String indexSettings = "{\n" +
+                "    \"settings\" : {\n" +
+                "        \"index\" : {\n" +
+                "            \"number_of_shards\" : 3, \n" +
+                "            \"number_of_replicas\" : 2 \n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        for (String index : listOfIndexesToTest) {
+            RestHelper.HttpResponse response = rh.executePutRequest(index, indexSettings, protectedIndexUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.OK.getStatus());
+        }
+    }
+
+    // Test indices:data/write
+    @Test
+    public void testCreateDocument() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            // Try to create documents
+            String doc = "{\"foo\": \"bar\"}";
+            RestHelper.HttpResponse response = rh.executePostRequest(index + "/_doc", doc, protectedIndexUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.CREATED.getStatus());
+        }
+    }
+
+    @Test
+    public void testDeleteDocument() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            // Try to delete documents
+            RestHelper.HttpResponse response = rh.executeDeleteRequest(index + "/_doc/document1", protectedIndexUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.OK.getStatus());
+        }
+    }
+
+    // Test indices:admin/delete
+    @Test
+    public void testDeleteIndex() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            // Try to delete documents
+            RestHelper.HttpResponse response = rh.executeDeleteRequest(index, protectedIndexUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.OK.getStatus());
+        }
+    }
+
+    // Tests indices:admin/mapping/put
+    @Test
+    public void testUpdateMappings() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        String newMappings = "{\"properties\": {" +
+                "\"user_name\": {" +
+                "\"type\": \"text\"" +
+                "}}}";
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            RestHelper.HttpResponse response = rh.executePutRequest(index + "/_mapping", newMappings, protectedIndexUserHeader);
+
+            assertTrue(response.getStatusCode() == RestStatus.OK.getStatus());
+        }
+    }
+
+    // Tests indices:admin/close
+    @Test
+    public void testCloseIndex() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            RestHelper.HttpResponse response = rh.executePostRequest(index + "/_close", "", protectedIndexUserHeader);
+
+            assertTrue(response.getStatusCode() == RestStatus.OK.getStatus());
+        }
+    }
+
+    // Tests indices:admin/open
+    @Test
+    public void testOpenIndex() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            RestHelper.HttpResponse response = rh.executePostRequest(index + "/_open", "", protectedIndexUserHeader);
+
+            assertTrue(response.getStatusCode() == RestStatus.OK.getStatus());
+        }
+    }
+
+    // Tests indices:admin/aliases
+    @Test
+    public void testAliasOperations() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        // Test create alias
+        String aliasTemplate = "{\"actions\" : [{ \"add\" : { \"index\" : \"%s\", \"alias\" : \"foobar\" } }]}";
+        for (String index : listOfIndexesToTest) {
+
+            RestHelper.HttpResponse response = rh.executePostRequest("_aliases", String.format(aliasTemplate, index), protectedIndexUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.OK.getStatus());
+        }
+
+        // Test remove alias
+        aliasTemplate = "{\"actions\" : [{ \"remove\" : { \"index\" : \"%s\", \"alias\" : \"foobar\" } }]}";
+        for (String index : listOfIndexesToTest) {
+
+            RestHelper.HttpResponse response = rh.executePostRequest("_aliases", String.format(aliasTemplate, index), protectedIndexUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.OK.getStatus());
+        }
+
+        // Test remove index
+        aliasTemplate = "{\"actions\" : [{ \"remove_index\" : { \"index\" : \"%s\"} }]}";
+        for (String index : listOfIndexesToTest) {
+
+            RestHelper.HttpResponse response = rh.executePostRequest("_aliases", String.format(aliasTemplate, index), protectedIndexUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.OK.getStatus());
+        }
+    }
+
+    // Tests indicies:admin/settings/update permission
+    @Test
+    public void testUpdateIndexSettings() throws Exception {
+        setupSettingsEnabled();
+        createTestIndicesAndDocs();
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        String indexSettings = "{\n" +
+                "    \"index\" : {\n" +
+                "        \"refresh_interval\" : null\n" +
+                "    }\n" +
+                "}";
+
+        for (String index : listOfIndexesToTest) {
+            RestHelper.HttpResponse response = rh.executePutRequest(index + "/_settings", indexSettings, protectedIndexUserHeader);
+            assertTrue(response.getStatusCode() == RestStatus.OK.getStatus());
+        }
+    }
+
+    /************************************************************************************************
+     * Test snapshot operations
+     ***********************************************************************************************/
+
+    @Test
+    public void testNoAccessSnapshot() throws Exception {
+        setupSettingsEnabledSnapshot();
+        createTestIndicesAndDocs();
+        createSnapshots();
+
+        try (TransportClient tc = getInternalTransportClient()) {
+            for (String index : listOfIndexesToTest) {
+                tc.admin().indices().close(new CloseIndexRequest(index)).actionGet();
+            }
+        }
+
+        String putSnapshot = "{"+
+                "\"indices\": \"%s\"," +
+                "\"ignore_unavailable\": false," +
+                "\"include_global_state\": false" +
+                "}";
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            assertEquals(HttpStatus.SC_FORBIDDEN, rh.executeGetRequest("_snapshot/" + index + "/" + index + "_1", indexAccessNoRoleUserHeader).getStatusCode());
+            assertEquals(HttpStatus.SC_FORBIDDEN, rh.executePostRequest("_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true","{ \"include_global_state\": true, \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_with_global_state_$1\" }", indexAccessNoRoleUserHeader).getStatusCode());
+            assertEquals(HttpStatus.SC_FORBIDDEN, rh.executePostRequest("_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true", "", indexAccessNoRoleUserHeader).getStatusCode());
+            assertEquals(HttpStatus.SC_FORBIDDEN, rh.executePostRequest("_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true","{ \"indices\": \"" + index + "\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"" + index + "\" }", indexAccessNoRoleUserHeader).getStatusCode());
+            assertEquals(HttpStatus.SC_FORBIDDEN, rh.executePutRequest("_snapshot/" + index + "/" + index + "_2?wait_for_completion=true", String.format(putSnapshot, index), indexAccessNoRoleUserHeader).getStatusCode());
+        }
+    }
+
+    @Test
+    public void testAccessSnapshot() throws Exception {
+        setupSettingsEnabledSnapshot();
+        createTestIndicesAndDocs();
+        createSnapshots();
+
+        try (TransportClient tc = getInternalTransportClient()) {
+            for (String index : listOfIndexesToTest) {
+                tc.admin().indices().close(new CloseIndexRequest(index)).actionGet();
+            }
+        }
+
+        String putSnapshot = "{"+
+                "\"indices\": \"%s\"," +
+                "\"ignore_unavailable\": false," +
+                "\"include_global_state\": false" +
+                "}";
+
+        // Create rest client
+        RestHelper rh = nonSslRestHelper();
+
+        for (String index : listOfIndexesToTest) {
+            assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_snapshot/" + index + "/" + index + "_1", protectedIndexUserHeader).getStatusCode());
+            assertEquals(HttpStatus.SC_OK, rh.executePostRequest("_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true","{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_with_global_state_$1\" }", protectedIndexUserHeader).getStatusCode());
+            assertEquals(HttpStatus.SC_OK, rh.executePostRequest("_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true", "", protectedIndexUserHeader).getStatusCode());
+            assertEquals(HttpStatus.SC_OK, rh.executePostRequest("_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true","{ \"indices\": \"" + index + "\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"" + index + "_1\" }", protectedIndexUserHeader).getStatusCode());
+            assertEquals(HttpStatus.SC_OK, rh.executePutRequest("_snapshot/" + index + "/" + index + "_2?wait_for_completion=true", String.format(putSnapshot, index), protectedIndexUserHeader).getStatusCode());
+        }
+    }
+}

--- a/src/test/resources/config_protected_indices.yml
+++ b/src/test/resources/config_protected_indices.yml
@@ -1,0 +1,94 @@
+---
+_meta:
+  type: "config"
+  config_version: 2
+config:
+  dynamic:
+    filtered_alias_mode: "disallow"
+    disable_rest_auth: false
+    disable_intertransport_auth: false
+    respect_request_indices_options: false
+    kibana:
+      multitenancy_enabled: true
+      server_username: "kibanaserver"
+      index: ".kibana"
+    http:
+      anonymous_auth_enabled: false
+      xff:
+        enabled: false
+        internalProxies: "192\\.168\\.0\\.10|192\\.168\\.0\\.11"
+        remoteIpHeader: "x-forwarded-for"
+    authc:
+      authentication_domain_kerb:
+        http_enabled: false
+        transport_enabled: false
+        order: 3
+        http_authenticator:
+          challenge: true
+          type: "kerberos"
+          config: {}
+        authentication_backend:
+          type: "noop"
+          config: {}
+        description: "Migrated from v6"
+      authentication_domain_proxy:
+        http_enabled: false
+        transport_enabled: false
+        order: 2
+        http_authenticator:
+          challenge: true
+          type: "proxy"
+          config:
+            user_header: "x-proxy-user"
+            roles_header: "x-proxy-roles"
+        authentication_backend:
+          type: "noop"
+          config: {}
+        description: "Migrated from v6"
+      authentication_domain_clientcert:
+        http_enabled: false
+        transport_enabled: false
+        order: 1
+        http_authenticator:
+          challenge: true
+          type: "clientcert"
+          config: {}
+        authentication_backend:
+          type: "noop"
+          config: {}
+        description: "Migrated from v6"
+      authentication_domain_basic_internal:
+        http_enabled: true
+        transport_enabled: true
+        order: 0
+        http_authenticator:
+          challenge: true
+          type: "basic"
+          config: {}
+        authentication_backend:
+          type: "intern"
+          config: {}
+        description: "Migrated from v6"
+    authz:
+      roles_from_xxx:
+        http_enabled: false
+        transport_enabled: false
+        authorization_backend:
+          type: "xxx"
+          config: {}
+        description: "Migrated from v6"
+      roles_from_myldap:
+        http_enabled: false
+        transport_enabled: false
+        authorization_backend:
+          type: "ldap"
+          config:
+            rolesearch: "(uniqueMember={0})"
+            resolve_nested_roles: true
+            rolebase: "ou=groups,o=TEST"
+            rolename: "cn"
+        description: "Migrated from v6"
+    do_not_fail_on_forbidden: false
+    multi_rolespan_enabled: false
+    hosts_resolver_mode: "ip-only"
+    transport_userrname_attribute: null

--- a/src/test/resources/internal_users_protected_indices.yml
+++ b/src/test/resources/internal_users_protected_indices.yml
@@ -1,0 +1,19 @@
+---
+_meta:
+  type: "internalusers"
+  config_version: 2
+indexAccessNoRoleUser:
+  hash: "$2y$12$93KcWlQxeify28LSx8EjYOnHv1AQ6vJZXSRUVTnfSN7AxTfvCBfu."
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "User mapped to all cluster and index permissions but no role to view protected index"
+
+protectedIndexUser:
+  hash: "$2y$12$LavzCpUFiFwXD22rc0n.SOVExdnzDcn6lHY48XKPl6KKdvAHm0awm"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "User mapped to all cluster and index permissions but no role to view protected index"

--- a/src/test/resources/roles_mapping_protected_indices.yml
+++ b/src/test/resources/roles_mapping_protected_indices.yml
@@ -1,0 +1,23 @@
+---
+_meta:
+  type: "rolesmapping"
+  config_version: 2
+
+all_access:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "indexAccessNoRoleUser"
+    - "protectedIndexUser"
+  description: "Full index permissions, but no role to view protected indices."
+
+protected_index_role1:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "protectedIndexUser"
+  description: "Role to have access to protected indices."

--- a/src/test/resources/roles_protected_indices.yml
+++ b/src/test/resources/roles_protected_indices.yml
@@ -1,0 +1,17 @@
+---
+_meta:
+  type: "roles"
+  config_version: 2
+
+full_index_permissions:
+  description: "All access role, but not protected index role."
+  cluster_permissions:
+    - '*'
+  index_permissions:
+    - index_patterns:
+        - '*'
+      allowed_actions:
+        - '*'
+
+protected_index_role1:
+    description: "Blank role to give access to protected indices."


### PR DESCRIPTION
# Information

While Kibana is coming up we noticed an issue with requests failing due to performing `_all` requests while creating index aliases. This caused kibana to fail to come up. This change makes the permissions equal to that of the security index.

# Tests
## Security
```
To complete
```
## Advanced Modules
```
To complete
```

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._