### PR TITLE
Bumping subversion 0.10.0.3

### DIFF
--- a/opendistro-elasticsearch-security.release-notes
+++ b/opendistro-elasticsearch-security.release-notes
@@ -1,3 +1,7 @@
+## 2019-09-11, Version 0.10.0.3 (Current)
+
+- Fix protected index kibana
+
 ## 2019-09-06, Version 0.10.0.2
 
 - Add 3 new default read only roles to easily allow integration with the opendistro alerting plugin

--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -3,7 +3,7 @@
 description=Provide access control related features for Elasticsearch 6
 #
 # 'version': plugin's version
-version=0.10.0.2
+version=0.10.0.3
 #
 # 'name': the plugin name
 name=opendistro_security

--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
   <parent>
     <groupId>com.amazon.opendistroforelasticsearch</groupId>
     <artifactId>opendistro_security_parent</artifactId>
-    <version>0.10.0.2</version>
+    <version>0.10.0.3</version>
   </parent>
 
   <artifactId>opendistro_security</artifactId>
   <packaging>jar</packaging>
-  <version>0.10.0.2</version>
+  <version>0.10.0.3</version>
   <name>Open Distro Security for Elasticsearch</name>
   <description>Open Distro For Elasticsearch Security</description>
   <inceptionYear>2015</inceptionYear>
@@ -52,8 +52,8 @@
   </licenses>
 
   <properties>
-    <opendistro_security_ssl.version>0.10.0.2</opendistro_security_ssl.version>
-    <opendistro_security_advanced_modules.version>0.10.0.2</opendistro_security_advanced_modules.version>
+    <opendistro_security_ssl.version>0.10.0.3</opendistro_security_ssl.version>
+    <opendistro_security_advanced_modules.version>0.10.0.3</opendistro_security_advanced_modules.version>
     <elasticsearch.version>6.8.1</elasticsearch.version>
     
     <!-- deps -->
@@ -76,7 +76,7 @@
     <url>https://github.com/opendistro-for-elasticsearch/security</url>
     <connection>scm:git:git@github.com:opendistro-for-elasticsearch/security.git</connection>
     <developerConnection>scm:git:git@github.com:opendistro-for-elasticsearch/security.git</developerConnection>
-    <tag>0.10.0.2</tag>
+    <tag>0.10.0.3</tag>
   </scm>
 
   <issueManagement>


### PR DESCRIPTION
Update pom file, plugin-descriptor.properties, and release notes.

[INFO] Results:
[INFO]
[WARNING] Tests run: 128, Failures: 0, Errors: 0, Skipped: 4
[INFO]
[INFO]
[INFO] --- maven-jar-plugin:3.1.0:jar (default-jar) @ opendistro_security ---
[INFO] Building jar: /Opendistro/security/target/opendistro_security-0.10.0.3.jar
[INFO]
[INFO] --- git-commit-id-plugin:2.2.3:validateRevision (validate-the-git-infos) @ opendistro_security ---
[INFO]
[INFO] --- maven-jar-plugin:3.1.0:test-jar (default) @ opendistro_security ---
[INFO] Building jar: /Opendistro/security/target/opendistro_security-0.10.0.3-tests.jar
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ opendistro_security ---
[INFO] Installing /Opendistro/security/target/opendistro_security-0.10.0.3.jar to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/0.10.0.3/opendistro_security-0.10.0.3.jar
[INFO] Installing /Opendistro/security/pom.xml to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/0.10.0.3/opendistro_security-0.10.0.3.pom
[INFO] Installing /Opendistro/security/target/opendistro_security-0.10.0.3-tests.jar to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/0.10.0.3/opendistro_security-0.10.0.3-tests.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------