### PR TITLE
Use BASE_DIR in demo install script

### DIFF
--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -113,17 +113,12 @@ SUDO_CMD=""
 ES_INSTALL_TYPE=".tar.gz"
 
 #Check if its a rpm/deb install
-if [ -f /usr/share/elasticsearch/bin/elasticsearch ]; then
+if [ "/usr/share/elasticsearch" -ef "$BASE_DIR" ]; then
     ES_CONF_FILE="/usr/share/elasticsearch/config/elasticsearch.yml"
 
     if [ ! -f "$ES_CONF_FILE" ]; then
         ES_CONF_FILE="/etc/elasticsearch/elasticsearch.yml"
     fi
-
-    ES_BIN_DIR="/usr/share/elasticsearch/bin"
-    ES_PLUGINS_DIR="/usr/share/elasticsearch/plugins"
-    ES_MODULES_DIR="/usr/share/elasticsearch/modules"
-    ES_LIB_PATH="/usr/share/elasticsearch/lib"
 
     if [ -x "$(command -v sudo)" ]; then
         SUDO_CMD="sudo"


### PR DESCRIPTION
In `install_demo_configuration.sh` was hardcoded the default directory
`/usr/share/elasticsearch`, this won't work if elasticsearch is
installed on a custom location (or if it used from the tar.gz for
testing).

Using the `BASE_DIR` variable we can get more flexibility from the script.