### PR TITLE
Getting ready for opendistro-1.4 release

### DIFF
--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -3,7 +3,7 @@
 description=Provide access control related features for Elasticsearch 7
 #
 # 'version': plugin's version
-version=1.3.0.0
+version=1.4.0.0
 #
 # 'name': the plugin name
 name=opendistro_security
@@ -22,4 +22,4 @@ java.version=1.8
 # elasticsearch release. This version is checked when the plugin
 # is loaded so Elasticsearch will refuse to start in the presence of
 # plugins with the incorrect elasticsearch.version.
-elasticsearch.version=7.3.2
+elasticsearch.version=7.4.2

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <groupId>com.amazon.opendistroforelasticsearch</groupId>
     <artifactId>opendistro_security</artifactId>
     <packaging>jar</packaging>
-    <version>1.3.0.0</version>
+    <version>1.4.0.0</version>
     <name>Open Distro Security for Elasticsearch</name>
     <description>Open Distro For Elasticsearch Security</description>
     <inceptionYear>2015</inceptionYear>
@@ -67,7 +67,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.release>8</maven.compiler.release>
 
-        <elasticsearch.version>7.3.2</elasticsearch.version>
+        <elasticsearch.version>7.4.2</elasticsearch.version>
 
         <!-- deps -->
         <netty-native.version>2.0.25.Final</netty-native.version>
@@ -97,7 +97,7 @@
         <url>https://github.com/opendistro-for-elasticsearch/security</url>
         <connection>scm:git:git@github.com:opendistro-for-elasticsearch/security.git</connection>
         <developerConnection>scm:git:git@github.com:opendistro-for-elasticsearch/security.git</developerConnection>
-        <tag>1.3.0.0</tag>
+        <tag>1.4.0.0</tag>
     </scm>
 
     <issueManagement>

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/action/configupdate/ConfigUpdateAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/action/configupdate/ConfigUpdateAction.java
@@ -30,21 +30,14 @@
 
 package com.amazon.opendistroforelasticsearch.security.action.configupdate;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class ConfigUpdateAction extends StreamableResponseActionType<ConfigUpdateResponse> {
+public class ConfigUpdateAction extends ActionType<ConfigUpdateResponse> {
 
     public static final ConfigUpdateAction INSTANCE = new ConfigUpdateAction();
     public static final String NAME = "cluster:admin/opendistro_security/config/update";
 
     protected ConfigUpdateAction() {
-        super(NAME);
+        super(NAME, ConfigUpdateResponse::new);
     }
-
-    @Override
-    public ConfigUpdateResponse newResponse() {
-        return new ConfigUpdateResponse();
-    }
-
-    
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/action/configupdate/ConfigUpdateNodeResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/action/configupdate/ConfigUpdateNodeResponse.java
@@ -43,7 +43,10 @@ public class ConfigUpdateNodeResponse extends BaseNodeResponse {
     private String[] updatedConfigTypes;
     private String message;
     
-    ConfigUpdateNodeResponse() {
+    public ConfigUpdateNodeResponse(StreamInput in) throws IOException {
+        super(in);
+        this.updatedConfigTypes = in.readStringArray();
+        this.message = in.readOptionalString();
     }
 
     public ConfigUpdateNodeResponse(final DiscoveryNode node, String[] updatedConfigTypes, String message) {
@@ -53,9 +56,7 @@ public class ConfigUpdateNodeResponse extends BaseNodeResponse {
     }
     
     public static ConfigUpdateNodeResponse readNodeResponse(StreamInput in) throws IOException {
-        ConfigUpdateNodeResponse nodeResponse = new ConfigUpdateNodeResponse();
-        nodeResponse.readFrom(in);
-        return nodeResponse;
+        return new ConfigUpdateNodeResponse(in);
     }
     
     public String[] getUpdatedConfigTypes() {
@@ -71,13 +72,6 @@ public class ConfigUpdateNodeResponse extends BaseNodeResponse {
         super.writeTo(out);
         out.writeStringArray(updatedConfigTypes);
         out.writeOptionalString(message);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        updatedConfigTypes = in.readStringArray();
-        message = in.readOptionalString();
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/action/configupdate/ConfigUpdateRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/action/configupdate/ConfigUpdateRequest.java
@@ -41,19 +41,18 @@ public class ConfigUpdateRequest extends BaseNodesRequest<ConfigUpdateRequest> {
 
     private String[] configTypes;
 
-    public ConfigUpdateRequest() {
-        super();
-    }
-
-    public ConfigUpdateRequest(final String[] configTypes) {
-        super();
-        this.configTypes = configTypes;
-    }
-
-    @Override
-    public void readFrom(final StreamInput in) throws IOException {
-        super.readFrom(in);
+    public ConfigUpdateRequest(StreamInput in) throws IOException {
+        super(in);
         this.configTypes = in.readStringArray();
+    }
+
+    public ConfigUpdateRequest() {
+        super(new String[0]);
+    }
+
+    public ConfigUpdateRequest(String[] configTypes) {
+    	this();
+    	setConfigTypes(configTypes);
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/action/configupdate/ConfigUpdateRequestBuilder.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/action/configupdate/ConfigUpdateRequestBuilder.java
@@ -30,22 +30,19 @@
 
 package com.amazon.opendistroforelasticsearch.security.action.configupdate;
 
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.nodes.NodesOperationRequestBuilder;
-import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.client.ElasticsearchClient;
 
 public class ConfigUpdateRequestBuilder extends
 NodesOperationRequestBuilder<ConfigUpdateRequest, ConfigUpdateResponse, ConfigUpdateRequestBuilder> {
-    public ConfigUpdateRequestBuilder(final ClusterAdminClient client) {
-        this(client, ConfigUpdateAction.INSTANCE);
-    }
 
-    public ConfigUpdateRequestBuilder(final ElasticsearchClient client, final ConfigUpdateAction action) {
+    protected ConfigUpdateRequestBuilder(ElasticsearchClient client, ActionType<ConfigUpdateResponse> action) {
         super(client, action, new ConfigUpdateRequest());
     }
 
     public ConfigUpdateRequestBuilder setShardId(final String[] configTypes) {
-        request().setConfigTypes(configTypes);
+        request.setConfigTypes(configTypes);
         return this;
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/action/configupdate/ConfigUpdateResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/action/configupdate/ConfigUpdateResponse.java
@@ -41,7 +41,8 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 public class ConfigUpdateResponse extends BaseNodesResponse<ConfigUpdateNodeResponse> {
 
-    public ConfigUpdateResponse() {
+    public ConfigUpdateResponse(StreamInput in) throws IOException {
+        super(in);
     }
     
     public ConfigUpdateResponse(final ClusterName clusterName, List<ConfigUpdateNodeResponse> nodes, List<FailedNodeException> failures) {
@@ -55,6 +56,6 @@ public class ConfigUpdateResponse extends BaseNodesResponse<ConfigUpdateNodeResp
 
     @Override
     public void writeNodesTo(final StreamOutput out, List<ConfigUpdateNodeResponse> nodes) throws IOException {
-        out.writeStreamableList(nodes);
+        out.writeList(nodes);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/action/configupdate/TransportConfigUpdateAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/action/configupdate/TransportConfigUpdateAction.java
@@ -32,6 +32,7 @@ package com.amazon.opendistroforelasticsearch.security.action.configupdate;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -82,18 +83,13 @@ TransportNodesAction<ConfigUpdateRequest, ConfigUpdateResponse, TransportConfigU
 
         ConfigUpdateRequest request;
 
-        public NodeConfigUpdateRequest() {
+        public NodeConfigUpdateRequest(StreamInput in) throws IOException{
+            super(in);
+            request = new ConfigUpdateRequest(in);
         }
 
         public NodeConfigUpdateRequest(final ConfigUpdateRequest request) {
             this.request = request;
-        }
-
-        @Override
-        public void readFrom(final StreamInput in) throws IOException {
-            super.readFrom(in);
-            request = new ConfigUpdateRequest();
-            request.readFrom(in);
         }
 
         @Override
@@ -104,13 +100,10 @@ TransportNodesAction<ConfigUpdateRequest, ConfigUpdateResponse, TransportConfigU
     }
 
     @Override
-    protected ConfigUpdateNodeResponse newNodeResponse() {
-        return new ConfigUpdateNodeResponse(clusterService.localNode(), new String[0], null);
+    protected ConfigUpdateNodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return new ConfigUpdateNodeResponse(in);
     }
     
-    
-    
-	
     @Override
     protected ConfigUpdateResponse newResponse(ConfigUpdateRequest request, List<ConfigUpdateNodeResponse> responses,
             List<FailedNodeException> failures) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/action/whoami/TransportWhoAmIAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/action/whoami/TransportWhoAmIAction.java
@@ -33,7 +33,6 @@ package com.amazon.opendistroforelasticsearch.security.action.whoami;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/action/whoami/WhoAmIAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/action/whoami/WhoAmIAction.java
@@ -30,20 +30,14 @@
 
 package com.amazon.opendistroforelasticsearch.security.action.whoami;
 
-import org.elasticsearch.action.StreamableResponseActionType;
+import org.elasticsearch.action.ActionType;
 
-public class WhoAmIAction extends StreamableResponseActionType<WhoAmIResponse> {
+public class WhoAmIAction extends ActionType<WhoAmIResponse> {
 
     public static final WhoAmIAction INSTANCE = new WhoAmIAction();
     public static final String NAME = "cluster:admin/opendistro_security/whoami";
 
     protected WhoAmIAction() {
-        super(NAME);
+        super(NAME, WhoAmIResponse::new);
     }
-
-    @Override
-    public WhoAmIResponse newResponse() {
-        return new WhoAmIResponse(null, false, false, false);
-    }
-
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/action/whoami/WhoAmIRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/action/whoami/WhoAmIRequest.java
@@ -38,17 +38,11 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 public class WhoAmIRequest extends BaseNodesRequest<WhoAmIRequest> {
 
-    public WhoAmIRequest() {
-        super();
+    public WhoAmIRequest(final StreamInput in) throws IOException {
+        super(in);
     }
 
-    @Override
-    public void readFrom(final StreamInput in) throws IOException {
-        super.readFrom(in);
-    }
-
-    @Override
-    public void writeTo(final StreamOutput out) throws IOException {
-        super.writeTo(out);
+    public WhoAmIRequest() throws IOException {
+        super(new String[0]);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/action/whoami/WhoAmIRequestBuilder.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/action/whoami/WhoAmIRequestBuilder.java
@@ -34,13 +34,15 @@ import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.client.ElasticsearchClient;
 
+import java.io.IOException;
+
 public class WhoAmIRequestBuilder extends
 ActionRequestBuilder<WhoAmIRequest, WhoAmIResponse> {    
-    public WhoAmIRequestBuilder(final ClusterAdminClient client) {
+    public WhoAmIRequestBuilder(final ClusterAdminClient client) throws IOException {
         this(client, WhoAmIAction.INSTANCE);
     }
 
-    public WhoAmIRequestBuilder(final ElasticsearchClient client, final WhoAmIAction action) {
+    public WhoAmIRequestBuilder(final ElasticsearchClient client, final WhoAmIAction action) throws IOException {
         super(client, action, new WhoAmIRequest());
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/action/whoami/WhoAmIResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/action/whoami/WhoAmIResponse.java
@@ -52,23 +52,30 @@ public class WhoAmIResponse extends ActionResponse implements ToXContent {
         this.isAuthenticated = isAuthenticated;
         this.isNodeCertificateRequest = isNodeCertificateRequest;
     }
-    
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeString(dn);
-        out.writeBoolean(isAdmin);
-        out.writeBoolean(isAuthenticated);
-        out.writeBoolean(isNodeCertificateRequest);
+
+
+    public WhoAmIResponse() {
+        super();
+        this.dn = null;
+        this.isAdmin = false;
+        this.isAuthenticated = false;
+        this.isNodeCertificateRequest = false;
     }
 
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
+    public WhoAmIResponse(StreamInput in) throws IOException {
+        super(in);
         dn = in.readString();
         isAdmin = in.readBoolean();
         isAuthenticated = in.readBoolean();
         isNodeCertificateRequest = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(dn);
+        out.writeBoolean(isAdmin);
+        out.writeBoolean(isAuthenticated);
+        out.writeBoolean(isNodeCertificateRequest);
     }
 
     public String getDn() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
@@ -84,7 +84,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 								final Client client, final AdminDNs adminDNs, final ConfigurationRepository cl,
 								final ClusterService cs, final PrincipalExtractor principalExtractor, final PrivilegesEvaluator evaluator,
 								ThreadPool threadPool, AuditLog auditLog) {
-		super(settings);
+		super();
 		this.settings = settings;
 		this.opendistroIndex = settings.get(ConfigConstants.OPENDISTRO_SECURITY_CONFIG_INDEX_NAME,
 				ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PermissionsInfoAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PermissionsInfoAction.java
@@ -57,7 +57,7 @@ public class PermissionsInfoAction extends BaseRestHandler {
 	protected PermissionsInfoAction(final Settings settings, final Path configPath, final RestController controller, final Client client,
 			final AdminDNs adminDNs, final ConfigurationRepository cl, final ClusterService cs,
 			final PrincipalExtractor principalExtractor, final PrivilegesEvaluator privilegesEvaluator, ThreadPool threadPool, AuditLog auditLog) {
-		super(settings);
+		super();
 		controller.registerHandler(Method.GET, "/_opendistro/_security/api/permissionsinfo", this);
 		this.threadPool = threadPool;
 		this.privilegesEvaluator = privilegesEvaluator;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/rest/KibanaInfoAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/rest/KibanaInfoAction.java
@@ -60,7 +60,7 @@ public class KibanaInfoAction extends BaseRestHandler {
     private final ThreadContext threadContext;
 
     public KibanaInfoAction(final Settings settings, final RestController controller, final PrivilegesEvaluator evaluator, final ThreadPool threadPool) {
-        super(settings);
+        super();
         this.threadContext = threadPool.getThreadContext();
         this.evaluator = evaluator;
         controller.registerHandler(GET, "/_opendistro/_security/kibanainfo", this);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/rest/OpenDistroSecurityHealthAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/rest/OpenDistroSecurityHealthAction.java
@@ -52,7 +52,7 @@ public class OpenDistroSecurityHealthAction extends BaseRestHandler {
     private final BackendRegistry registry;
     
     public OpenDistroSecurityHealthAction(final Settings settings, final RestController controller, final BackendRegistry registry) {
-        super(settings);
+        super();
         this.registry = registry;
         controller.registerHandler(GET, "/_opendistro/_security/health", this);
         controller.registerHandler(POST, "/_opendistro/_security/health", this);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/rest/OpenDistroSecurityInfoAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/rest/OpenDistroSecurityInfoAction.java
@@ -68,7 +68,7 @@ public class OpenDistroSecurityInfoAction extends BaseRestHandler {
     private final ThreadContext threadContext;
 
     public OpenDistroSecurityInfoAction(final Settings settings, final RestController controller, final PrivilegesEvaluator evaluator, final ThreadPool threadPool) {
-        super(settings);
+        super();
         this.threadContext = threadPool.getThreadContext();
         this.evaluator = evaluator;
         controller.registerHandler(GET, "/_opendistro/_security/authinfo", this);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/rest/TenantInfoAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/rest/TenantInfoAction.java
@@ -67,7 +67,7 @@ public class TenantInfoAction extends BaseRestHandler {
 
     public TenantInfoAction(final Settings settings, final RestController controller, 
     		final PrivilegesEvaluator evaluator, final ThreadPool threadPool, final ClusterService clusterService, final AdminDNs adminDns) {
-        super(settings);
+        super();
         this.threadContext = threadPool.getThreadContext();
         this.evaluator = evaluator;
         this.clusterService = clusterService;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/DefaultOpenDistroSecurityKeyStore.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/DefaultOpenDistroSecurityKeyStore.java
@@ -124,7 +124,7 @@ public class DefaultOpenDistroSecurityKeyStore implements OpenDistroSecurityKeyS
                 .getAsBoolean(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE, true);
 
         if(!OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable() && (settings.getAsBoolean(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_ENABLE_OPENSSL_IF_AVAILABLE, true) || settings.getAsBoolean(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE, true) )) {
-            String text = "Support for OpenSSL when Java 12 is present has been removed from Open Distro Security since Elasticsearch 7.4.0\n";
+            String text = "Support for OpenSSL with Java 12+ has been removed from Open Distro Security since Elasticsearch 7.4.0. Using JDK SSL instead.\n";
             System.out.println(text);
             log.warn(text);
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/DefaultOpenDistroSecurityKeyStore.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/DefaultOpenDistroSecurityKeyStore.java
@@ -54,7 +54,6 @@ import javax.net.ssl.SSLParameters;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.util.Constants;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.SpecialPermission;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/DefaultOpenDistroSecurityKeyStore.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/DefaultOpenDistroSecurityKeyStore.java
@@ -119,20 +119,13 @@ public class DefaultOpenDistroSecurityKeyStore implements OpenDistroSecurityKeyS
                 SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_ENABLED_DEFAULT);
         transportSSLEnabled = settings.getAsBoolean(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLED,
                 SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLED_DEFAULT);
-        final boolean useOpenSSLForHttpIfAvailable = settings
+        final boolean useOpenSSLForHttpIfAvailable = OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && settings
                 .getAsBoolean(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_ENABLE_OPENSSL_IF_AVAILABLE, true);
-        final boolean useOpenSSLForTransportIfAvailable = settings
+        final boolean useOpenSSLForTransportIfAvailable = OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && settings
                 .getAsBoolean(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE, true);
 
-
         if(!OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable() && (settings.getAsBoolean(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_ENABLE_OPENSSL_IF_AVAILABLE, true) || settings.getAsBoolean(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE, true) )) {
-
-            String text = "Support for OpenSSL has been removed from Open Distro Security since Elasticsearch 7.4.0\n";
-            if(Constants.JRE_IS_MINIMUM_JAVA11) {
-                text += "Since you are running Java "+Constants.JAVA_VERSION+" you should not experience any performance impact but maybe not all your ciphers are supported. If you experience problems upgrade to Java 12+";
-            } else {
-                text += "You are running a very old version of Java ("+Constants.JAVA_VERSION+") so you may experience a performance impact and it is strongly advised to update to Java 12+";
-            }
+            String text = "Support for OpenSSL when Java 12 is present has been removed from Open Distro Security since Elasticsearch 7.4.0\n";
             System.out.println(text);
             log.warn(text);
         }
@@ -574,7 +567,7 @@ public class DefaultOpenDistroSecurityKeyStore implements OpenDistroSecurityKeyS
     }
 
     private void logOpenSSLInfos() {
-        if (OpenSsl.isAvailable()) {
+        if (OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable()) {
             log.info("OpenSSL " + OpenSsl.versionString() + " (" + OpenSsl.version() + ") available");
 
             if (OpenSsl.version() < 0x10002000L) {
@@ -630,7 +623,7 @@ public class DefaultOpenDistroSecurityKeyStore implements OpenDistroSecurityKeyS
         final List<String> secureHttpSSLProtocols = Arrays.asList(SSLConfigConstants.getSecureSSLProtocols(settings, true));
         final List<String> secureTransportSSLProtocols = Arrays.asList(SSLConfigConstants.getSecureSSLProtocols(settings, false));
 
-        if (OpenSsl.isAvailable()) {
+        if (OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable()) {
             final Set<String> openSSLSecureHttpCiphers = new HashSet<>();
             for (final String secure : secureHttpSSLCiphers) {
                 if (OpenSsl.isCipherSuiteAvailable(secure)) {
@@ -648,7 +641,7 @@ public class DefaultOpenDistroSecurityKeyStore implements OpenDistroSecurityKeyS
             enabledHttpCiphersOpenSSLProvider = Collections.emptyList();
         }
 
-        if (OpenSsl.isAvailable()) {
+        if (OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable()) {
             final Set<String> openSSLSecureTransportCiphers = new HashSet<>();
             for (final String secure : secureTransportSSLCiphers) {
                 if (OpenSsl.isCipherSuiteAvailable(secure)) {
@@ -662,7 +655,7 @@ public class DefaultOpenDistroSecurityKeyStore implements OpenDistroSecurityKeyS
             enabledTransportCiphersOpenSSLProvider = Collections.emptyList();
         }
         
-        if(OpenSsl.isAvailable() && OpenSsl.version() > 0x10101009L) {
+        if(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable() && OpenSsl.version() > 0x10101009L) {
             enabledHttpProtocolsOpenSSLProvider = new ArrayList(Arrays.asList("TLSv1.3","TLSv1.2","TLSv1.1","TLSv1"));
             enabledHttpProtocolsOpenSSLProvider.retainAll(secureHttpSSLProtocols);
             enabledTransportProtocolsOpenSSLProvider = new ArrayList(Arrays.asList("TLSv1.3","TLSv1.2","TLSv1.1"));
@@ -670,7 +663,7 @@ public class DefaultOpenDistroSecurityKeyStore implements OpenDistroSecurityKeyS
             
             log.info("OpenSSL supports TLSv1.3");
             
-        } else if(OpenSsl.isAvailable()){
+        } else if(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable()){
             enabledHttpProtocolsOpenSSLProvider = new ArrayList(Arrays.asList("TLSv1.2","TLSv1.1","TLSv1"));
             enabledHttpProtocolsOpenSSLProvider.retainAll(secureHttpSSLProtocols);
             enabledTransportProtocolsOpenSSLProvider = new ArrayList(Arrays.asList("TLSv1.2","TLSv1.1"));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/DefaultOpenDistroSecurityKeyStore.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/DefaultOpenDistroSecurityKeyStore.java
@@ -54,6 +54,7 @@ import javax.net.ssl.SSLParameters;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.SpecialPermission;
@@ -122,6 +123,19 @@ public class DefaultOpenDistroSecurityKeyStore implements OpenDistroSecurityKeyS
                 .getAsBoolean(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_ENABLE_OPENSSL_IF_AVAILABLE, true);
         final boolean useOpenSSLForTransportIfAvailable = settings
                 .getAsBoolean(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE, true);
+
+
+        if(!OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable() && (settings.getAsBoolean(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_ENABLE_OPENSSL_IF_AVAILABLE, true) || settings.getAsBoolean(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE, true) )) {
+
+            String text = "Support for OpenSSL has been removed from Open Distro Security since Elasticsearch 7.4.0\n";
+            if(Constants.JRE_IS_MINIMUM_JAVA11) {
+                text += "Since you are running Java "+Constants.JAVA_VERSION+" you should not experience any performance impact but maybe not all your ciphers are supported. If you experience problems upgrade to Java 12+";
+            } else {
+                text += "You are running a very old version of Java ("+Constants.JAVA_VERSION+") so you may experience a performance impact and it is strongly advised to update to Java 12+";
+            }
+            System.out.println(text);
+            log.warn(text);
+        }
 
         boolean openSSLInfoLogged = false;
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/OpenDistroSecuritySSLPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/OpenDistroSecuritySSLPlugin.java
@@ -82,6 +82,7 @@ import com.amazon.opendistroforelasticsearch.security.ssl.util.SSLConfigConstant
 //For ES5 this class has only effect when SSL only plugin is installed
 public class OpenDistroSecuritySSLPlugin extends Plugin implements ActionPlugin, NetworkPlugin {
 
+    public static final boolean OPENSSL_SUPPORTED = false;
     protected final Logger log = LogManager.getLogger(this.getClass());
     protected static final String CLIENT_TYPE = "client.type";
     protected final boolean client;
@@ -305,9 +306,9 @@ public class OpenDistroSecuritySSLPlugin extends Plugin implements ActionPlugin,
         settings.add(Setting.simpleString(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH, Property.NodeScope, Property.Filtered));
         settings.add(Setting.simpleString(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD, Property.NodeScope, Property.Filtered));
         settings.add(Setting.simpleString(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_TRUSTSTORE_TYPE, Property.NodeScope, Property.Filtered));
-        settings.add(Setting.boolSetting(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_ENABLE_OPENSSL_IF_AVAILABLE, true, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.boolSetting(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_ENABLE_OPENSSL_IF_AVAILABLE, false, Property.NodeScope, Property.Filtered));
         settings.add(Setting.boolSetting(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_ENABLED, SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_ENABLED_DEFAULT, Property.NodeScope, Property.Filtered));
-        settings.add(Setting.boolSetting(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE, true,Property.NodeScope, Property.Filtered));
+        settings.add(Setting.boolSetting(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE, false,Property.NodeScope, Property.Filtered));
         settings.add(Setting.boolSetting(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLED, SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLED_DEFAULT, Property.NodeScope, Property.Filtered));
         settings.add(Setting.boolSetting(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENFORCE_HOSTNAME_VERIFICATION, true, Property.NodeScope, Property.Filtered));
         settings.add(Setting.boolSetting(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENFORCE_HOSTNAME_VERIFICATION_RESOLVE_HOST_NAME, true, Property.NodeScope, Property.Filtered));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/OpenDistroSecuritySSLPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/OpenDistroSecuritySSLPlugin.java
@@ -82,7 +82,7 @@ import com.amazon.opendistroforelasticsearch.security.ssl.util.SSLConfigConstant
 //For ES5 this class has only effect when SSL only plugin is installed
 public class OpenDistroSecuritySSLPlugin extends Plugin implements ActionPlugin, NetworkPlugin {
 
-    public static final boolean OPENSSL_SUPPORTED = false;
+    public static final boolean OPENSSL_SUPPORTED = PlatformDependent.javaVersion() < 12;
     protected final Logger log = LogManager.getLogger(this.getClass());
     protected static final String CLIENT_TYPE = "client.type";
     protected final boolean client;
@@ -306,9 +306,9 @@ public class OpenDistroSecuritySSLPlugin extends Plugin implements ActionPlugin,
         settings.add(Setting.simpleString(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH, Property.NodeScope, Property.Filtered));
         settings.add(Setting.simpleString(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD, Property.NodeScope, Property.Filtered));
         settings.add(Setting.simpleString(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_TRUSTSTORE_TYPE, Property.NodeScope, Property.Filtered));
-        settings.add(Setting.boolSetting(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_ENABLE_OPENSSL_IF_AVAILABLE, false, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.boolSetting(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_ENABLE_OPENSSL_IF_AVAILABLE, OPENSSL_SUPPORTED, Property.NodeScope, Property.Filtered));
         settings.add(Setting.boolSetting(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_ENABLED, SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_ENABLED_DEFAULT, Property.NodeScope, Property.Filtered));
-        settings.add(Setting.boolSetting(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE, false,Property.NodeScope, Property.Filtered));
+        settings.add(Setting.boolSetting(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE, OPENSSL_SUPPORTED,Property.NodeScope, Property.Filtered));
         settings.add(Setting.boolSetting(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLED, SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLED_DEFAULT, Property.NodeScope, Property.Filtered));
         settings.add(Setting.boolSetting(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENFORCE_HOSTNAME_VERIFICATION, true, Property.NodeScope, Property.Filtered));
         settings.add(Setting.boolSetting(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENFORCE_HOSTNAME_VERIFICATION_RESOLVE_HOST_NAME, true, Property.NodeScope, Property.Filtered));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/http/netty/ValidatingDispatcher.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/http/netty/ValidatingDispatcher.java
@@ -64,9 +64,9 @@ public class ValidatingDispatcher implements Dispatcher {
     }
 
     @Override
-    public void dispatchBadRequest(RestRequest request, RestChannel channel, ThreadContext threadContext, Throwable cause) {
-        checkRequest(request, channel);
-        originalDispatcher.dispatchBadRequest(request, channel, threadContext, cause);
+    public void dispatchBadRequest(RestChannel channel, ThreadContext threadContext, Throwable cause) {
+        checkRequest(channel.request(), channel);
+        originalDispatcher.dispatchBadRequest(channel, threadContext, cause);
     }
     
     protected void checkRequest(final RestRequest request, final RestChannel channel) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/rest/OpenDistroSecuritySSLInfoAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/rest/OpenDistroSecuritySSLInfoAction.java
@@ -53,7 +53,7 @@ public class OpenDistroSecuritySSLInfoAction extends BaseRestHandler {
 
     public OpenDistroSecuritySSLInfoAction(final Settings settings, final Path configPath, final RestController controller,
             final OpenDistroSecurityKeyStore odsks, final PrincipalExtractor principalExtractor) {
-        super(settings);
+        super();
         this.settings = settings;
         this.odsks = odsks;
         this.principalExtractor = principalExtractor;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/tools/OpenDistroSecurityAdmin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/tools/OpenDistroSecurityAdmin.java
@@ -448,7 +448,6 @@ public class OpenDistroSecurityAdmin {
                 .put(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENFORCE_HOSTNAME_VERIFICATION, !nhnv)
                 .put(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENFORCE_HOSTNAME_VERIFICATION_RESOLVE_HOST_NAME, !nrhn)
                 .put(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLED, true)
-                .put(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE, useOpenSSLIfAvailable)
                 .put(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE, OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && useOpenSSLIfAvailable)
                 .putList(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLED_CIPHERS, enabledCiphers)
                 .putList(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, enabledProtocols)

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/tools/OpenDistroSecurityAdmin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/tools/OpenDistroSecurityAdmin.java
@@ -123,6 +123,7 @@ import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.Inter
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.RoleMappingsV7;
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.RoleV7;
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.TenantV7;
+import com.amazon.opendistroforelasticsearch.security.ssl.OpenDistroSecuritySSLPlugin;
 import com.amazon.opendistroforelasticsearch.security.ssl.util.ExceptionUtils;
 import com.amazon.opendistroforelasticsearch.security.ssl.util.SSLConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
@@ -448,6 +449,7 @@ public class OpenDistroSecurityAdmin {
                 .put(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENFORCE_HOSTNAME_VERIFICATION_RESOLVE_HOST_NAME, !nrhn)
                 .put(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLED, true)
                 .put(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE, useOpenSSLIfAvailable)
+                .put(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE, OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && useOpenSSLIfAvailable)
                 .putList(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLED_CIPHERS, enabledCiphers)
                 .putList(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, enabledProtocols)
                 

--- a/src/main/resources/static_config/static_roles.yml
+++ b/src/main/resources/static_config/static_roles.yml
@@ -27,7 +27,6 @@ kibana_user:
   static: true
   description: "Provide the minimum permissions for a kibana user"
   cluster_permissions:
-    - "indices_monitor"
     - "cluster_composite_ops"
   index_permissions:
     - index_patterns:

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
@@ -402,7 +402,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		addUserWithPassword("$1aAAAAAAAAC", "$1aAAAAAAAAC", HttpStatus.SC_BAD_REQUEST);
 		addUserWithPassword("$1aAAAAAAAac", "$1aAAAAAAAAC", HttpStatus.SC_BAD_REQUEST);
 		addUserWithPassword(URLEncoder.encode("$1aAAAAAAAac%", "UTF-8"), "$1aAAAAAAAAC%", HttpStatus.SC_BAD_REQUEST);
-		addUserWithPassword(URLEncoder.encode("$1aAAAAAAAac%!=\"/\\;: test&~@^", "UTF-8"), "$1aAAAAAAAac%!=\\\"/\\\\;: test&~@^", HttpStatus.SC_BAD_REQUEST);
+		addUserWithPassword(URLEncoder.encode("$1aAAAAAAAac%!=\"/\\;:test&~@^", "UTF-8").replace("+", "%2B"), "$1aAAAAAAAac%!=\\\"/\\\\;:test&~@^", HttpStatus.SC_BAD_REQUEST);
 		addUserWithPassword(URLEncoder.encode("$1aAAAAAAAac%!=\"/\\;: test&", "UTF-8"), "$1aAAAAAAAac%!=\\\"/\\\\;: test&123", HttpStatus.SC_CREATED);
 
 		response = rh.executeGetRequest("/_opendistro/_security/api/internalusers/nothinghthere?pretty", new Header[0]);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/OpenSSLTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/OpenSSLTest.java
@@ -66,69 +66,69 @@ public class OpenSSLTest extends SSLTest {
     @Override
     @Test
     public void testHttps() throws Exception {
-        Assume.assumeTrue(OpenSsl.isAvailable());
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
         super.testHttps();
     }
 
     @Override
     @Test
     public void testHttpsAndNodeSSL() throws Exception {
-        Assume.assumeTrue(OpenSsl.isAvailable());
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
         super.testHttpsAndNodeSSL();
     }
 
     @Override
     @Test
     public void testHttpPlainFail() throws Exception {
-        Assume.assumeTrue(OpenSsl.isAvailable());
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
         super.testHttpPlainFail();
     }
 
     @Override
     @Test
     public void testHttpsNoEnforce() throws Exception {
-        Assume.assumeTrue(OpenSsl.isAvailable());
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
         super.testHttpsNoEnforce();
     }
 
     @Override
     @Test
     public void testHttpsV3Fail() throws Exception {
-        Assume.assumeTrue(OpenSsl.isAvailable());
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
         super.testHttpsV3Fail();
     }
 
     @Override
     @Test(timeout=40000)
     public void testTransportClientSSL() throws Exception {
-        Assume.assumeTrue(OpenSsl.isAvailable());
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
         super.testTransportClientSSL();
     }
 
     @Override
     @Test(timeout=40000)
     public void testNodeClientSSL() throws Exception {
-        Assume.assumeTrue(OpenSsl.isAvailable());
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
         super.testNodeClientSSL();
     }
 
     @Override
     @Test(timeout=40000)
     public void testTransportClientSSLFail() throws Exception {
-        Assume.assumeTrue(OpenSsl.isAvailable());
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
         super.testTransportClientSSLFail();
     }
     
     @Override
     @Test
     public void testHttpsOptionalAuth() throws Exception {
-        Assume.assumeTrue(OpenSsl.isAvailable());
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
         super.testHttpsOptionalAuth();
     }
     
     @Test
     public void testAvailCiphersOpenSSL() throws Exception {
-        Assume.assumeTrue(OpenSsl.isAvailable());
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
 
         // Set<String> openSSLAvailCiphers = new
         // HashSet<>(OpenSsl.availableCipherSuites());
@@ -149,38 +149,38 @@ public class OpenSSLTest extends SSLTest {
     
     @Test
     public void testHttpsEnforceFail() throws Exception {
-        Assume.assumeTrue(OpenSsl.isAvailable());
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
         super.testHttpsEnforceFail();
     }
 
     @Override
     public void testCipherAndProtocols() throws Exception {
-        Assume.assumeTrue(OpenSsl.isAvailable());
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
         super.testCipherAndProtocols();
     }
 
     @Override
     public void testHttpsAndNodeSSLFailedCipher() throws Exception {
-        Assume.assumeTrue(OpenSsl.isAvailable());
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
         super.testHttpsAndNodeSSLFailedCipher();
     }
     
     @Test
     public void testHttpsAndNodeSSLPem() throws Exception {
-        Assume.assumeTrue(OpenSsl.isAvailable());
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
         super.testHttpsAndNodeSSLPem();
     }
     
     @Test
     public void testHttpsAndNodeSSLPemEnc() throws Exception {
-        Assume.assumeTrue(OpenSsl.isAvailable());
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
         super.testHttpsAndNodeSSLPemEnc();
     }
     
     @Test
     public void testNodeClientSSLwithOpenSslTLSv13() throws Exception {
         
-        Assume.assumeTrue(OpenSsl.isAvailable() && OpenSsl.version() > 0x10101009L);
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable() && OpenSsl.version() > 0x10101009L);
 
         final Settings settings = Settings.builder().put("opendistro_security.ssl.transport.enabled", true)
                 .put(ConfigConstants.OPENDISTRO_SECURITY_SSL_ONLY, true)
@@ -225,7 +225,7 @@ public class OpenSSLTest extends SSLTest {
 
     @Test
     public void testTLSv1() throws Exception {
-        Assume.assumeTrue(OpenSsl.isAvailable());
+        Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
         super.testTLSv1();
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/OpenSSLTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/OpenSSLTest.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 
+import io.netty.util.internal.PlatformDependent;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
@@ -227,5 +228,13 @@ public class OpenSSLTest extends SSLTest {
     public void testTLSv1() throws Exception {
         Assume.assumeTrue(OpenDistroSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
         super.testTLSv1();
+    }
+
+    @Test
+    public void testJava12WithOpenSslEnabled() throws Exception {
+        // If the user has Java 12 and have OpenSSL enabled, we give
+        // a Twarning, ignore OpenSSL and use JDK SSl instead.
+        Assume.assumeTrue(PlatformDependent.javaVersion() >= 12);
+        super.testHttps();
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/OpenSSLTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/OpenSSLTest.java
@@ -232,8 +232,8 @@ public class OpenSSLTest extends SSLTest {
 
     @Test
     public void testJava12WithOpenSslEnabled() throws Exception {
-        // If the user has Java 12 and have OpenSSL enabled, we give
-        // a Twarning, ignore OpenSSL and use JDK SSl instead.
+        // If the user has Java 12 running and OpenSSL enabled, we give
+        // a warning, ignore OpenSSL and use JDK SSl instead.
         Assume.assumeTrue(PlatformDependent.javaVersion() >= 12);
         super.testHttps();
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/plugin/UserInjectorPlugin.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/plugin/UserInjectorPlugin.java
@@ -104,12 +104,10 @@ public class UserInjectorPlugin extends Plugin implements NetworkPlugin {
         }
 
         @Override
-        public void dispatchBadRequest(RestRequest request, RestChannel channel, ThreadContext threadContext,
-                Throwable cause) {
-            threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, request.header(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER));
-            originalDispatcher.dispatchBadRequest(request, channel, threadContext, cause);
-            
+        public void dispatchBadRequest(RestChannel channel, ThreadContext threadContext, Throwable cause) {
+            threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, channel.request().header(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER));
+            originalDispatcher.dispatchBadRequest(channel, threadContext, cause);
         }
     }
-    
+
 }


### PR DESCRIPTION
Changes:

1. Minor changes to reflect ES API changes.
2. Removing support of OpenSSL for Java 12+

This means: 
1. For java versions before 12, the behavior stays the same.
2. For java 12+, we use JDK SSL, and if the user enables OpenSSL with Java 12+, we give a message saying that we don't support OpenSsl with Java12+ and continue to use JDK SSL

Tested with Java 1.8, 11 & 12
