### PR TITLE
Add Account API to enable users to change their own password

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
@@ -96,7 +96,15 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 		this.restApiPrivilegesEvaluator = new RestApiPrivilegesEvaluator(settings, adminDNs, evaluator,
 				principalExtractor, configPath, threadPool);
 		this.auditLog = auditLog;
+		this.registerHandlers(controller, settings);
 	}
+
+	/**
+	 * Abstract function to register handlers for API actions
+	 * @param controller rest controller
+	 * @param settings settings configuration
+	 */
+	protected abstract void registerHandlers(RestController controller, Settings settings);
 
 	protected abstract AbstractConfigurationValidator getValidator(RestRequest request, BytesReference ref, Object... params);
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.dlic.rest.api;
+
+import com.amazon.opendistroforelasticsearch.security.DefaultObjectMapper;
+import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog;
+import com.amazon.opendistroforelasticsearch.security.configuration.AdminDNs;
+import com.amazon.opendistroforelasticsearch.security.configuration.ConfigurationRepository;
+import com.amazon.opendistroforelasticsearch.security.dlic.rest.validation.AbstractConfigurationValidator;
+import com.amazon.opendistroforelasticsearch.security.dlic.rest.validation.AccountValidator;
+import com.amazon.opendistroforelasticsearch.security.privileges.PrivilegesEvaluator;
+import com.amazon.opendistroforelasticsearch.security.securityconf.Hashed;
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.CType;
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.SecurityDynamicConfiguration;
+import com.amazon.opendistroforelasticsearch.security.ssl.transport.PrincipalExtractor;
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import com.amazon.opendistroforelasticsearch.security.support.SecurityJsonNode;
+import com.amazon.opendistroforelasticsearch.security.user.User;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Set;
+
+import static com.amazon.opendistroforelasticsearch.security.dlic.rest.support.Utils.hash;
+
+/**
+ * Rest API action to fetch or update account details of the signed-in user.
+ * Currently this action serves GET and PUT request for /_opendistro/_security/api/account endpoint
+ */
+public class AccountApiAction extends AbstractApiAction {
+
+    private static final String RESOURCE_NAME = "account";
+    private final PrivilegesEvaluator privilegesEvaluator;
+    private final ThreadContext threadContext;
+
+    public AccountApiAction(Settings settings,
+                            Path configPath,
+                            RestController controller,
+                            Client client,
+                            AdminDNs adminDNs,
+                            ConfigurationRepository cl,
+                            ClusterService cs,
+                            PrincipalExtractor principalExtractor,
+                            PrivilegesEvaluator privilegesEvaluator,
+                            ThreadPool threadPool,
+                            AuditLog auditLog) {
+        super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, privilegesEvaluator, threadPool, auditLog);
+        this.privilegesEvaluator = privilegesEvaluator;
+        this.threadContext = threadPool.getThreadContext();
+    }
+
+    @Override
+    protected void registerHandlers(RestController controller, Settings settings) {
+        controller.registerHandler(RestRequest.Method.GET, "/_opendistro/_security/api/account", this);
+        controller.registerHandler(RestRequest.Method.PUT, "/_opendistro/_security/api/account", this);
+    }
+
+    /**
+     * GET request to fetch account details
+     *
+     * Sample request:
+     * GET _opendistro/_security/api/account
+     *
+     * Sample response:
+     * {
+     *   "user_name" : "test",
+     *   "is_reserved" : false,
+     *   "is_hidden" : false,
+     *   "is_internal_user" : true,
+     *   "user_requested_tenant" : "__user__",
+     *   "backend_roles" : [ ],
+     *   "custom_attribute_names" : [ ],
+     *   "tenants" : {
+     *     "test" : true
+     *   },
+     *   "roles" : [
+     *     "own_index"
+     *   ]
+     * }
+     *
+     * @param channel channel to return response
+     * @param request request to be served
+     * @param client client
+     * @param content content body
+     * @throws IOException
+     */
+    @Override
+    protected void handleGet(RestChannel channel, RestRequest request, Client client, final JsonNode content) throws IOException {
+        final XContentBuilder builder = channel.newBuilder();
+        BytesRestResponse response;
+
+        try {
+            builder.startObject();
+            final User user = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
+            if (user != null) {
+                final TransportAddress remoteAddress = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS);
+                final Set<String> securityRoles = privilegesEvaluator.mapRoles(user, remoteAddress);
+                final SecurityDynamicConfiguration<?> configuration = load(getConfigName(), false);
+
+                builder.field("user_name", user.getName())
+                        .field("is_reserved", isReserved(configuration, user.getName()))
+                        .field("is_hidden", isHidden(configuration, user.getName()))
+                        .field("is_internal_user", configuration.exists(user.getName()))
+                        .field("user_requested_tenant", user.getRequestedTenant())
+                        .field("backend_roles", user.getRoles())
+                        .field("custom_attribute_names", user.getCustomAttributesMap().keySet())
+                        .field("tenants", privilegesEvaluator.mapTenants(user, securityRoles))
+                        .field("roles", securityRoles);
+            }
+            builder.endObject();
+
+            response = new BytesRestResponse(RestStatus.OK, builder);
+        } catch (final Exception exception) {
+            log.error(exception.toString(), exception);
+
+            builder.startObject()
+                    .field("error", exception.toString())
+                    .endObject();
+
+            response = new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, builder);
+        }
+        channel.sendResponse(response);
+    }
+
+    /**
+     * PUT request to update account password.
+     *
+     * Sample request:
+     * PUT _opendistro/_security/api/account
+     * {
+     *     "current_password": "old-pass",
+     *     "password": "new-pass"
+     * }
+     *
+     * Sample response:
+     * {
+     *     "status":"OK",
+     *     "message":"'test' updated."
+     * }
+     *
+     * @param channel channel to return response
+     * @param request request to be served
+     * @param client client
+     * @param content content body
+     * @throws IOException
+     */
+    @Override
+    protected void handlePut(RestChannel channel, final RestRequest request, final Client client, final JsonNode content) throws IOException {
+        final User user = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
+        final String username = user.getName();
+        final SecurityDynamicConfiguration<?> internalUser = load(CType.INTERNALUSERS, false);
+
+        if (!internalUser.exists(username)) {
+            notFound(channel, "Could not find user.");
+            return;
+        }
+
+        if (isHidden(internalUser, username)) {
+            forbidden(channel, "Resource '" + username + "' is not available.");
+            return;
+        }
+
+        if (isReserved(internalUser, username)) {
+            forbidden(channel, "Resource '" + username + "' is read-only.");
+            return;
+        }
+
+        final SecurityJsonNode securityJsonNode = new SecurityJsonNode(content);
+        final String currentPassword = content.get("current_password").asText();
+        final String hash = ((Hashed) internalUser.getCEntry(username)).getHash();
+
+        if (hash == null || !OpenBSDBCrypt.checkPassword(hash, currentPassword.toCharArray())) {
+            badRequestResponse(channel, "Could not validate your current password.");
+            return;
+        }
+
+        ObjectNode contentAsNode = (ObjectNode) content;
+        contentAsNode.remove("current_password");
+
+        // if password is set, it takes precedence over hash
+        final String plainTextPassword = securityJsonNode.get("password").asString();
+        final String origHash = securityJsonNode.get("hash").asString();
+        if (plainTextPassword != null && plainTextPassword.length() > 0) {
+            contentAsNode.remove("password");
+            contentAsNode.put("hash", hash(plainTextPassword.toCharArray()));
+        } else if (origHash != null && origHash.length() > 0) {
+            contentAsNode.remove("password");
+        } else if (plainTextPassword != null && plainTextPassword.isEmpty() && origHash == null) {
+            contentAsNode.remove("password");
+        }
+
+        internalUser.remove(username);
+
+        // checks complete, update the user
+        internalUser.putCObject(username, DefaultObjectMapper.readTree(contentAsNode, internalUser.getImplementingClass()));
+
+        saveAnUpdateConfigs(client, request, CType.INTERNALUSERS, internalUser, new OnSucessActionListener<IndexResponse>(channel) {
+            @Override
+            public void onResponse(IndexResponse response) {
+                successResponse(channel, "'" + username + "' updated.");
+            }
+        });
+    }
+
+    @Override
+    protected AbstractConfigurationValidator getValidator(RestRequest request, BytesReference ref, Object... params) {
+        final User user = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
+        return new AccountValidator(request, ref, this.settings, user.getName());
+    }
+
+    @Override
+    protected String getResourceName() {
+        return RESOURCE_NAME;
+    }
+
+    @Override
+    protected Endpoint getEndpoint() {
+        return Endpoint.ACCOUNT;
+    }
+
+    @Override
+    protected void filter(SecurityDynamicConfiguration<?> builder) {
+        super.filter(builder);
+        // replace password hashes in addition. We must not remove them from the
+        // Builder since this would remove users completely if they
+        // do not have any addition properties like roles or attributes
+        builder.clearHashes();
+    }
+
+    @Override
+    protected CType getConfigName() {
+        return CType.INTERNALUSERS;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/ActionGroupsApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/ActionGroupsApiAction.java
@@ -48,7 +48,10 @@ public class ActionGroupsApiAction extends PatchableResourceApiAction {
 								 final AdminDNs adminDNs, final ConfigurationRepository cl, final ClusterService cs,
 								 final PrincipalExtractor principalExtractor, final PrivilegesEvaluator evaluator, ThreadPool threadPool, AuditLog auditLog) {
 		super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
+	}
 
+	@Override
+	protected void registerHandlers(RestController controller, Settings settings) {
 		// legacy mapping for backwards compatibility
 		// TODO: remove in next version
 		controller.registerHandler(Method.GET, "/_opendistro/_security/api/actiongroup/{name}", this);
@@ -63,7 +66,6 @@ public class ActionGroupsApiAction extends PatchableResourceApiAction {
 		controller.registerHandler(Method.PUT, "/_opendistro/_security/api/actiongroups/{name}", this);
 		controller.registerHandler(Method.PATCH, "/_opendistro/_security/api/actiongroups/", this);
 		controller.registerHandler(Method.PATCH, "/_opendistro/_security/api/actiongroups/{name}", this);
-
 	}
 
 	@Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AuthTokenProcessorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AuthTokenProcessorAction.java
@@ -50,7 +50,10 @@ public class AuthTokenProcessorAction extends AbstractApiAction {
 			ThreadPool threadPool, AuditLog auditLog) {
 		super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool,
 				auditLog);
+	}
 
+	@Override
+	protected void registerHandlers(RestController controller, Settings settings) {
 		controller.registerHandler(Method.POST, "/_opendistro/_security/api/authtoken", this);
 	}
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/Endpoint.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/Endpoint.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.security.dlic.rest.api;
 
 public enum Endpoint {
+	ACCOUNT,
 	ACTIONGROUPS,
 	CACHE,
 	CONFIG,

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -51,6 +51,10 @@ public class FlushCacheApiAction extends AbstractApiAction {
 			final AdminDNs adminDNs, final ConfigurationRepository cl, final ClusterService cs,
             final PrincipalExtractor principalExtractor, final PrivilegesEvaluator evaluator, ThreadPool threadPool, AuditLog auditLog) {
 		super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
+	}
+
+	@Override
+	protected void registerHandlers(RestController controller, Settings settings) {
 		controller.registerHandler(Method.DELETE, "/_opendistro/_security/api/cache", this);
 		controller.registerHandler(Method.GET, "/_opendistro/_security/api/cache", this);
 		controller.registerHandler(Method.PUT, "/_opendistro/_security/api/cache", this);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/OpenDistroSecurityConfigAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/OpenDistroSecurityConfigAction.java
@@ -51,25 +51,26 @@ public class OpenDistroSecurityConfigAction extends PatchableResourceApiAction {
     public OpenDistroSecurityConfigAction(final Settings settings, final Path configPath, final RestController controller, final Client client,
                           final AdminDNs adminDNs, final ConfigurationRepository cl, final ClusterService cs,
                           final PrincipalExtractor principalExtractor, final PrivilegesEvaluator evaluator, ThreadPool threadPool, AuditLog auditLog) {
-        super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
 
+        super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
         allowPutOrPatch = settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, false);
 
+    }
 
+    @Override
+    protected void registerHandlers(RestController controller, Settings settings) {
         controller.registerHandler(Method.GET, "/_opendistro/_security/api/securityconfig/", this);
 
         //controller.registerHandler(Method.GET, "/_opendistro/_security/api/config/", this);
 
-        if(allowPutOrPatch) {
+        boolean enablePutOrPatch = settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, false);
+        if (enablePutOrPatch) {
 
             //deprecated, will be removed with ODFE 8, use opendistro_security_config instead of config
             controller.registerHandler(Method.PUT, "/_opendistro/_security/api/securityconfig/{name}", this);
             controller.registerHandler(Method.PATCH, "/_opendistro/_security/api/securityconfig/", this);
-
-
         }
     }
-
 
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/OpenDistroSecurityRestApiActions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/OpenDistroSecurityRestApiActions.java
@@ -36,19 +36,20 @@ import com.amazon.opendistroforelasticsearch.security.ssl.transport.PrincipalExt
 
 public class OpenDistroSecurityRestApiActions {
 
-	public static Collection<RestHandler> getHandler(Settings settings, Path configPath, RestController controller, Client client,
-	        AdminDNs adminDns, ConfigurationRepository cr, ClusterService cs, PrincipalExtractor principalExtractor, 
-	        final PrivilegesEvaluator evaluator, ThreadPool threadPool, AuditLog auditLog) {
-	    final List<RestHandler> handlers = new ArrayList<RestHandler>(9);
-	    handlers.add(new InternalUsersApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
-	    handlers.add(new RolesMappingApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
-	    handlers.add(new RolesApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
-	    handlers.add(new ActionGroupsApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
-	    handlers.add(new FlushCacheApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
-	    handlers.add(new OpenDistroSecurityConfigAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
-	    handlers.add(new PermissionsInfoAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
-	    handlers.add(new AuthTokenProcessorAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
-	    handlers.add(new TenantsApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
-	    return Collections.unmodifiableCollection(handlers);
-	}
+    public static Collection<RestHandler> getHandler(Settings settings, Path configPath, RestController controller, Client client,
+                                                     AdminDNs adminDns, ConfigurationRepository cr, ClusterService cs, PrincipalExtractor principalExtractor,
+                                                     final PrivilegesEvaluator evaluator, ThreadPool threadPool, AuditLog auditLog) {
+        final List<RestHandler> handlers = new ArrayList<RestHandler>(9);
+        handlers.add(new InternalUsersApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
+        handlers.add(new RolesMappingApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
+        handlers.add(new RolesApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
+        handlers.add(new ActionGroupsApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
+        handlers.add(new FlushCacheApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
+        handlers.add(new OpenDistroSecurityConfigAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
+        handlers.add(new PermissionsInfoAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
+        handlers.add(new AuthTokenProcessorAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
+        handlers.add(new TenantsApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
+        handlers.add(new AccountApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
+        return Collections.unmodifiableCollection(handlers);
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RestApiPrivilegesEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RestApiPrivilegesEvaluator.java
@@ -216,6 +216,12 @@ public class RestApiPrivilegesEvaluator {
 			logger.debug("Checking admin access for endpoint {}, path {} and method {}", endpoint.name(),  request.path(), request.method().name());
 		}
 
+		// Grant permission for Account endpoint.
+		// Return null to grant access.
+		if (endpoint == Endpoint.ACCOUNT) {
+			return null;
+		}
+
 		String roleBasedAccessFailureReason = checkRoleBasedAccessPermissions(request, endpoint);
 		// Role based access granted
 		if (roleBasedAccessFailureReason == null) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiAction.java
@@ -42,13 +42,16 @@ public class RolesApiAction extends PatchableResourceApiAction {
 	public RolesApiAction(Settings settings, final Path configPath, RestController controller, Client client, AdminDNs adminDNs, ConfigurationRepository cl,
 			ClusterService cs, final PrincipalExtractor principalExtractor, final PrivilegesEvaluator evaluator, ThreadPool threadPool, AuditLog auditLog) {
 		super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
+	}
+
+	@Override
+	protected void registerHandlers(RestController controller, Settings settings) {
 		controller.registerHandler(Method.GET, "/_opendistro/_security/api/roles/", this);
 		controller.registerHandler(Method.GET, "/_opendistro/_security/api/roles/{name}", this);
 		controller.registerHandler(Method.DELETE, "/_opendistro/_security/api/roles/{name}", this);
 		controller.registerHandler(Method.PUT, "/_opendistro/_security/api/roles/{name}", this);
-        controller.registerHandler(Method.PATCH, "/_opendistro/_security/api/roles/", this);
-        controller.registerHandler(Method.PATCH, "/_opendistro/_security/api/roles/{name}", this);
-
+		controller.registerHandler(Method.PATCH, "/_opendistro/_security/api/roles/", this);
+		controller.registerHandler(Method.PATCH, "/_opendistro/_security/api/roles/{name}", this);
 	}
 
 	@Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesMappingApiAction.java
@@ -43,14 +43,16 @@ public class RolesMappingApiAction extends PatchableResourceApiAction {
 			final AdminDNs adminDNs, final ConfigurationRepository cl, final ClusterService cs,
             final PrincipalExtractor principalExtractor, final PrivilegesEvaluator evaluator, ThreadPool threadPool, AuditLog auditLog) {
 		super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
+	}
 
+	@Override
+	protected void registerHandlers(RestController controller, Settings settings) {
 		controller.registerHandler(Method.GET, "/_opendistro/_security/api/rolesmapping/", this);
 		controller.registerHandler(Method.GET, "/_opendistro/_security/api/rolesmapping/{name}", this);
 		controller.registerHandler(Method.DELETE, "/_opendistro/_security/api/rolesmapping/{name}", this);
 		controller.registerHandler(Method.PUT, "/_opendistro/_security/api/rolesmapping/{name}", this);
-        controller.registerHandler(Method.PATCH, "/_opendistro/_security/api/rolesmapping/", this);
-        controller.registerHandler(Method.PATCH, "/_opendistro/_security/api/rolesmapping/{name}", this);
-
+		controller.registerHandler(Method.PATCH, "/_opendistro/_security/api/rolesmapping/", this);
+		controller.registerHandler(Method.PATCH, "/_opendistro/_security/api/rolesmapping/{name}", this);
 	}
 
 	@Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/TenantsApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/TenantsApiAction.java
@@ -29,15 +29,16 @@ public class TenantsApiAction extends PatchableResourceApiAction {
                             final AdminDNs adminDNs, final ConfigurationRepository cl, final ClusterService cs,
                             final PrincipalExtractor principalExtractor, final PrivilegesEvaluator evaluator, ThreadPool threadPool, AuditLog auditLog) {
         super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
+    }
 
-        // corrected mapping, introduced in SG6
+    @Override
+    protected void registerHandlers(RestController controller, Settings settings) {
         controller.registerHandler(Method.GET, "/_opendistro/_security/api/tenants/{name}", this);
         controller.registerHandler(Method.GET, "/_opendistro/_security/api/tenants/", this);
         controller.registerHandler(Method.DELETE, "/_opendistro/_security/api/tenants/{name}", this);
         controller.registerHandler(Method.PUT, "/_opendistro/_security/api/tenants/{name}", this);
         controller.registerHandler(Method.PATCH, "/_opendistro/_security/api/tenants/", this);
         controller.registerHandler(Method.PATCH, "/_opendistro/_security/api/tenants/{name}", this);
-
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/support/Utils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/support/Utils.java
@@ -19,9 +19,13 @@ import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
+import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.SpecialPermission;
@@ -177,5 +181,20 @@ public class Utils {
                 throw new RuntimeException(e.getCause());
             }
         }
+    }
+
+    /**
+     * This generates hash for a given password
+     * @param clearTextPassword plain text password for which hash should be generated.
+     *                          This will be cleared from memory.
+     * @return hash of the password
+     */
+    public static String hash(final char[] clearTextPassword) {
+        final byte[] salt = new byte[16];
+        new SecureRandom().nextBytes(salt);
+        final String hash = OpenBSDBCrypt.generate((Objects.requireNonNull(clearTextPassword)), salt, 12);
+        Arrays.fill(salt, (byte) 0);
+        Arrays.fill(clearTextPassword, '\0');
+        return hash;
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/AccountValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/AccountValidator.java
@@ -1,0 +1,31 @@
+/*
+ * Portions Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.dlic.rest.validation;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestRequest;
+
+/**
+ * Validator for Account Api Action.
+ */
+public class AccountValidator extends CredentialsValidator {
+    public AccountValidator(RestRequest request, BytesReference ref, Settings esSettings, Object... param) {
+        super(request, ref, esSettings, param);
+        allowedKeys.put("current_password", DataType.STRING);
+        mandatoryKeys.add("current_password");
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/CredentialsValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/CredentialsValidator.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.dlic.rest.validation;
+
+import com.amazon.opendistroforelasticsearch.security.ssl.util.Utils;
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.compress.NotXContentException;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.rest.RestRequest;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Validator for validating password and hash present in the payload
+ */
+public class CredentialsValidator extends AbstractConfigurationValidator {
+
+    public CredentialsValidator(final RestRequest request, BytesReference ref, final Settings esSettings,
+                                Object... param) {
+        super(request, ref, esSettings, param);
+        this.payloadMandatory = true;
+        allowedKeys.put("hash", DataType.STRING);
+        allowedKeys.put("password", DataType.STRING);
+    }
+
+    /**
+     * Function to validate password in the content body.
+     * @return true if validation is successful else false
+     */
+    @Override
+    public boolean validate() {
+        if (!super.validate()) {
+            return false;
+        }
+
+        final String regex = this.esSettings.get(ConfigConstants.OPENDISTRO_SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX, null);
+
+        if ((request.method() == RestRequest.Method.PUT || request.method() == RestRequest.Method.PATCH)
+                && regex != null
+                && !regex.isEmpty()
+                && this.content != null
+                && this.content.length() > 1) {
+            try {
+                final Map<String, Object> contentAsMap = XContentHelper.convertToMap(this.content, false, XContentType.JSON).v2();
+                if (contentAsMap != null && contentAsMap.containsKey("password")) {
+                    final String password = (String) contentAsMap.get("password");
+
+                    if (password == null || password.isEmpty()) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Unable to validate password because no password is given");
+                        }
+                        return false;
+                    }
+
+                    if (!regex.isEmpty() && !Pattern.compile("^" + regex + "$").matcher(password).matches()) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Regex does not match password");
+                        }
+                        this.errorType = ErrorType.INVALID_PASSWORD;
+                        return false;
+                    }
+
+                    final String username = Utils.coalesce(request.param("name"), hasParams() ? (String) param[0] : null);
+
+                    if (username == null || username.isEmpty()) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Unable to validate username because no user is given");
+                        }
+                        return false;
+                    }
+
+                    if (username.toLowerCase().equals(password.toLowerCase())) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Username must not match password");
+                        }
+                        this.errorType = ErrorType.INVALID_PASSWORD;
+                        return false;
+                    }
+                }
+            } catch (NotXContentException e) {
+                //this.content is not valid json/yaml
+                log.error("Invalid xContent: " + e, e);
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/InternalUsersValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/InternalUsersValidator.java
@@ -15,90 +15,21 @@
 
 package com.amazon.opendistroforelasticsearch.security.dlic.rest.validation;
 
-import java.util.Map;
-import java.util.regex.Pattern;
-
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.compress.NotXContentException;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestRequest.Method;
 
-import com.amazon.opendistroforelasticsearch.security.ssl.util.Utils;
-import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
-
-public class InternalUsersValidator extends AbstractConfigurationValidator {
+/**
+ * Validator for Internal Users Api Action.
+ */
+public class InternalUsersValidator extends CredentialsValidator {
 
     public InternalUsersValidator(final RestRequest request, BytesReference ref, final Settings esSettings,
             Object... param) {
         super(request, ref, esSettings, param);
-        this.payloadMandatory = true;
-        allowedKeys.put("hash", DataType.STRING);
-        allowedKeys.put("password", DataType.STRING);
         allowedKeys.put("backend_roles", DataType.ARRAY);
         allowedKeys.put("attributes", DataType.OBJECT);
         allowedKeys.put("description", DataType.STRING);
         allowedKeys.put("opendistro_security_roles", DataType.ARRAY);
-    }
-
-    @Override
-    public boolean validate() {
-        if(!super.validate()) {
-            return false;
-        }
-
-        final String regex = this.esSettings.get(ConfigConstants.OPENDISTRO_SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX, null);
-
-        if((request.method() == Method.PUT || request.method() == Method.PATCH )
-                && regex != null
-                && !regex.isEmpty()
-                && this.content != null
-                && this.content.length() > 1) {
-            try {
-                final Map<String, Object> contentAsMap = XContentHelper.convertToMap(this.content, false, XContentType.JSON).v2();
-                if(contentAsMap != null && contentAsMap.containsKey("password")) {
-                    final String password = (String) contentAsMap.get("password");
-
-                    if(password == null || password.isEmpty()) {
-                        if(log.isDebugEnabled()) {
-                            log.debug("Unable to validate password because no password is given");
-                        }
-                        return false;
-                    }
-
-                    if(!regex.isEmpty() && !Pattern.compile("^"+regex+"$").matcher(password).matches()) {
-                        if(log.isDebugEnabled()) {
-                            log.debug("Regex does not match password");
-                        }
-                        this.errorType = ErrorType.INVALID_PASSWORD;
-                        return false;
-                    }
-
-                    final String username = Utils.coalesce(request.param("name"), hasParams()?(String)param[0]:null);
-
-                    if(username == null || username.isEmpty()) {
-                        if(log.isDebugEnabled()) {
-                            log.debug("Unable to validate username because no user is given");
-                        }
-                        return false;
-                    }
-
-                    if(username.toLowerCase().equals(password.toLowerCase())) {
-                        if(log.isDebugEnabled()) {
-                            log.debug("Username must not match password");
-                        }
-                        this.errorType = ErrorType.INVALID_PASSWORD;
-                        return false;
-                    }
-                }
-            } catch (NotXContentException e) {
-                //this.content is not valid json/yaml
-                log.error("Invalid xContent: "+e,e);
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.dlic.rest.api;
+
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.CType;
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper.HttpResponse;
+import org.apache.http.Header;
+import org.apache.http.HttpStatus;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class AccountApiTest extends AbstractRestApiUnitTest {
+
+    public static final String ENDPOINT = "/_opendistro/_security/api/account";
+
+    @Test
+    public void testGetAccount() throws Exception {
+        // arrange
+        setup();
+        final String testUser = "test-user";
+        final String testPass = "test-pass";
+        addUserWithPassword(testUser, testPass, HttpStatus.SC_CREATED);
+
+        // test - unauthorized access as credentials are missing.
+        HttpResponse response = rh.executeGetRequest(ENDPOINT, new Header[0]);
+        assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
+
+        // test - incorrect password
+        response = rh.executeGetRequest(ENDPOINT, encodeBasicHeader(testUser, "wrong-pass"));
+        assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
+
+        // test - incorrect user
+        response = rh.executeGetRequest(ENDPOINT, encodeBasicHeader("wrong-user", testPass));
+        assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
+
+        // test - valid request
+        response = rh.executeGetRequest(ENDPOINT, encodeBasicHeader(testUser, testPass));
+        Settings body = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(testUser, body.get("user_name"));
+        assertFalse(body.getAsBoolean("is_reserved", true));
+        assertFalse(body.getAsBoolean("is_hidden", true));
+        assertTrue(body.getAsBoolean("is_internal_user", false));
+        assertNull(body.get("user_requested_tenant"));
+        assertNotNull(body.getAsList("backend_roles").size());
+        assertNotNull(body.getAsList("custom_attribute_names").size());
+        assertNotNull(body.getAsSettings("tenants"));
+        assertNotNull(body.getAsList("roles"));
+    }
+
+    @Test
+    public void testPutAccount() throws Exception {
+        // arrange
+        setup();
+        final String testUser = "test-user";
+        final String testPass = "test-old-pass";
+        final String testPassHash = "$2y$12$b7TNPn2hgl0nS7gXJ.beuOd8JGl6Nz5NsTyxofglGCItGNyDdwivK"; // hash for test-old-pass
+        final String testNewPass = "test-new-pass";
+        final String testNewPassHash = "$2y$12$cclJJdVdXMMVzkhqQhEoE.hoERKE8bDzctR0S3aYj2EPHq45Y.GXC"; // hash for test-old-pass
+        addUserWithPassword(testUser, testPass, HttpStatus.SC_CREATED);
+
+        // test - unauthorized access as credentials are missing.
+        HttpResponse response = rh.executePutRequest(ENDPOINT, "", new Header[0]);
+        assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
+
+        // test - bad request as body is missing
+        response = rh.executePutRequest(ENDPOINT, "", encodeBasicHeader(testUser, testPass));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+
+        // test - bad request as current password is missing
+        String payload = "{\"password\":\"new-pass\"}";
+        response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader(testUser, testPass));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+
+        // test - bad request as current password is incorrect
+        payload = "{\"password\":\"" + testNewPass + "\", \"current_password\":\"" + "wrong-pass" + "\"}";
+        response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader(testUser, testPass));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+
+        // test - bad request as invalid parameters are present
+        payload = "{\"password\":\"new-pass\", \"current_password\":\"" + testPass + "\", \"backend_roles\": []}";
+        response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader(testUser, testPass));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+
+        // test - invalid user
+        payload = "{\"password\":\"" + testNewPass + "\", \"current_password\":\"" + testPass + "\"}";
+        response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader("wrong-user", testPass));
+        assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
+
+        // test - valid password change with hash
+        payload = "{\"hash\":\"" + testNewPassHash + "\", \"current_password\":\"" + testPass + "\"}";
+        response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader(testUser, testPass));
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        // test - valid password change
+        payload = "{\"password\":\"" + testPass + "\", \"current_password\":\"" + testNewPass + "\"}";
+        response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader(testUser, testNewPass));
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        // create users from - resources/restapi/internal_users.yml
+        rh.keystore = "restapi/kirk-keystore.jks";
+        rh.sendHTTPClientCertificate = true;
+        response = rh.executeGetRequest("_opendistro/_security/api/" + CType.INTERNALUSERS.toLCString());
+        rh.sendHTTPClientCertificate = false;
+        Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
+
+        // test - reserved user - sarek
+        response = rh.executeGetRequest(ENDPOINT, encodeBasicHeader("sarek", "sarek"));
+        Settings body = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
+        // check reserved user exists
+        assertTrue(body.getAsBoolean("is_reserved", false));
+        payload = "{\"password\":\"" + testPass + "\", \"current_password\":\"" + "sarek" + "\"}";
+        response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader("sarek", "sarek"));
+        assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // test - hidden user - hide
+        response = rh.executeGetRequest(ENDPOINT, encodeBasicHeader("hide", "hide"));
+        body = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
+        // check hidden user exists
+        assertTrue(body.getAsBoolean("is_hidden", false));
+        payload = "{\"password\":\"" + testPass + "\", \"current_password\":\"" + "hide" + "\"}";
+        response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader("hide", "hide"));
+        assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // test - admin with admin cert - internal user does not exist
+        rh.keystore = "restapi/kirk-keystore.jks";
+        rh.sendHTTPClientCertificate = true;
+        response = rh.executeGetRequest(ENDPOINT, encodeBasicHeader("admin", "admin"));
+        body = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
+        assertEquals("CN=kirk,OU=client,O=client,L=Test,C=DE", body.get("user_name"));
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());        // check admin user exists
+        System.out.println(response.getBody());
+        payload = "{\"password\":\"" + testPass + "\", \"current_password\":\"" + "admin" + "\"}";
+        response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader("admin", "admin"));
+        assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RestApiPrivilegesEvaluatorTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RestApiPrivilegesEvaluatorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.dlic.rest.api;
+
+import com.amazon.opendistroforelasticsearch.security.configuration.AdminDNs;
+import com.amazon.opendistroforelasticsearch.security.privileges.PrivilegesEvaluator;
+import com.amazon.opendistroforelasticsearch.security.ssl.transport.PrincipalExtractor;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+public class RestApiPrivilegesEvaluatorTest {
+
+    private RestApiPrivilegesEvaluator privilegesEvaluator;
+
+    @Before
+    public void setUp() {
+        this.privilegesEvaluator = new RestApiPrivilegesEvaluator(Settings.EMPTY,
+                mock(AdminDNs.class),
+                mock(PrivilegesEvaluator.class),
+                mock(PrincipalExtractor.class),
+                mock(Path.class),
+                mock(ThreadPool.class));
+    }
+
+    @Test
+    public void testAccountEndpointBypass() throws IOException {
+        // act
+        String res = privilegesEvaluator.checkAccessPermissions(mock(RestRequest.class), Endpoint.ACCOUNT);
+        // assert
+        assertNull(res);
+
+        res = privilegesEvaluator.checkAccessPermissions(mock(RestRequest.class), Endpoint.INTERNALUSERS);
+        // assert
+        assertNotNull(res);
+    }
+}

--- a/src/test/resources/restapi/internal_users.yml
+++ b/src/test/resources/restapi/internal_users.yml
@@ -46,3 +46,10 @@ worf:
   - "klingon"
   attributes: {}
   description: "Migrated from v6"
+hide:
+  hash: "$2y$12$unbLt6ftTcIofGrFEcfwSOGYvYjUGLUvKWPjDG74KUv6kgUtesQMS"
+  reserved: false
+  hidden: true
+  backend_roles: []
+  attributes: {}
+  description: "Hidden user - password - hide"


### PR DESCRIPTION
Add new REST endpoint `_opendistro/_security/api/account`.
- GET request to get basic information of the signed-in user

```
Sample request:
GET _opendistro/_security/api/account

Sample response:
{
    "user_name" : "test",
    "is_reserved" : false,
    "is_hidden" : false,
    "is_internal_user" : true,
    "user_requested_tenant" : "__user__",
    "backend_roles" : [ ],
    "custom_attribute_names" : [ ],
    "tenants" : {
    "test" : true
    },
    "roles" : [
    "own_index"
    ]
}
```

- PUT request to update the credentials of the user.
```
Sample request:
PUT _opendistro/_security/api/account
{
    "current_password" : "old-pass",
    "password" : "new-pass"
}
Sample response:
{
    "status": "OK",
    "message":"'test' updated."
}
```

Supporting PR in security-kibana-plugin: https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/pull/126