### PR TITLE
Set cluster.routing.allocation.disk.threshold_enabled default value

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/cluster/ClusterHelper.java
@@ -358,7 +358,7 @@ public final class ClusterHelper {
                 .put("transport.tcp.port", tcpPort)
                 .put("http.port", httpPort)
                 //.put("http.enabled", true)
-                .put("cluster.routing.allocation.disk.threshold_enabled", false)
+                .put("cluster.routing.allocation.disk.threshold_enabled", true)
                 .put("http.cors.enabled", true)
                 .put("path.home", ".");
     }

--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -382,7 +382,7 @@ echo 'opendistro_security.restapi.roles_enabled: ["all_access", "security_rest_a
 if $SUDO_CMD grep --quiet -i "^cluster.routing.allocation.disk.threshold_enabled" "$ES_CONF_FILE"; then
 	: #already present
 else
-    echo 'cluster.routing.allocation.disk.threshold_enabled: false' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
+    echo 'cluster.routing.allocation.disk.threshold_enabled: true' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 fi
 
 #network.host


### PR DESCRIPTION
This PR fix #208 by setting `cluster.routing.allocation.disk.threshold_enabled` default value (_true_), according to Elasticsearch default value