### PR TITLE
Opendistro 1.1

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/AdminDNs.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/AdminDNs.java
@@ -83,7 +83,7 @@ public class AdminDNs {
         }
        
         log.debug("Loaded {} admin DN's {}",adminDn.size(),  adminDn);
-        
+
         final Settings impersonationDns = settings.getByPrefix(ConfigConstants.OPENDISTRO_SECURITY_AUTHCZ_IMPERSONATION_DN+".");
         
         for (String dnString:impersonationDns.keySet()) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/ActionGroupsApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/ActionGroupsApiAction.java
@@ -70,7 +70,7 @@ public class ActionGroupsApiAction extends PatchableResourceApiAction {
 
 	@Override
 	protected AbstractConfigurationValidator getValidator(final RestRequest request, BytesReference ref, Object... param) {
-		return new ActionGroupValidator(request, ref, this.settings, param);
+		return new ActionGroupValidator(request, isSuperAdmin(), ref, this.settings, param);
 	}
 
 	@Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -103,7 +103,7 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
         }
 
         // check if resource is writeable
-        if (isReserved(configuration, username)) {
+        if (!isReservedAndAccessible(configuration, username)) {
             forbidden(channel, "Resource '" + username + "' is read-only.");
             return;
         }
@@ -215,6 +215,6 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
 
     @Override
     protected AbstractConfigurationValidator getValidator(RestRequest request, BytesReference ref, Object... params) {
-        return new InternalUsersValidator(request, ref, this.settings, params);
+        return new InternalUsersValidator(request, isSuperAdmin(), ref, this.settings, params);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
@@ -106,7 +106,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
             return;
         }
 
-        if (isReserved(existingConfiguration, name)) {
+        if (!isReservedAndAccessible(existingConfiguration, name)) {
             forbidden(channel, "Resource '" + name + "' is read-only.");
             return;
         }
@@ -181,7 +181,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
 
             if (oldResource != null && !oldResource.equals(patchedResource)) {
 
-                if (isReserved(existingConfiguration, resourceName)) {
+                if (!isReservedAndAccessible(existingConfiguration, resourceName)) {
                     forbidden(channel, "Resource '" + resourceName + "' is read-only.");
                     return;
                 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiAction.java
@@ -61,7 +61,7 @@ public class RolesApiAction extends PatchableResourceApiAction {
 
 	@Override
 	protected AbstractConfigurationValidator getValidator(RestRequest request, BytesReference ref, Object... param) {
-		return new RolesValidator(request, ref, this.settings, param);
+		return new RolesValidator(request, isSuperAdmin(), ref, this.settings, param);
 	}
 
 	@Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesMappingApiAction.java
@@ -62,7 +62,7 @@ public class RolesMappingApiAction extends PatchableResourceApiAction {
 
 	@Override
 	protected AbstractConfigurationValidator getValidator(RestRequest request, BytesReference ref, Object... param) {
-		return new RolesMappingValidator(request, ref, this.settings, param);
+		return new RolesMappingValidator(request, isSuperAdmin(), ref, this.settings, param);
 	}
 
 	@Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/TenantsApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/TenantsApiAction.java
@@ -48,7 +48,7 @@ public class TenantsApiAction extends PatchableResourceApiAction {
 
     @Override
     protected AbstractConfigurationValidator getValidator(final RestRequest request, BytesReference ref, Object... param) {
-        return new TenantValidator(request, ref, this.settings, param);
+        return new TenantValidator(request, isSuperAdmin(), ref, this.settings, param);
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/AbstractConfigurationValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/AbstractConfigurationValidator.java
@@ -273,7 +273,7 @@ public abstract class AbstractConfigurationValidator {
     }
 
     public static enum DataType {
-        STRING, ARRAY, OBJECT;
+        STRING, ARRAY, OBJECT, BOOLEAN;
     }
 
     public static enum ErrorType {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/ActionGroupValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/ActionGroupValidator.java
@@ -24,12 +24,13 @@ import com.amazon.opendistroforelasticsearch.security.dlic.rest.validation.Abstr
 
 public class ActionGroupValidator extends AbstractConfigurationValidator {
 
-	public ActionGroupValidator(final RestRequest request, BytesReference ref, final Settings esSettings, Object... param) {
+	public ActionGroupValidator(final RestRequest request, boolean isSuperAdmin, BytesReference ref, final Settings esSettings, Object... param) {
 		super(request, ref, esSettings, param);
 		this.payloadMandatory = true;
 		allowedKeys.put("allowed_actions", DataType.ARRAY);
 	    allowedKeys.put("description", DataType.STRING);
 	    allowedKeys.put("type", DataType.STRING);
+	    if (isSuperAdmin) allowedKeys.put("reserved" , DataType.BOOLEAN);
 
 		mandatoryKeys.add("allowed_actions");
 	}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/InternalUsersValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/InternalUsersValidator.java
@@ -30,7 +30,6 @@ public class InternalUsersValidator extends CredentialsValidator {
         allowedKeys.put("backend_roles", DataType.ARRAY);
         allowedKeys.put("attributes", DataType.OBJECT);
         allowedKeys.put("description", DataType.STRING);
-        allowedKeys.put("opendistro_security_roles", DataType.ARRAY);
         if (isSuperAdmin) allowedKeys.put("reserved", DataType.BOOLEAN);
 
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/InternalUsersValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/InternalUsersValidator.java
@@ -24,11 +24,14 @@ import org.elasticsearch.rest.RestRequest;
  */
 public class InternalUsersValidator extends CredentialsValidator {
 
-    public InternalUsersValidator(final RestRequest request, BytesReference ref, final Settings esSettings,
+    public InternalUsersValidator(final RestRequest request, boolean isSuperAdmin, BytesReference ref, final Settings esSettings,
             Object... param) {
         super(request, ref, esSettings, param);
         allowedKeys.put("backend_roles", DataType.ARRAY);
         allowedKeys.put("attributes", DataType.OBJECT);
         allowedKeys.put("description", DataType.STRING);
+        allowedKeys.put("opendistro_security_roles", DataType.ARRAY);
+        if (isSuperAdmin) allowedKeys.put("reserved", DataType.BOOLEAN);
+
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/RolesMappingValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/RolesMappingValidator.java
@@ -21,7 +21,7 @@ import org.elasticsearch.rest.RestRequest;
 
 public class RolesMappingValidator extends AbstractConfigurationValidator {
 
-	public RolesMappingValidator(final RestRequest request, final BytesReference ref, final Settings esSettings, Object... param) {
+	public RolesMappingValidator(final RestRequest request, boolean isSuperAdmin, final BytesReference ref, final Settings esSettings, Object... param) {
 		super(request, ref, esSettings, param);
 		this.payloadMandatory = true;
 		allowedKeys.put("backend_roles", DataType.ARRAY);
@@ -29,6 +29,7 @@ public class RolesMappingValidator extends AbstractConfigurationValidator {
 		allowedKeys.put("hosts", DataType.ARRAY);
 		allowedKeys.put("users", DataType.ARRAY);
 		allowedKeys.put("description", DataType.STRING);
+		if (isSuperAdmin) allowedKeys.put("reserved", DataType.BOOLEAN);
 
 		mandatoryOrKeys.add("backend_roles");
 		mandatoryOrKeys.add("and_backend_roles");

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/RolesValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/RolesValidator.java
@@ -27,13 +27,14 @@ import com.jayway.jsonpath.ReadContext;
 
 public class RolesValidator extends AbstractConfigurationValidator {
 
-	public RolesValidator(final RestRequest request, final BytesReference ref, final Settings esSettings, Object... param) {
+	public RolesValidator(final RestRequest request, boolean isSuperAdmin, final BytesReference ref, final Settings esSettings, Object... param) {
 		super(request, ref, esSettings, param);
 		this.payloadMandatory = true;
         allowedKeys.put("cluster_permissions", DataType.ARRAY);
         allowedKeys.put("tenant_permissions", DataType.ARRAY);
         allowedKeys.put("index_permissions", DataType.ARRAY);
         allowedKeys.put("description", DataType.STRING);
+        if (isSuperAdmin) allowedKeys.put("reserved", DataType.BOOLEAN);
 	}
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/TenantValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/TenantValidator.java
@@ -8,10 +8,11 @@ import org.elasticsearch.rest.RestRequest;
 
 public class TenantValidator extends AbstractConfigurationValidator {
 
-    public TenantValidator(final RestRequest request, BytesReference ref, final Settings esSettings, Object... param) {
+    public TenantValidator(final RestRequest request, boolean isSuperAdmin, BytesReference ref, final Settings esSettings, Object... param) {
         super(request, ref, esSettings, param);
         this.payloadMandatory = true;
         allowedKeys.put("description", DataType.STRING);
+        if (isSuperAdmin) allowedKeys.put("reserved", DataType.BOOLEAN);
     }
 
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/HttpIntegrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/HttpIntegrationTests.java
@@ -367,7 +367,7 @@ public class HttpIntegrationTests extends SingleClusterTest {
         
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "spock-keystore.jks";
         Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_search").getStatusCode());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, rh.executePutRequest(".opendistro_security/"+getType()+"/x", "{}").getStatusCode());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/InitializationIntegrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/InitializationIntegrationTests.java
@@ -77,7 +77,7 @@ public class InitializationIntegrationTests extends SingleClusterTest {
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         Assert.assertEquals(HttpStatus.SC_SERVICE_UNAVAILABLE, rh.executePutRequest(".opendistro_security/config/0", "{}", encodeBasicHeader("___", "")).getStatusCode());
         Assert.assertEquals(HttpStatus.SC_SERVICE_UNAVAILABLE, rh.executePutRequest(".opendistro_security/"+getType()+"/config", "{}", encodeBasicHeader("___", "")).getStatusCode());
         

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/SecurityAdminMigrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/SecurityAdminMigrationTests.java
@@ -49,7 +49,7 @@ public class SecurityAdminMigrationTests extends SingleClusterTest {
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
         
         final String prefix = getResourceFolder()==null?"":getResourceFolder()+"/";
@@ -95,7 +95,7 @@ public class SecurityAdminMigrationTests extends SingleClusterTest {
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
         
         final String prefix = getResourceFolder()==null?"":getResourceFolder()+"/";

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/SecurityAdminTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/SecurityAdminTests.java
@@ -287,7 +287,7 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
         System.out.println(rh.executePutRequest(".opendistro_security/"+getType()+"/roles", FileHelper.loadFile("roles_invalidxcontent.yml")).getBody());;
         Assert.assertEquals(HttpStatus.SC_OK, rh.executePutRequest(".opendistro_security/"+getType()+"/roles", "{\"roles\":\"dummy\"}").getStatusCode());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/AbstractAuditlogiUnitTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/AbstractAuditlogiUnitTest.java
@@ -62,15 +62,15 @@ public abstract class AbstractAuditlogiUnitTest extends SingleClusterTest {
     }
 
     protected void setupStarfleetIndex() throws Exception {
-        final boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
+        final boolean sendAdminCertificate = rh.sendAdminCertificate;
         final String keystore = rh.keystore;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "auditlog/kirk-keystore.jks";
         rh.executePutRequest("sf", null, new Header[0]);
         rh.executePutRequest("sf/public/0?refresh", "{\"number\" : \"NCC-1701-D\"}", new Header[0]);
         rh.executePutRequest("sf/public/0?refresh", "{\"some\" : \"value\"}", new Header[0]);
         rh.executePutRequest("sf/public/0?refresh", "{\"some\" : \"value\"}", new Header[0]);
-        rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+        rh.sendAdminCertificate = sendAdminCertificate;
         rh.keystore = keystore;
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/compliance/ComplianceAuditlogTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/compliance/ComplianceAuditlogTest.java
@@ -49,14 +49,14 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
                 .build();
 
         setup(additionalSettings);
-        final boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
+        final boolean sendAdminCertificate = rh.sendAdminCertificate;
         final String keystore = rh.keystore;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "auditlog/kirk-keystore.jks";
         rh.executePutRequest("emp/doc/0?refresh", "{\"Designation\" : \"CEO\", \"Gender\" : \"female\", \"Salary\" : 100}", new Header[0]);
         rh.executePutRequest("emp/doc/1?refresh", "{\"Designation\" : \"IT\", \"Gender\" : \"male\", \"Salary\" : 200}", new Header[0]);
         rh.executePutRequest("emp/doc/2?refresh", "{\"Designation\" : \"IT\", \"Gender\" : \"female\", \"Salary\" : 300}", new Header[0]);
-        rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+        rh.sendAdminCertificate = sendAdminCertificate;
         rh.keystore = keystore;
 
         System.out.println("#### test source includes");
@@ -103,14 +103,14 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
                 .build();
 
         setup(additionalSettings);
-        final boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
+        final boolean sendAdminCertificate = rh.sendAdminCertificate;
         final String keystore = rh.keystore;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "auditlog/kirk-keystore.jks";
         rh.executePutRequest("emp/doc/0?refresh", "{\"Designation\" : \"CEO\", \"Gender\" : \"female\", \"Salary\" : 100}", new Header[0]);
         rh.executePutRequest("emp/doc/1?refresh", "{\"Designation\" : \"IT\", \"Gender\" : \"male\", \"Salary\" : 200}", new Header[0]);
         rh.executePutRequest("emp/doc/2?refresh", "{\"Designation\" : \"IT\", \"Gender\" : \"female\", \"Salary\" : 300}", new Header[0]);
-        rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+        rh.sendAdminCertificate = sendAdminCertificate;
         rh.keystore = keystore;
 
         System.out.println("#### test source includes");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/compliance/RestApiComplianceAuditlogTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/compliance/RestApiComplianceAuditlogTest.java
@@ -81,7 +81,7 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
 
         HttpResponse response = rh.executePutRequest("_opendistro/_security/api/internalusers/compuser?pretty", body);
@@ -117,7 +117,7 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
         System.out.println("----rest");
         HttpResponse response = rh.executeGetRequest("_opendistro/_security/api/rolesmapping/opendistro_security_all_access?pretty");
@@ -209,7 +209,7 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
         System.out.println("req");
         HttpResponse response = rh.executeGetRequest("_opendistro/_security/api/internalusers/admin?pretty");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/integration/BasicAuditlogTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/integration/BasicAuditlogTest.java
@@ -490,12 +490,12 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         setup(additionalSettings);
         setupStarfleetIndex();
 
-        final boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
+        final boolean sendAdminCertificate = rh.sendAdminCertificate;
         final String keystore = rh.keystore;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "auditlog/kirk-keystore.jks";
         HttpResponse res = rh.executeGetRequest("_cat/indices", new Header[0]);
-        rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+        rh.sendAdminCertificate = sendAdminCertificate;
         rh.keystore = keystore;
 
         Assert.assertTrue(res.getBody().contains("auditlog-20"));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
@@ -109,25 +109,25 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
 	}
 
 	protected void deleteUser(String username) throws Exception {
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = true;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = true;
 		HttpResponse response = rh.executeDeleteRequest("/_opendistro/_security/api/internalusers/" + username, new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 	}
 
 	protected void addUserWithPassword(String username, String password, int status) throws Exception {
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = true;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = true;
 		HttpResponse response = rh.executePutRequest("/_opendistro/_security/api/internalusers/" + username,
 				"{\"password\": \"" + password + "\"}", new Header[0]);
 		Assert.assertEquals(status, response.getStatusCode());
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 	}
 
 	protected void addUserWithPassword(String username, String password, String[] roles, int status) throws Exception {
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = true;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = true;
 		String payload = "{" + "\"password\": \"" + password + "\"," + "\"backend_roles\": [";
 		for (int i = 0; i < roles.length; i++) {
 			payload += "\"" + roles[i] + "\"";
@@ -138,12 +138,12 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
 		payload += "]}";
 		HttpResponse response = rh.executePutRequest("/_opendistro/_security/api/internalusers/" + username, payload, new Header[0]);
 		Assert.assertEquals(status, response.getStatusCode());
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 	}
 
 	protected void addUserWithoutPasswordOrHash(String username, String[] roles, int status) throws Exception {
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = true;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = true;
 		String payload = "{ \"backend_roles\": [";
 		for (int i = 0; i < roles.length; i++) {
 			payload += "\" " + roles[i] + " \"";
@@ -154,7 +154,7 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
 		payload += "]}";
 		HttpResponse response = rh.executePutRequest("/_opendistro/_security/api/internalusers/" + username, payload, new Header[0]);
 		Assert.assertEquals(status, response.getStatusCode());
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 	}
 
 	protected void addUserWithHash(String username, String hash) throws Exception {
@@ -162,34 +162,34 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
 	}
 
 	protected void addUserWithHash(String username, String hash, int status) throws Exception {
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = true;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = true;
 		HttpResponse response = rh.executePutRequest("/_opendistro/_security/api/internalusers/" + username, "{\"hash\": \"" + hash + "\"}",
 				new Header[0]);
 		Assert.assertEquals(status, response.getStatusCode());
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 	}
 
 	protected void checkGeneralAccess(int status, String username, String password) throws Exception {
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = false;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = false;
 		Assert.assertEquals(status,
 				rh.executeGetRequest("",
 						encodeBasicHeader(username, password))
 						.getStatusCode());
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 	}
 
 	protected String checkReadAccess(int status, String username, String password, String indexName, String type,
 			int id) throws Exception {
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = false;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = false;
 		String action = indexName + "/" + type + "/" + id;
 		HttpResponse response = rh.executeGetRequest(action,
 				encodeBasicHeader(username, password));
 		int returnedStatus = response.getStatusCode();
 		Assert.assertEquals(status, returnedStatus);
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 		return response.getBody();
 
 	}
@@ -197,25 +197,25 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
 	protected String checkWriteAccess(int status, String username, String password, String indexName, String type,
 			int id) throws Exception {
 
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = false;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = false;
 		String action = indexName + "/" + type + "/" + id;
 		String payload = "{\"value\" : \"true\"}";
 		HttpResponse response = rh.executePutRequest(action, payload,
 				encodeBasicHeader(username, password));
 		int returnedStatus = response.getStatusCode();
 		Assert.assertEquals(status, returnedStatus);
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 		return response.getBody();
 	}
 
 	protected void setupStarfleetIndex() throws Exception {
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = true;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = true;
 		rh.executePutRequest("sf", null, new Header[0]);
 		rh.executePutRequest("sf/ships/0", "{\"number\" : \"NCC-1701-D\"}", new Header[0]);
 		rh.executePutRequest("sf/public/0", "{\"some\" : \"value\"}", new Header[0]);
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 	}
 
 	protected Settings defaultNodeSettings(boolean enableRestSSL) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
@@ -116,9 +116,9 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
 
         // create users from - resources/restapi/internal_users.yml
         rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executeGetRequest("_opendistro/_security/api/" + CType.INTERNALUSERS.toLCString());
-        rh.sendHTTPClientCertificate = false;
+        rh.sendAdminCertificate = false;
         Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
 
         // test - reserved user - sarek
@@ -141,7 +141,7 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
 
         // test - admin with admin cert - internal user does not exist
         rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executeGetRequest(ENDPOINT, encodeBasicHeader("admin", "admin"));
         body = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
         assertEquals("CN=kirk,OU=client,O=client,L=Test,C=DE", body.get("user_name"));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/ActionGroupsApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/ActionGroupsApiTest.java
@@ -36,7 +36,7 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
 		setup();
 
 		rh.keystore = "restapi/kirk-keystore.jks";
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		// --- GET_UT
         // GET_UT, actiongroup exists
@@ -91,7 +91,7 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
 
 		// -- DELETE
 		// Non-existing role
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		response = rh.executeDeleteRequest("/_opendistro/_security/api/actiongroups/idonotexist", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
@@ -102,7 +102,7 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
 		response = rh.executeDeleteRequest("/_opendistro/_security/api/actiongroups/READ_UT", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 		checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "ships", 0);
 
 		// put picard in captains role. Role opendistro_security_role_captains uses the CRUD_UT
@@ -114,16 +114,16 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
 		checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "ships", 0);
 
 		// now remove also CRUD_UT groups, write also not possible anymore
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 		response = rh.executeDeleteRequest("/_opendistro/_security/api/actiongroups/CRUD_UT", new Header[0]);
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 		checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "ships", 0);
 		checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "ships", 0);
 
 		// -- PUT
 
 		// put with empty payload, must fail
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 		response = rh.executePutRequest("/_opendistro/_security/api/actiongroups/SOMEGROUP", "", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
@@ -139,82 +139,85 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
 		response = rh.executePutRequest("/_opendistro/_security/api/actiongroups/CRUD_UT", FileHelper.loadFile("restapi/actiongroup_crud.json"), new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
 
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 
 		// write access allowed again, read forbidden, since READ_UT group is still missing
 		checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "ships", 0);
 		checkWriteAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "ships", 0);
 
 		// restore READ_UT action groups
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 		response = rh.executePutRequest("/_opendistro/_security/api/actiongroups/READ_UT", FileHelper.loadFile("restapi/actiongroup_read.json"), new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
 
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 		// read/write allowed again
 		checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "ships", 0);
 		checkWriteAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "ships", 0);
 
 		// -- PUT, new JSON format including readonly flag, disallowed in REST API
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 		response = rh.executePutRequest("/_opendistro/_security/api/actiongroups/CRUD_UT", FileHelper.loadFile("restapi/actiongroup_readonly.json"), new Header[0]);
-		Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
 		// -- DELETE read only resource, must be forbidden
-		rh.sendHTTPClientCertificate = true;
+        // superAdmin can delete read only resource
+		rh.sendAdminCertificate = true;
 		response = rh.executeDeleteRequest("/_opendistro/_security/api/actiongroups/GET_UT", new Header[0]);
-		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
 		// -- PUT read only resource, must be forbidden
-		rh.sendHTTPClientCertificate = true;
+        // superAdmin can add/update read only resource
+		rh.sendAdminCertificate = true;
         response = rh.executePutRequest("/_opendistro/_security/api/actiongroups/GET_UT", FileHelper.loadFile("restapi/actiongroup_read.json"), new Header[0]);
-		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
-        Assert.assertTrue(response.getBody().contains("Resource 'GET_UT' is read-only."));
+		Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
+        Assert.assertFalse(response.getBody().contains("Resource 'GET_UT' is read-only."));
 
         // -- GET_UT hidden resource, must be 404
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executeGetRequest("/_opendistro/_security/api/actiongroups/INTERNAL", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
 		// -- DELETE hidden resource, must be 404
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executeDeleteRequest("/_opendistro/_security/api/actiongroups/INTERNAL", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // -- PUT hidden resource, must be forbidden
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePutRequest("/_opendistro/_security/api/actiongroups/INTERNAL", FileHelper.loadFile("restapi/actiongroup_read.json"), new Header[0]);
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
 
         // -- PATCH
         // PATCH on non-existing resource
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups/imnothere", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // PATCH read only resource, must be forbidden
-        rh.sendHTTPClientCertificate = true;
-        response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups/GET_UT", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        // SuperAdmin can patch read only resource
+        rh.sendAdminCertificate = true;
+        response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups/GET_UT", "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         // PATCH hidden resource, must be not found
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups/INTERNAL", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // PATCH value of hidden flag, must fail with validation error
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups/CRUD_UT", "[{ \"op\": \"add\", \"path\": \"/hidden\", \"value\": true }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         Assert.assertTrue(response.getBody(), response.getBody().matches(".*\"invalid_keys\"\\s*:\\s*\\{\\s*\"keys\"\\s*:\\s*\"hidden\"\\s*\\}.*"));
 
         // PATCH with relative JSON pointer, must fail
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups/CRUD_UT", "[{ \"op\": \"add\", \"path\": \"1/INTERNAL/allowed_actions/-\", \"value\": \"OPENDISTRO_SECURITY_DELETE\" }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         // PATCH new format
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups/CRUD_UT", "[{ \"op\": \"add\", \"path\": \"/allowed_actions/-\", \"value\": \"OPENDISTRO_SECURITY_DELETE\" }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rh.executeGetRequest("/_opendistro/_security/api/actiongroups/CRUD_UT", new Header[0]);
@@ -230,40 +233,46 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
 
         // -- PATCH on whole config resource
         // PATCH read only resource, must be forbidden
-        rh.sendHTTPClientCertificate = true;
+        // SuperAdmin can patch read only resource
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups", "[{ \"op\": \"add\", \"path\": \"/GET_UT/a\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+
+        rh.sendAdminCertificate = true;
+        response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups", "[{ \"op\": \"add\", \"path\": \"/GET_UT/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         // PATCH hidden resource, must be bad request
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups", "[{ \"op\": \"add\", \"path\": \"/INTERNAL/a\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         // PATCH delete read only resource, must be forbidden
-        rh.sendHTTPClientCertificate = true;
+        // SuperAdmin can delete read only resource
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups", "[{ \"op\": \"remove\", \"path\": \"/GET_UT\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         // PATCH delete hidden resource, must be bad request
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups", "[{ \"op\": \"remove\", \"path\": \"/INTERNAL\" }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
 
         // PATCH value of hidden flag, must fail with validation error
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups", "[{ \"op\": \"add\", \"path\": \"/CRUD_UT/hidden\", \"value\": true }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         Assert.assertTrue(response.getBody().matches(".*\"invalid_keys\"\\s*:\\s*\\{\\s*\"keys\"\\s*:\\s*\"hidden\"\\s*\\}.*"));
 
         // add new resource with hidden flag, must fail with validation error
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups", "[{ \"op\": \"add\", \"path\": \"/NEWNEWNEW\", \"value\": {\"allowed_actions\": [\"indices:data/write*\"], \"hidden\":true }}]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         Assert.assertTrue(response.getBody().matches(".*\"invalid_keys\"\\s*:\\s*\\{\\s*\"keys\"\\s*:\\s*\"hidden\"\\s*\\}.*"));
 
         // add new valid resources
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups", "[{ \"op\": \"add\", \"path\": \"/BULKNEW1\", \"value\": {\"allowed_actions\": [\"indices:data/*\", \"cluster:monitor/*\"] } }," + "{ \"op\": \"add\", \"path\": \"/BULKNEW2\", \"value\": {\"allowed_actions\": [\"READ_UT\"] } }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rh.executeGetRequest("/_opendistro/_security/api/actiongroups/BULKNEW1", new Header[0]);
@@ -298,4 +307,36 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
         Assert.assertEquals(1, permissions.size());
         Assert.assertTrue(permissions.contains("READ_UT"));        
 	}
+
+    @Test
+    public void testActionGroupsApiForNonSuperAdmin() throws Exception {
+
+        setupWithRestRoles();
+
+        rh.keystore = "restapi/kirk-keystore.jks";
+        rh.sendAdminCertificate = false;
+        rh.sendHTTPClientCredentials = true;
+
+        HttpResponse response;
+
+        response = rh.executeGetRequest("/_opendistro/_security/api/actiongroups" , new Header[0]);
+
+        // Delete read only actiongroups
+        response = rh.executeDeleteRequest("/_opendistro/_security/api/actiongroups/create_index" , new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // Put read only actiongroups
+        response = rh.executePutRequest("/_opendistro/_security/api/actiongroups/create_index", FileHelper.loadFile("restapi/actiongroup_crud.json"), new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // Patch single read only actiongroups
+        response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups/create_index", "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // Patch multiple read only actiongroups
+        response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups", "[{ \"op\": \"replace\", \"path\": \"/create_index/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+    }
+
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/FlushCacheApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/FlushCacheApiTest.java
@@ -33,7 +33,7 @@ public class FlushCacheApiTest extends AbstractRestApiUnitTest {
 
 		// Only DELETE is allowed for flush cache
 		rh.keystore = "restapi/kirk-keystore.jks";
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		// GET
 		HttpResponse response = rh.executeGetRequest("/_opendistro/_security/api/cache");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/GetConfigurationApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/GetConfigurationApiTest.java
@@ -32,7 +32,7 @@ public class GetConfigurationApiTest extends AbstractRestApiUnitTest {
 
 		setup();
 		rh.keystore = "restapi/kirk-keystore.jks";
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		// wrong config name -> bad request
 		HttpResponse response = null;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/IndexMissingTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/IndexMissingTest.java
@@ -42,7 +42,7 @@ public class IndexMissingTest extends AbstractRestApiUnitTest {
 	protected void testHttpOperations() throws Exception {
 
 		rh.keystore = "restapi/kirk-keystore.jks";
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		// GET configuration
 		HttpResponse response = rh.executeGetRequest("_opendistro/_security/api/roles");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/MigrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/MigrationTests.java
@@ -42,7 +42,7 @@ public class MigrationTests extends SingleClusterTest {
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
 
         HttpResponse res = rh.executePostRequest("_opendistro/_security/api/migrate?pretty", "");
@@ -72,7 +72,7 @@ public class MigrationTests extends SingleClusterTest {
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
 
         HttpResponse res = rh.executePostRequest("_opendistro/_security/api/migrate?pretty", "");
@@ -100,7 +100,7 @@ public class MigrationTests extends SingleClusterTest {
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
 
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/api/validate?pretty");
@@ -122,7 +122,7 @@ public class MigrationTests extends SingleClusterTest {
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
 
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/api/validate?accept_invalid=true&pretty");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/OpenDistroSecurityApiAccessTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/OpenDistroSecurityApiAccessTest.java
@@ -36,7 +36,7 @@ public class OpenDistroSecurityApiAccessTest extends AbstractRestApiUnitTest {
 
 		// test with non-admin cert, must fail
 		rh.keystore = "restapi/node-0-keystore.jks";
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 		Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED,
 				rh.executeGetRequest("_opendistro/_security/api/internalusers").getStatusCode());
 		Assert.assertEquals(HttpStatus.SC_FORBIDDEN,

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RoleBasedAccessTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RoleBasedAccessTest.java
@@ -33,7 +33,7 @@ public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
 
 		setupWithRestRoles();
 
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 
 		// worf and sarek have access, worf has some endpoints disabled
 
@@ -206,7 +206,7 @@ public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
 		Assert.assertEquals(new SecurityJsonNode(DefaultObjectMapper.readTree(response.getBody())).getDotted("opendistro_security_role_starfleet_captains.index_permissions").get(0).get("allowed_actions").get(0).asString(), "blafasel");
 
 		// Try the same, but now with admin certificate
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		// admin
 		response = rh.executeGetRequest("/_opendistro/_security/api/internalusers/admin", encodeBasicHeader("la", "lu"));
@@ -225,7 +225,7 @@ public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
 
 		// -- test user, does not have any endpoints disabled, but has access to API, i.e. full access
 
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 
 		// GET actiongroups
 		// response = rh.executeGetRequest("_opendistro/_security/api/configuration/actiongroups", encodeBasicHeader("test", "test"));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiTest.java
@@ -39,7 +39,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         setup();
 
         rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         // check roles exists
         HttpResponse response = rh.executePutRequest("/_opendistro/_security/api/roles/admin", FileHelper.loadFile("restapi/simple_role.json"));
         System.out.println(response.getBody());
@@ -60,8 +60,8 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         setup();
 
         rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendHTTPClientCertificate = true;
-        HttpResponse response = rh.executeGetRequest("/_opendistro/_security/api/roles");
+        rh.sendAdminCertificate = true;
+        HttpResponse response = rh.executeGetRequest("_opendistro/_security/api/roles");
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         Assert.assertFalse(response.getBody().contains("_meta"));
     }
@@ -72,7 +72,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         setup();
 
         rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
 
         // check roles exists
         HttpResponse response = rh.executeGetRequest("/_opendistro/_security/api/roles");
@@ -124,15 +124,15 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
         // -- DELETE
 
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
 
         // Non-existing role
         response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/idonotexist", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
-        // read only role
+        // read only role, SuperAdmin can delete the read-only role
         response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/opendistro_security_transport_client", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         // hidden role
         response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/opendistro_security_internal", new Header[0]);
@@ -142,7 +142,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/opendistro_security_role_starfleet_captains", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
-        rh.sendHTTPClientCertificate = false;
+        rh.sendAdminCertificate = false;
 
         // user has only role starfleet left, role has READ access only
         checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "ships", 1);
@@ -151,7 +151,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         // So we also get a 403 FORBIDDEN when tring to add new document type
         checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "public", 0);
 
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         // remove also starfleet role, nothing is allowed anymore
         response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/opendistro_security_role_starfleet", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
@@ -191,9 +191,10 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         Assert.assertTrue(settings.get("cluster_permissions").asText().equals("Array expected"));
 
         // put read only role, must be forbidden
+        // But SuperAdmin can still create it
         response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_transport_client",
                 FileHelper.loadFile("restapi/roles_captains.json"), new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
 
         // put hidden role, must be forbidden
         response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_internal",
@@ -204,7 +205,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_role_starfleet",
                 FileHelper.loadFile("restapi/roles_starfleet.json"), new Header[0]);
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
-        rh.sendHTTPClientCertificate = false;
+        rh.sendAdminCertificate = false;
         checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "ships", 0);
 
         // now picard is only in opendistro_security_role_starfleet, which has write access to
@@ -216,25 +217,25 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         // ES7 only supports one doc type, so trying to create a second one leads to 400  BAD REQUEST
         checkWriteAccess(HttpStatus.SC_BAD_REQUEST, "picard", "picard", "sf", "public", 0);
 
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
 
         // restore captains role
         response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_role_starfleet_captains",
                 FileHelper.loadFile("restapi/roles_captains.json"), new Header[0]);
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
-        rh.sendHTTPClientCertificate = false;
+        rh.sendAdminCertificate = false;
         checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "ships", 0);
         checkWriteAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "ships", 0);
 
         // ES7 only supports one doc type, so trying to create a second one leads to 400  BAD REQUEST
         checkWriteAccess(HttpStatus.SC_BAD_REQUEST, "picard", "picard", "sf", "public", 0);
 
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_role_starfleet_captains",
                 FileHelper.loadFile("restapi/roles_complete_invalid.json"), new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
-//		rh.sendHTTPClientCertificate = true;
+//		rh.sendAdminCertificate = true;
 //		response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_role_starfleet_captains",
 //				FileHelper.loadFile("restapi/roles_multiple.json"), new Header[0]);
 //		Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
@@ -244,7 +245,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         // check tenants
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_role_starfleet_captains",
                 FileHelper.loadFile("restapi/roles_captains_tenants.json"), new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
@@ -310,22 +311,23 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
         // -- PATCH
         // PATCH on non-existing resource
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/roles/imnothere", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // PATCH read only resource, must be forbidden
-        rh.sendHTTPClientCertificate = true;
-        response = rh.executePatchRequest("/_opendistro/_security/api/roles/opendistro_security_transport_client", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        // SuperAdmin can patch it
+        rh.sendAdminCertificate = true;
+        response = rh.executePatchRequest("/_opendistro/_security/api/roles/opendistro_security_transport_client", "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         // PATCH hidden resource, must be not found
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/roles/opendistro_security_internal", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // PATCH value of hidden flag, must fail with validation error
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/roles/opendistro_security_role_starfleet", "[{ \"op\": \"add\", \"path\": \"/hidden\", \"value\": true }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         Assert.assertTrue(response.getBody(), response.getBody().matches(".*\"invalid_keys\"\\s*:\\s*\\{\\s*\"keys\"\\s*:\\s*\"hidden\"\\s*\\}.*"));
@@ -335,7 +337,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         // PATCH 
         /*
          * how to patch with new v7 config format?
-         * rh.sendHTTPClientCertificate = true;
+         * rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/roles/opendistro_security_role_starfleet", "[{ \"op\": \"add\", \"path\": \"/index_permissions/sf/ships/-\", \"value\": \"SEARCH\" }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rh.executeGetRequest("/_opendistro/_security/api/roles/opendistro_security_role_starfleet", new Header[0]);
@@ -349,38 +351,39 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
         // -- PATCH on whole config resource
         // PATCH on non-existing resource
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/roles", "[{ \"op\": \"add\", \"path\": \"/imnothere/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         // PATCH read only resource, must be forbidden
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/roles", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_transport_client/a\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         // PATCH hidden resource, must be bad request
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/roles", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_internal/a\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         // PATCH delete read only resource, must be forbidden
-        rh.sendHTTPClientCertificate = true;
+        // SuperAdmin can delete read only user
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/roles", "[{ \"op\": \"remove\", \"path\": \"/opendistro_security_transport_client\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         // PATCH hidden resource, must be bad request
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/roles", "[{ \"op\": \"remove\", \"path\": \"/opendistro_security_internal\"}]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         // PATCH value of hidden flag, must fail with validation error
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/roles", "[{ \"op\": \"add\", \"path\": \"/newnewnew\", \"value\": {  \"hidden\": true, \"index_permissions\" : [ {\"index_patterns\" : [ \"sf\" ],\"allowed_actions\" : [ \"OPENDISTRO_SECURITY_READ\" ]}] }}]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         Assert.assertTrue(response.getBody().matches(".*\"invalid_keys\"\\s*:\\s*\\{\\s*\"keys\"\\s*:\\s*\"hidden\"\\s*\\}.*"));
 
         // PATCH 
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/roles", "[{ \"op\": \"add\", \"path\": \"/bulknew1\", \"value\": {   \"index_permissions\" : [ {\"index_patterns\" : [ \"sf\" ],\"allowed_actions\" : [ \"OPENDISTRO_SECURITY_READ\" ]}] }}]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rh.executeGetRequest("/_opendistro/_security/api/roles/bulknew1", new Header[0]);
@@ -392,7 +395,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         Assert.assertTrue(permissions.contains("OPENDISTRO_SECURITY_READ"));
 
         // delete resource
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/roles", "[{ \"op\": \"remove\", \"path\": \"/bulknew1\"}]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rh.executeGetRequest("/_opendistro/_security/api/roles/bulknew1", new Header[0]);
@@ -409,4 +412,36 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
     }
+
+    @Test
+    public void testRolesApiForNonSuperAdmin() throws Exception {
+
+        setupWithRestRoles();
+
+        rh.keystore = "restapi/kirk-keystore.jks";
+        rh.sendAdminCertificate = false;
+        rh.sendHTTPClientCredentials = true;
+
+        HttpResponse response;
+
+        response = rh.executeGetRequest("_opendistro/_security/api/roles");
+
+        // Delete read only roles
+        response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/opendistro_security_transport_client" , new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // Put read only roles
+        response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_transport_client", "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // Patch single read only roles
+        response = rh.executePatchRequest("/_opendistro/_security/api/roles/opendistro_security_transport_client", "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // Patch multiple read only roles
+        response = rh.executePatchRequest("/_opendistro/_security/api/roles/", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_transport_client/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+    }
+
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesMappingApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesMappingApiTest.java
@@ -36,7 +36,7 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 		setup();
 
 		rh.keystore = "restapi/kirk-keystore.jks";
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		// check rolesmapping exists, old config api
 		HttpResponse response = rh.executeGetRequest("_opendistro/_security/api/rolesmapping");
@@ -90,15 +90,16 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 
 		// --- DELETE
 
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		// Non-existing role
 		response = rh.executeDeleteRequest("/_opendistro/_security/api/rolesmapping/idonotexist", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
 		// read only role
+		// SuperAdmin can delete read only role
 		response = rh.executeDeleteRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_library", new Header[0]);
-		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         // hidden role
         response = rh.executeDeleteRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_internal", new Header[0]);
@@ -108,7 +109,7 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 		response = rh.executeDeleteRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_captains", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		response = rh.executeGetRequest("_opendistro/_security/api/configuration/rolesmapping");
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 
 		// now picard is only in opendistro_security_role_starfleet, which has write access to
 		// public, but not to ships
@@ -118,13 +119,13 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 		// checkWriteAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "public", 1);
 
 		// remove also opendistro_security_role_starfleet, poor picard has no mapping left
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 		response = rh.executeDeleteRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 		checkAllSfForbidden();
 
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		// --- PUT
 
@@ -181,9 +182,10 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 		Assert.assertTrue(settings.get("backend_roles").equals("Array expected"));	
 
 		// Read only role mapping
+		// SuperAdmin can add read only roles - mappings
 		response = rh.executePutRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_library",
 				FileHelper.loadFile("restapi/rolesmapping_all_access.json"), new Header[0]);
-		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+		Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
 
         // hidden role
         response = rh.executePutRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_internal",
@@ -196,28 +198,29 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 
 	    // -- PATCH
         // PATCH on non-existing resource
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping/imnothere", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // PATCH read only resource, must be forbidden
-        rh.sendHTTPClientCertificate = true;
-        response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_library", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+		// SuperAdmin can patch read-only resource
+        rh.sendAdminCertificate = true;
+        response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_library", "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"foo\"] }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         // PATCH hidden resource, must be not found
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_internal", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // PATCH value of hidden flag, must fail with validation error
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_vulcans", "[{ \"op\": \"add\", \"path\": \"/hidden\", \"value\": true }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         Assert.assertTrue(response.getBody().matches(".*\"invalid_keys\"\\s*:\\s*\\{\\s*\"keys\"\\s*:\\s*\"hidden\"\\s*\\}.*"));
 
         // PATCH
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_vulcans", "[{ \"op\": \"add\", \"path\": \"/backend_roles/-\", \"value\": \"spring\" }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rh.executeGetRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_vulcans", new Header[0]);
@@ -229,28 +232,29 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 
         // -- PATCH on whole config resource
         // PATCH on non-existing resource
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping", "[{ \"op\": \"add\", \"path\": \"/imnothere/a\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         // PATCH read only resource, must be forbidden
-        rh.sendHTTPClientCertificate = true;
-        response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_role_starfleet_library/a\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+		// SuperAdmin can patch read only resource
+        rh.sendAdminCertificate = true;
+        response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_role_starfleet_library/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         // PATCH hidden resource, must be bad request
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_role_internal/a\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         // PATCH value of hidden flag, must fail with validation error
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_role_vulcans/hidden\", \"value\": true }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         Assert.assertTrue(response.getBody().matches(".*\"invalid_keys\"\\s*:\\s*\\{\\s*\"keys\"\\s*:\\s*\"hidden\"\\s*\\}.*"));
 
         // PATCH
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping", "[{ \"op\": \"add\", \"path\": \"/bulknew1\", \"value\": {  \"backend_roles\":[\"vulcanadmin\"]} }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rh.executeGetRequest("/_opendistro/_security/api/rolesmapping/bulknew1", new Header[0]);
@@ -261,7 +265,7 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
         Assert.assertTrue(permissions.contains("vulcanadmin"));
 
         // PATCH delete
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping", "[{ \"op\": \"remove\", \"path\": \"/bulknew1\"}]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rh.executeGetRequest("/_opendistro/_security/api/rolesmapping/bulknew1", new Header[0]);
@@ -303,7 +307,7 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 	}
 
 	private void checkAllSfAllowed() throws Exception {
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 		checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "ships", 1);
 		checkWriteAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "ships", 1);
 
@@ -312,20 +316,53 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 	}
 
 	private void checkAllSfForbidden() throws Exception {
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 		checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "ships", 1);
 		checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "ships", 1);
 	}
 
 	private HttpResponse deleteAndputNewMapping(String fileName) throws Exception {
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 		HttpResponse response = rh.executeDeleteRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_captains",
 				new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		response = rh.executePutRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_captains",
 				FileHelper.loadFile("restapi/"+fileName), new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 		return response;
+	}
+
+	@Test
+	public void testRolesMappingApiForNonSuperAdmin() throws Exception {
+
+		setupWithRestRoles();
+
+		rh.keystore = "restapi/kirk-keystore.jks";
+		rh.sendAdminCertificate = false;
+		rh.sendHTTPClientCredentials = true;
+
+		HttpResponse response;
+
+		response = rh.executeGetRequest("/_opendistro/_security/api/rolesmapping" , new Header[0]);
+
+		// Delete read only roles mapping
+		response = rh.executeDeleteRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_library" , new Header[0]);
+		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+		// Put read only roles mapping
+		response = rh.executePutRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_library",
+				FileHelper.loadFile("restapi/rolesmapping_all_access.json"), new Header[0]);
+		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+		// Patch single read only roles mapping
+		response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_library", "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
+		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+		// Patch multiple read only roles mapping
+		response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_role_starfleet_library/description\", \"value\": \"foo\" }]", new Header[0]);
+		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+
 	}
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/SecurityConfigApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/SecurityConfigApiTest.java
@@ -33,7 +33,7 @@ public class SecurityConfigApiTest extends AbstractRestApiUnitTest {
 		setup();
 
 		rh.keystore = "restapi/kirk-keystore.jks";
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		HttpResponse response = rh.executeGetRequest("/_opendistro/_security/api/securityconfig", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
@@ -59,7 +59,7 @@ public class SecurityConfigApiTest extends AbstractRestApiUnitTest {
         setup(settings);
 
         rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
 
         HttpResponse response = rh.executeGetRequest("/_opendistro/_security/api/securityconfig", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
@@ -34,12 +34,37 @@ import java.util.List;
 public class UserApiTest extends AbstractRestApiUnitTest {
 
     @Test
+    public void testOpenDistroSecurityRoles() throws Exception {
+
+        setup();
+
+        rh.keystore = "restapi/kirk-keystore.jks";
+        rh.sendAdminCertificate = true;
+
+        // initial configuration, 5 users
+        HttpResponse response = rh
+                .executeGetRequest("_opendistro/_security/api/" + CType.INTERNALUSERS.toLCString());
+        Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
+        Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
+        Assert.assertEquals(35, settings.size());
+
+        response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/newuser\", \"value\": {\"password\": \"newuser\", \"opendistro_security_roles\": [\"all_access\"] } }]", new Header[0]);
+        Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeGetRequest("/_opendistro/_security/api/internalusers/newuser", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"opendistro_security_roles\":[\"all_access\"]"));
+
+        checkGeneralAccess(HttpStatus.SC_OK, "newuser", "newuser");
+    }
+
+    @Test
     public void testUserApi() throws Exception {
 
         setup();
 
         rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
 
         // initial configuration, 5 users
         HttpResponse response = rh
@@ -104,28 +129,29 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 
         // -- PATCH
         // PATCH on non-existing resource
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/imnothere", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
-        // PATCH read only resource, must be forbidden
-        rh.sendHTTPClientCertificate = true;
-        response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/sarek", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        // PATCH read only resource, must be forbidden,
+        // but SuperAdmin can PATCH read-only resource
+        rh.sendAdminCertificate = true;
+        response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/sarek", "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         // PATCH hidden resource, must be not found
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/q", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // PATCH value of hidden flag, must fail with validation error
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/test", "[{ \"op\": \"add\", \"path\": \"/hidden\", \"value\": true }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         Assert.assertTrue(response.getBody().matches(".*\"invalid_keys\"\\s*:\\s*\\{\\s*\"keys\"\\s*:\\s*\"hidden\"\\s*\\}.*"));
 
         // PATCH password
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/test", "[{ \"op\": \"add\", \"path\": \"/password\", \"value\": \"neu\" }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rh.executeGetRequest("/_opendistro/_security/api/internalusers/test", new Header[0]);
@@ -136,28 +162,33 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 
         // -- PATCH on whole config resource
         // PATCH on non-existing resource
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/imnothere/a\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
-        // PATCH read only resource, must be forbidden
-        rh.sendHTTPClientCertificate = true;
+        // PATCH read only resource, must be forbidden,
+        // but SuperAdmin can PATCH read only resouce
+        rh.sendAdminCertificate = true;
+        response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/sarek/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        rh.sendAdminCertificate = false;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/sarek/a\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
 
         // PATCH hidden resource, must be bad request
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/q/a\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         // PATCH value of hidden flag, must fail with validation error
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/test/hidden\", \"value\": true }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         Assert.assertTrue(response.getBody().matches(".*\"invalid_keys\"\\s*:\\s*\\{\\s*\"keys\"\\s*:\\s*\"hidden\"\\s*\\}.*"));
 
         // PATCH
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/bulknew1\", \"value\": {\"password\": \"bla\", \"backend_roles\": [\"vulcan\"] } }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rh.executeGetRequest("/_opendistro/_security/api/internalusers/bulknew1", new Header[0]);
@@ -175,17 +206,18 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         checkGeneralAccess(HttpStatus.SC_UNAUTHORIZED, "nagilum", "nagilum");
 
         // add/update user, user is read only, forbidden
-        rh.sendHTTPClientCertificate = true;
+        // SuperAdmin can add read only users
+        rh.sendAdminCertificate = true;
         addUserWithHash("sarek", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m",
-                HttpStatus.SC_FORBIDDEN);
+                HttpStatus.SC_OK);
 
         // add/update user, user is hidden, forbidden
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         addUserWithHash("q", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m",
                 HttpStatus.SC_FORBIDDEN);
 
         // add users
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         addUserWithHash("nagilum", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m",
                 HttpStatus.SC_CREATED);
 
@@ -193,7 +225,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         checkGeneralAccess(HttpStatus.SC_OK, "nagilum", "nagilum");
 
         // try remove user, no username
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executeDeleteRequest("/_opendistro/_security/api/internalusers", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
@@ -203,7 +235,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 
         // try remove readonly user
         response = rh.executeDeleteRequest("/_opendistro/_security/api/internalusers/sarek", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         // try remove hidden user
         response = rh.executeDeleteRequest("/_opendistro/_security/api/internalusers/q", new Header[0]);
@@ -213,21 +245,21 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         deleteUser("nagilum");
 
         // Access must be forbidden now
-        rh.sendHTTPClientCertificate = false;
+        rh.sendAdminCertificate = false;
         checkGeneralAccess(HttpStatus.SC_UNAUTHORIZED, "nagilum", "nagilum");
 
         // use password instead of hash
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         addUserWithPassword("nagilum", "correctpassword", HttpStatus.SC_CREATED);
 
-        rh.sendHTTPClientCertificate = false;
+        rh.sendAdminCertificate = false;
         checkGeneralAccess(HttpStatus.SC_UNAUTHORIZED, "nagilum", "wrongpassword");
         checkGeneralAccess(HttpStatus.SC_OK, "nagilum", "correctpassword");
 
         deleteUser("nagilum");
 
         // Check unchanged password functionality
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
 
         // new user, password or hash is mandatory
         addUserWithoutPasswordOrHash("nagilum", new String[]{"starfleet"}, HttpStatus.SC_BAD_REQUEST);
@@ -248,38 +280,38 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         setupStarfleetIndex();
 
         // wrong datatypes in roles file
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePutRequest("/_opendistro/_security/api/internalusers/picard", FileHelper.loadFile("restapi/users_wrong_datatypes.json"), new Header[0]);
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         Assert.assertEquals(AbstractConfigurationValidator.ErrorType.WRONG_DATATYPE.getMessage(), settings.get("reason"));
         Assert.assertTrue(settings.get("backend_roles").equals("Array expected"));
-        rh.sendHTTPClientCertificate = false;
+        rh.sendAdminCertificate = false;
 
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePutRequest("/_opendistro/_security/api/internalusers/picard", FileHelper.loadFile("restapi/users_wrong_datatypes.json"), new Header[0]);
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         Assert.assertEquals(AbstractConfigurationValidator.ErrorType.WRONG_DATATYPE.getMessage(), settings.get("reason"));
         Assert.assertTrue(settings.get("backend_roles").equals("Array expected"));
-        rh.sendHTTPClientCertificate = false;
+        rh.sendAdminCertificate = false;
 
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePutRequest("/_opendistro/_security/api/internalusers/picard", FileHelper.loadFile("restapi/users_wrong_datatypes2.json"), new Header[0]);
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         Assert.assertEquals(AbstractConfigurationValidator.ErrorType.WRONG_DATATYPE.getMessage(), settings.get("reason"));
         Assert.assertTrue(settings.get("password").equals("String expected"));
         Assert.assertTrue(settings.get("backend_roles") == null);
-        rh.sendHTTPClientCertificate = false;
+        rh.sendAdminCertificate = false;
 
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePutRequest("/_opendistro/_security/api/internalusers/picard", FileHelper.loadFile("restapi/users_wrong_datatypes3.json"), new Header[0]);
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         Assert.assertEquals(AbstractConfigurationValidator.ErrorType.WRONG_DATATYPE.getMessage(), settings.get("reason"));
         Assert.assertTrue(settings.get("backend_roles").equals("Array expected"));
-        rh.sendHTTPClientCertificate = false;
+        rh.sendAdminCertificate = false;
 
         // use backendroles when creating user. User picard does not exist in
         // the internal user DB
@@ -303,7 +335,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "ships", 0);
         checkWriteAccess(HttpStatus.SC_CREATED, "picard", "picard", "sf", "ships", 1);
 
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executeGetRequest("/_opendistro/_security/api/internalusers/picard", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
@@ -336,7 +368,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         setup(nodeSettings);
 
         rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
 
         // initial configuration, 5 users
         HttpResponse response = rh
@@ -411,7 +443,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         setup();
 
         rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
 
         // initial configuration, 5 users
         HttpResponse response = rh
@@ -440,7 +472,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         setup();
 
         rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
 
         // initial configuration, 5 users
         HttpResponse response;
@@ -464,5 +496,35 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
     }
 
+    @Test
+    public void testUserApiForNonSuperAdmin() throws Exception {
+
+        setupWithRestRoles();
+
+        rh.keystore = "restapi/kirk-keystore.jks";
+        rh.sendAdminCertificate = false;
+        rh.sendHTTPClientCredentials = true;
+
+        HttpResponse response;
+
+        response = rh.executeGetRequest("/_opendistro/_security/api/internalusers" , new Header[0]);
+
+        // Delete read only user
+        response = rh.executeDeleteRequest("/_opendistro/_security/api/internalusers/sarek" , new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // Put read only users
+        response = rh.executePutRequest("/_opendistro/_security/api/internalusers/sarek", "[{ \"op\": \"add\", \"path\": \"/sarek/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // Patch single read only user
+        response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/sarek", "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // Patch multiple read only users
+        response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/sarek/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+    }
 
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
@@ -34,31 +34,6 @@ import java.util.List;
 public class UserApiTest extends AbstractRestApiUnitTest {
 
     @Test
-    public void testOpenDistroSecurityRoles() throws Exception {
-
-        setup();
-
-        rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendAdminCertificate = true;
-
-        // initial configuration, 5 users
-        HttpResponse response = rh
-                .executeGetRequest("_opendistro/_security/api/" + CType.INTERNALUSERS.toLCString());
-        Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
-        Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals(35, settings.size());
-
-        response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/newuser\", \"value\": {\"password\": \"newuser\", \"opendistro_security_roles\": [\"all_access\"] } }]", new Header[0]);
-        Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
-
-        response = rh.executeGetRequest("/_opendistro/_security/api/internalusers/newuser", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        Assert.assertTrue(response.getBody().contains("\"opendistro_security_roles\":[\"all_access\"]"));
-
-        checkGeneralAccess(HttpStatus.SC_OK, "newuser", "newuser");
-    }
-
-    @Test
     public void testUserApi() throws Exception {
 
         setup();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/SSLTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/SSLTest.java
@@ -99,7 +99,7 @@ public class SSLTest extends SingleClusterTest {
         RestHelper rh = restHelper();
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "node-untspec5-keystore.p12";
         
         System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty&show_dn=true"));
@@ -223,7 +223,7 @@ public class SSLTest extends SingleClusterTest {
         RestHelper rh = restHelper();
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
 
         System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
@@ -257,7 +257,7 @@ public class SSLTest extends SingleClusterTest {
         RestHelper rh = restHelper();
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         
         System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
@@ -298,7 +298,7 @@ public class SSLTest extends SingleClusterTest {
         RestHelper rh = restHelper();
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         
         System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
@@ -335,7 +335,7 @@ public class SSLTest extends SingleClusterTest {
         RestHelper rh = restHelper();
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         
         System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
@@ -398,7 +398,7 @@ public class SSLTest extends SingleClusterTest {
         RestHelper rh = restHelper();
         rh.enableHTTPClientSSL = false;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = false;
+        rh.sendAdminCertificate = false;
         
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
@@ -422,7 +422,7 @@ public class SSLTest extends SingleClusterTest {
         RestHelper rh = restHelper();
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = false;
+        rh.sendAdminCertificate = false;
         
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
@@ -446,7 +446,7 @@ public class SSLTest extends SingleClusterTest {
         RestHelper rh = restHelper();
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = false;
+        rh.sendAdminCertificate = false;
         
         try {
             rh.executeSimpleRequest("");
@@ -478,7 +478,7 @@ public class SSLTest extends SingleClusterTest {
         RestHelper rh = restHelper();
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = false;
+        rh.sendAdminCertificate = false;
         rh.enableHTTPClientSSLv3Only = true;
         
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
@@ -713,7 +713,7 @@ public class SSLTest extends SingleClusterTest {
         RestHelper rh = restHelper();
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         
         log.debug("Elasticsearch started");
 
@@ -773,7 +773,7 @@ public class SSLTest extends SingleClusterTest {
         RestHelper rh = restHelper();
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
     }
@@ -799,7 +799,7 @@ public class SSLTest extends SingleClusterTest {
         RestHelper rh = restHelper();
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
 
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
         
@@ -904,7 +904,7 @@ public class SSLTest extends SingleClusterTest {
         RestHelper rh = restHelper();
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         
         System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
@@ -946,7 +946,7 @@ public class SSLTest extends SingleClusterTest {
         RestHelper rh = restHelper();
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
     

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/rest/RestHelper.java
@@ -43,6 +43,9 @@ import javax.net.ssl.SSLContext;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
@@ -56,6 +59,7 @@ import org.apache.http.config.SocketConfig;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
@@ -73,8 +77,9 @@ public class RestHelper {
 	
 	public boolean enableHTTPClientSSL = true;
 	public boolean enableHTTPClientSSLv3Only = false;
-	public boolean sendHTTPClientCertificate = false;
+	public boolean sendAdminCertificate = false;
 	public boolean trustHTTPServerCertificate = true;
+	public boolean sendHTTPClientCredentials = false;
 	public String keystore = "node-0-keystore.jks";
 	public final String prefix;
 	//public String truststore = "truststore.jks";
@@ -195,6 +200,13 @@ public class RestHelper {
 
 		final HttpClientBuilder hcb = HttpClients.custom();
 
+		if (sendHTTPClientCredentials) {
+			CredentialsProvider provider = new BasicCredentialsProvider();
+			UsernamePasswordCredentials credentials = new UsernamePasswordCredentials("sarek", "sarek");
+			provider.setCredentials(AuthScope.ANY, credentials);
+			hcb.setDefaultCredentialsProvider(provider);
+		}
+
 		if (enableHTTPClientSSL) {
 
 			log.debug("Configure HTTP client with SSL");
@@ -218,7 +230,7 @@ public class RestHelper {
 				sslContextbBuilder.loadTrustMaterial(myTrustStore, null);
 			}
 
-			if (sendHTTPClientCertificate) {
+			if (sendAdminCertificate) {
 				sslContextbBuilder.loadKeyMaterial(keyStore, "changeit".toCharArray());
 			}
 


### PR DESCRIPTION
Functionality - Allow superAdmin to add, update and delete the reserved configuration such as roles, roles_mapping, internal_users, action_groups and tenants. Till now, the reserved were loaded from the default configuration present in yml files and now superAdmin has the privileges to do the same.

Testing - Tested on local to create, update and delete config.

Add the Reserved configuration -

curl -X PUT https://localhost:9200/_opendistro/_security/api/roles/palash_role -k -H 'Content-Type: application/json' -d '

{
"reserved": true,
"description": "This is Palash default role",
"cluster_permissions": [],
"index_permissions" : [
{
"index_patterns" : [],
"fls" : [],
"masked_fields" : [ ],
"allowed_actions" : [
"crud","read"
]
}
],
"tenant_permissions": []
}'
{"status":"CREATED","message":"'palash_role' created."}

Update the reserved configuration
curl -X PUT https://localhost:9200/_opendistro/_security/api/roles/palash_role -k -H 'Content-Type: application/json' -d '
{
"reserved": true,
"description": "This is Palash default role",
"cluster_permissions": [],
"index_permissions" : [
{
"index_patterns" : [],
"fls" : [],
"masked_fields" : [ ],
"allowed_actions" : [
"crud"
]
}
],
"tenant_permissions": []
}'
{"status":"OK","message":"'palash_role' updated."}

Delete the reserved configuration
curl -X DELETE https://localhost:9200/_opendistro/_security/api/roles/palash_role -k
{"status":"OK","message":"'palash_role' deleted."}