### PR TITLE
Allow SuperAdmin to update/delete/add read only config such as action…

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/AdminDNs.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/AdminDNs.java
@@ -83,7 +83,7 @@ public class AdminDNs {
         }
        
         log.debug("Loaded {} admin DN's {}",adminDn.size(),  adminDn);
-        
+
         final Settings impersonationDns = settings.getByPrefix(ConfigConstants.OPENDISTRO_SECURITY_AUTHCZ_IMPERSONATION_DN+".");
         
         for (String dnString:impersonationDns.keySet()) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
@@ -195,7 +195,7 @@ public class AccountApiAction extends AbstractApiAction {
             return;
         }
 
-        if (isReadOnly(existingAsSettings.v2(), username)) {
+        if (!isReadOnlyAndAccessible(existingAsSettings.v2(), username)) {
             forbidden(channel, "Resource '"+ username +"' is read-only.");
             return;
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/ActionGroupsApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/ActionGroupsApiAction.java
@@ -71,7 +71,7 @@ public class ActionGroupsApiAction extends PatchableResourceApiAction {
 
 	@Override
 	protected AbstractConfigurationValidator getValidator(final RestRequest request, BytesReference ref, Object... param) {
-		return new ActionGroupValidator(request, ref, this.settings, param);
+		return new ActionGroupValidator(request, isSuperAdmin(), ref, this.settings, param);
 	}
 
 	@Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -115,9 +115,7 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
         }
 
         // check if resource is writeable
-        Boolean readOnly = configurationSettings.v2().getAsBoolean(username + "." + ConfigConstants.CONFIGKEY_READONLY,
-                Boolean.FALSE);
-        if (readOnly) {
+        if (!isReadOnlyAndAccessible(configurationSettings.v2(), username)) {
             forbidden(channel, "Resource '" + username + "' is read-only.");
             return;
         }
@@ -228,6 +226,6 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
 
     @Override
     protected AbstractConfigurationValidator getValidator(RestRequest request, BytesReference ref, Object... params) {
-        return new InternalUsersValidator(request, ref, this.settings, params);
+        return new InternalUsersValidator(request, isSuperAdmin(), ref, this.settings, params);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
@@ -107,7 +107,8 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
             return;
         }
 
-        if (isReadOnly(existingAsSettings.v2(), name)) {
+
+        if (!isReadOnlyAndAccessible(existingAsSettings.v2(), name)) {
             forbidden(channel, "Resource '" + name + "' is read-only.");
             return;
         }
@@ -186,7 +187,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
 
             if (oldResource != null && !oldResource.equals(patchedResource)) {
 
-                if (isReadOnly(existingAsSettings.v2(), resourceName)) {
+                if (!isReadOnlyAndAccessible(existingAsSettings.v2(), resourceName)) {
                     forbidden(channel, "Resource '" + resourceName + "' is read-only.");
                     return;
                 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiAction.java
@@ -61,7 +61,7 @@ public class RolesApiAction extends PatchableResourceApiAction {
 
 	@Override
 	protected AbstractConfigurationValidator getValidator(RestRequest request, BytesReference ref, Object... param) {
-		return new RolesValidator(request, ref, this.settings, param);
+		return new RolesValidator(request, isSuperAdmin(), ref, this.settings, param);
 	}
 
 	@Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesMappingApiAction.java
@@ -62,7 +62,7 @@ public class RolesMappingApiAction extends PatchableResourceApiAction {
 
 	@Override
 	protected AbstractConfigurationValidator getValidator(RestRequest request, BytesReference ref, Object... param) {
-		return new RolesMappingValidator(request, ref, this.settings, param);
+		return new RolesMappingValidator(request, isSuperAdmin(), ref, this.settings, param);
 	}
 
 	@Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/AbstractConfigurationValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/AbstractConfigurationValidator.java
@@ -146,6 +146,7 @@ public abstract class AbstractConfigurationValidator {
         Set<String> allowed = new HashSet<>(allowedKeys.keySet());
         requested.removeAll(allowed);
         this.invalidKeys.addAll(requested);
+
         boolean valid = missingMandatoryKeys.isEmpty() && invalidKeys.isEmpty() && missingMandatoryOrKeys.isEmpty();
         if (!valid) {
             this.errorType = ErrorType.INVALID_CONFIGURATION;
@@ -264,7 +265,7 @@ public abstract class AbstractConfigurationValidator {
     }
 
     public static enum DataType {
-        STRING, ARRAY, OBJECT;
+        STRING, ARRAY, OBJECT, BOOLEAN;
     }
 
     public static enum ErrorType {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/ActionGroupValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/ActionGroupValidator.java
@@ -22,10 +22,11 @@ import org.elasticsearch.rest.RestRequest.Method;
 
 public class ActionGroupValidator extends AbstractConfigurationValidator {
 
-	public ActionGroupValidator(final RestRequest request, BytesReference ref, final Settings esSettings, Object... param) {
+	public ActionGroupValidator(final RestRequest request, boolean isSuperAdmin, BytesReference ref, final Settings esSettings, Object... param) {
 		super(request, ref, esSettings, param);
 		this.payloadMandatory = true;
 		allowedKeys.put("permissions", DataType.ARRAY);
+		if (isSuperAdmin) allowedKeys.put("readonly" , DataType.BOOLEAN);
 		mandatoryKeys.add("permissions");
 	}
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/InternalUsersValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/InternalUsersValidator.java
@@ -21,11 +21,12 @@ import org.elasticsearch.rest.RestRequest;
 
 public class InternalUsersValidator extends CredentialsValidator {
 
-    public InternalUsersValidator(final RestRequest request, BytesReference ref, final Settings esSettings,
+    public InternalUsersValidator(final RestRequest request, boolean isSuperAdmin, BytesReference ref, final Settings esSettings,
                                   Object... param) {
         super(request, ref, esSettings, param);
         allowedKeys.put("roles", DataType.ARRAY);
         allowedKeys.put("attributes", DataType.OBJECT);
         allowedKeys.put("username", DataType.STRING);
+        if (isSuperAdmin) allowedKeys.put("readonly", DataType.BOOLEAN);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/RolesMappingValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/RolesMappingValidator.java
@@ -22,12 +22,13 @@ import org.elasticsearch.rest.RestRequest.Method;
 
 public class RolesMappingValidator extends AbstractConfigurationValidator {
 
-	public RolesMappingValidator(final RestRequest request, final BytesReference ref, final Settings esSettings, Object... param) {
+	public RolesMappingValidator(final RestRequest request, boolean isSuperAdmin, final BytesReference ref, final Settings esSettings, Object... param) {
 		super(request, ref, esSettings, param);
 		this.payloadMandatory = true;
 		allowedKeys.put("backendroles", DataType.ARRAY);
 		allowedKeys.put("hosts", DataType.ARRAY);
 		allowedKeys.put("users", DataType.ARRAY);
+		if (isSuperAdmin) allowedKeys.put("readonly", DataType.BOOLEAN);
 
 		mandatoryOrKeys.add("backendroles");
 		mandatoryOrKeys.add("hosts");

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/RolesValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/RolesValidator.java
@@ -27,15 +27,18 @@ import com.jayway.jsonpath.ReadContext;
 
 public class RolesValidator extends AbstractConfigurationValidator {
 
-	public RolesValidator(final RestRequest request, final BytesReference ref, final Settings esSettings, Object... param) {
+	public RolesValidator(final RestRequest request, boolean isSuperAdmin, final BytesReference ref, final Settings esSettings, Object... param) {
 		super(request, ref, esSettings, param);
 		this.payloadMandatory = true;
+
 		allowedKeys.put("indices", DataType.OBJECT);
 		allowedKeys.put("cluster", DataType.ARRAY);
 		allowedKeys.put("tenants", DataType.OBJECT);
+        if (isSuperAdmin) allowedKeys.put("readonly", DataType.BOOLEAN);
 
 		mandatoryOrKeys.add("indices");
 		mandatoryOrKeys.add("cluster");
+
 	}
 
     @Override

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/HttpIntegrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/HttpIntegrationTests.java
@@ -369,7 +369,7 @@ public class HttpIntegrationTests extends SingleClusterTest {
         
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "spock-keystore.jks";
         Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_search").getStatusCode());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, rh.executePutRequest(".opendistro_security/security/x", "{}").getStatusCode());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/InitializationIntegrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/InitializationIntegrationTests.java
@@ -77,7 +77,7 @@ public class InitializationIntegrationTests extends SingleClusterTest {
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         Assert.assertEquals(HttpStatus.SC_SERVICE_UNAVAILABLE, rh.executePutRequest(".opendistro_security/config/0", "{}", encodeBasicHeader("___", "")).getStatusCode());
         Assert.assertEquals(HttpStatus.SC_SERVICE_UNAVAILABLE, rh.executePutRequest(".opendistro_security/sg/config", "{}", encodeBasicHeader("___", "")).getStatusCode());
         

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/SecurityAdminTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/SecurityAdminTests.java
@@ -117,7 +117,7 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
         System.out.println(rh.executePutRequest(".opendistro_security/security/roles", FileHelper.loadFile("roles_invalidxcontent.yml")).getBody());;
         Assert.assertEquals(HttpStatus.SC_OK, rh.executePutRequest(".opendistro_security/security/roles", "{\"roles\":\"dummy\"}").getStatusCode());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/AbstractAuditlogiUnitTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/AbstractAuditlogiUnitTest.java
@@ -62,15 +62,15 @@ public abstract class AbstractAuditlogiUnitTest extends SingleClusterTest {
     }
 
     protected void setupStarfleetIndex() throws Exception {
-        final boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
+        final boolean sendAdminCertificate = rh.sendAdminCertificate;
         final String keystore = rh.keystore;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "auditlog/kirk-keystore.jks";
         rh.executePutRequest("sf", null, new Header[0]);
         rh.executePutRequest("sf/public/0?refresh", "{\"number\" : \"NCC-1701-D\"}", new Header[0]);
         rh.executePutRequest("sf/public/0?refresh", "{\"some\" : \"value\"}", new Header[0]);
         rh.executePutRequest("sf/public/0?refresh", "{\"some\" : \"value\"}", new Header[0]);
-        rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+        rh.sendAdminCertificate = sendAdminCertificate;
         rh.keystore = keystore;
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/compliance/ComplianceAuditlogTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/compliance/ComplianceAuditlogTest.java
@@ -49,14 +49,14 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
                 .build();
 
         setup(additionalSettings);
-        final boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
+        final boolean sendAdminCertificate = rh.sendAdminCertificate;
         final String keystore = rh.keystore;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "auditlog/kirk-keystore.jks";
         rh.executePutRequest("emp/doc/0?refresh", "{\"Designation\" : \"CEO\", \"Gender\" : \"female\", \"Salary\" : 100}", new Header[0]);
         rh.executePutRequest("emp/doc/1?refresh", "{\"Designation\" : \"IT\", \"Gender\" : \"male\", \"Salary\" : 200}", new Header[0]);
         rh.executePutRequest("emp/doc/2?refresh", "{\"Designation\" : \"IT\", \"Gender\" : \"female\", \"Salary\" : 300}", new Header[0]);
-        rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+        rh.sendAdminCertificate = sendAdminCertificate;
         rh.keystore = keystore;
 
         System.out.println("#### test source includes");
@@ -103,14 +103,14 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
                 .build();
 
         setup(additionalSettings);
-        final boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
+        final boolean sendAdminCertificate = rh.sendAdminCertificate;
         final String keystore = rh.keystore;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "auditlog/kirk-keystore.jks";
         rh.executePutRequest("emp/doc/0?refresh", "{\"Designation\" : \"CEO\", \"Gender\" : \"female\", \"Salary\" : 100}", new Header[0]);
         rh.executePutRequest("emp/doc/1?refresh", "{\"Designation\" : \"IT\", \"Gender\" : \"male\", \"Salary\" : 200}", new Header[0]);
         rh.executePutRequest("emp/doc/2?refresh", "{\"Designation\" : \"IT\", \"Gender\" : \"female\", \"Salary\" : 300}", new Header[0]);
-        rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+        rh.sendAdminCertificate = sendAdminCertificate;
         rh.keystore = keystore;
 
         System.out.println("#### test source includes");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/compliance/RestApiComplianceAuditlogTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/compliance/RestApiComplianceAuditlogTest.java
@@ -81,7 +81,7 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
 
         HttpResponse response = rh.executePutRequest("_opendistro/_security/api/user/compuser?pretty", body);
@@ -117,7 +117,7 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
         System.out.println("----rest");
         HttpResponse response = rh.executeGetRequest("_opendistro/_security/api/rolesmapping/opendistro_security_all_access?pretty");
@@ -209,7 +209,7 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
         System.out.println("req");
         HttpResponse response = rh.executeGetRequest("_opendistro/_security/api/internalusers/admin?pretty");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/integration/BasicAuditlogTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/integration/BasicAuditlogTest.java
@@ -490,12 +490,12 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         setup(additionalSettings);
         setupStarfleetIndex();
 
-        final boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
+        final boolean sendAdminCertificate = rh.sendAdminCertificate;
         final String keystore = rh.keystore;
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         rh.keystore = "auditlog/kirk-keystore.jks";
         HttpResponse res = rh.executeGetRequest("_cat/indices", new Header[0]);
-        rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+        rh.sendAdminCertificate = sendAdminCertificate;
         rh.keystore = keystore;
 
         Assert.assertTrue(res.getBody().contains("auditlog-20"));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
@@ -107,35 +107,35 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
 	}
 
 	protected void deleteUser(String username) throws Exception {
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = true;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = true;
 		HttpResponse response = rh.executeDeleteRequest("/_opendistro/_security/api/user/" + username, new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 	}
 
 	protected void addUserWithPassword(String username, String password, int status) throws Exception {
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = true;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = true;
 		HttpResponse response = rh.executePutRequest("/_opendistro/_security/api/user/" + username,
 				"{\"password\": \"" + password + "\"}", new Header[0]);
 		Assert.assertEquals(status, response.getStatusCode());
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 	}
 
     protected void addDotUserWithPassword(String usernameWithDots, String password, int status, boolean replace) throws Exception {
         Assert.assertTrue(usernameWithDots.contains("."));
-        boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-        rh.sendHTTPClientCertificate = true;
+        boolean sendAdminCertificate = rh.sendAdminCertificate;
+        rh.sendAdminCertificate = true;
         HttpResponse response = rh.executePutRequest("/_opendistro/_security/api/user/" + usernameWithDots.replace('.', replace?'_':'.'),
                 "{\"password\": \"" + password + "\",\"username\":\""+usernameWithDots+"\"}", new Header[0]);
         Assert.assertEquals(status, response.getStatusCode());
-        rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+        rh.sendAdminCertificate = sendAdminCertificate;
     }
 
 	protected void addUserWithPassword(String username, String password, String[] roles, int status) throws Exception {
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = true;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = true;
 		String payload = "{" + "\"password\": \"" + password + "\"," + "\"roles\": [";
 		for (int i = 0; i < roles.length; i++) {
 			payload += "\"" + roles[i] + "\"";
@@ -146,12 +146,12 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
 		payload += "]}";
 		HttpResponse response = rh.executePutRequest("/_opendistro/_security/api/user/" + username, payload, new Header[0]);
 		Assert.assertEquals(status, response.getStatusCode());
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 	}
 
 	protected void addUserWithoutPasswordOrHash(String username, String[] roles, int status) throws Exception {
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = true;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = true;
 		String payload = "{ \"roles\": [";
 		for (int i = 0; i < roles.length; i++) {
 			payload += "\" " + roles[i] + " \"";
@@ -162,7 +162,7 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
 		payload += "]}";
 		HttpResponse response = rh.executePutRequest("/_opendistro/_security/api/user/" + username, payload, new Header[0]);
 		Assert.assertEquals(status, response.getStatusCode());
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 	}
 
 	protected void addUserWithHash(String username, String hash) throws Exception {
@@ -170,44 +170,44 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
 	}
 
 	protected void addUserWithHash(String username, String hash, int status) throws Exception {
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = true;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = true;
 		HttpResponse response = rh.executePutRequest("/_opendistro/_security/api/user/" + username, "{\"hash\": \"" + hash + "\"}",
 				new Header[0]);
 		Assert.assertEquals(status, response.getStatusCode());
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 	}
 
     protected void addDotUserUserWithHash(String usernameWithDots, String hash, int status, boolean replace) throws Exception {
         Assert.assertTrue(usernameWithDots.contains("."));
-        boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-        rh.sendHTTPClientCertificate = true;
+        boolean sendAdminCertificate = rh.sendAdminCertificate;
+        rh.sendAdminCertificate = true;
         HttpResponse response = rh.executePutRequest("/_opendistro/_security/api/user/" + usernameWithDots.replace('.', replace?'_':'.'),
                 "{\"hash\": \"" + hash + "\",\"username\":\""+usernameWithDots+"\"}", new Header[0]);
         Assert.assertEquals(status, response.getStatusCode());
-        rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+        rh.sendAdminCertificate = sendAdminCertificate;
     }
 
 	protected void checkGeneralAccess(int status, String username, String password) throws Exception {
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = false;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = false;
 		Assert.assertEquals(status,
 				rh.executeGetRequest("",
 						encodeBasicHeader(username, password))
 						.getStatusCode());
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 	}
 
 	protected String checkReadAccess(int status, String username, String password, String indexName, String type,
 			int id) throws Exception {
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = false;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = false;
 		String action = indexName + "/" + type + "/" + id;
 		HttpResponse response = rh.executeGetRequest(action,
 				encodeBasicHeader(username, password));
 		int returnedStatus = response.getStatusCode();
 		Assert.assertEquals(status, returnedStatus);
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 		return response.getBody();
 
 	}
@@ -215,25 +215,25 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
 	protected String checkWriteAccess(int status, String username, String password, String indexName, String type,
 			int id) throws Exception {
 
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = false;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = false;
 		String action = indexName + "/" + type + "/" + id;
 		String payload = "{\"value\" : \"true\"}";
 		HttpResponse response = rh.executePutRequest(action, payload,
 				encodeBasicHeader(username, password));
 		int returnedStatus = response.getStatusCode();
 		Assert.assertEquals(status, returnedStatus);
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 		return response.getBody();
 	}
 
 	protected void setupStarfleetIndex() throws Exception {
-		boolean sendHTTPClientCertificate = rh.sendHTTPClientCertificate;
-		rh.sendHTTPClientCertificate = true;
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = true;
 		rh.executePutRequest("sf", null, new Header[0]);
 		rh.executePutRequest("sf/ships/0", "{\"number\" : \"NCC-1701-D\"}", new Header[0]);
 		rh.executePutRequest("sf/public/0", "{\"some\" : \"value\"}", new Header[0]);
-		rh.sendHTTPClientCertificate = sendHTTPClientCertificate;
+		rh.sendAdminCertificate = sendAdminCertificate;
 	}
 
 	protected Settings defaultNodeSettings(boolean enableRestSSL) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
@@ -116,9 +116,9 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
 
         // create users from - resources/restapi/internal_users.yml
         rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executeGetRequest("_opendistro/_security/api/configuration/" + ConfigConstants.CONFIGNAME_INTERNAL_USERS);
-        rh.sendHTTPClientCertificate = false;
+        rh.sendAdminCertificate = false;
         Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
 
         // test - reserved user - sarek
@@ -142,7 +142,7 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
 
         // test - admin with admin cert - internal user does not exist
         rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executeGetRequest(ENDPOINT, encodeBasicHeader("admin", "admin"));
         body = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
         assertEquals("CN=kirk,OU=client,O=client,L=Test,C=DE", body.get("user_name"));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/FlushCacheApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/FlushCacheApiTest.java
@@ -33,7 +33,7 @@ public class FlushCacheApiTest extends AbstractRestApiUnitTest {
 
 		// Only DELETE is allowed for flush cache
 		rh.keystore = "restapi/kirk-keystore.jks";
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		// GET
 		HttpResponse response = rh.executeGetRequest("/_opendistro/_security/api/cache");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/GetConfigurationApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/GetConfigurationApiTest.java
@@ -30,7 +30,7 @@ public class GetConfigurationApiTest extends AbstractRestApiUnitTest {
 
 		setup();
 		rh.keystore = "restapi/kirk-keystore.jks";
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		// wrong config name -> bad request
 		HttpResponse response = rh.executeGetRequest("_opendistro/_security/api/configuration/doesnotexists");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/IndexMissingTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/IndexMissingTest.java
@@ -44,7 +44,7 @@ public class IndexMissingTest extends AbstractRestApiUnitTest {
 	protected void testHttpOperations() throws Exception {
 
 		rh.keystore = "restapi/kirk-keystore.jks";
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		// GET configuration
 		HttpResponse response = rh.executeGetRequest("_opendistro/_security/api/configuration/roles");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/OpenDistroSecurityApiAccessTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/OpenDistroSecurityApiAccessTest.java
@@ -36,7 +36,7 @@ public class OpenDistroSecurityApiAccessTest extends AbstractRestApiUnitTest {
 
 		// test with non-admin cert, must fail
 		rh.keystore = "restapi/node-0-keystore.jks";
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 		Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED,
 				rh.executeGetRequest("_opendistro/_security/api/configuration/internalusers").getStatusCode());
 		Assert.assertEquals(HttpStatus.SC_FORBIDDEN,

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RestApInfoEndpointTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RestApInfoEndpointTest.java
@@ -33,7 +33,7 @@ public class RestApInfoEndpointTest extends AbstractRestApiUnitTest {
 
 		setupWithRestRoles();
 
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 
 		HttpResponse response = rh.executeGetRequest("/_opendistro/_security/api/permissionsinfo", encodeBasicHeader("worf", "worf"));
 		System.out.println(response.getBody());
@@ -58,7 +58,7 @@ public class RestApInfoEndpointTest extends AbstractRestApiUnitTest {
 
 		setup();
 
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 
 		HttpResponse response = rh.executeGetRequest("/_opendistro/_security/api/permissionsinfo", encodeBasicHeader("admin", "admin"));
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RoleBasedAccessTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RoleBasedAccessTest.java
@@ -31,7 +31,7 @@ public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
 
 		setupWithRestRoles();
 
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 
 		// worf and sarek have access, worf has some endpoints disabled
 
@@ -206,7 +206,7 @@ public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
 		Assert.assertEquals(settings.getAsList("opendistro_security_role_starfleet_captains.indices.hulla.dulla").get(0), "blafasel");
 
 		// Try the same, but now with admin certificate
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		// admin
 		response = rh.executeGetRequest("/_opendistro/_security/api/user/admin", encodeBasicHeader("la", "lu"));
@@ -225,7 +225,7 @@ public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
 
 		// -- test user, does not have any endpoints disabled, but has access to API, i.e. full access
 
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 
 		// GET actiongroups
 		response = rh.executeGetRequest("_opendistro/_security/api/configuration/actiongroups", encodeBasicHeader("test", "test"));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/SecurityConfigApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/SecurityConfigApiTest.java
@@ -32,7 +32,7 @@ public class SecurityConfigApiTest extends AbstractRestApiUnitTest {
         setup();
 
         rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
 
         HttpResponse response = rh.executeGetRequest("/_opendistro/_security/api/securityconfig", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
@@ -58,7 +58,7 @@ public class SecurityConfigApiTest extends AbstractRestApiUnitTest {
         setup(settings);
 
         rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
 
         HttpResponse response = rh.executeGetRequest("/_opendistro/_security/api/securityconfig", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
@@ -39,7 +39,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		setup();
 
 		rh.keystore = "restapi/kirk-keystore.jks";
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		// initial configuration, 5 users
 		HttpResponse response = rh
@@ -66,11 +66,13 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		response = rh.executeGetRequest("/_opendistro/_security/api/user/", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
-		// GET, new URL endpoint in security
-		response = rh.executeGetRequest("/_opendistro/_security/api/user", new Header[0]);
-		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        	// GET, new URL endpoint in security
+        	response = rh.executeGetRequest("/_opendistro/_security/api/user/", new Header[0]);
+        	Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
-		// -- PUT
+        	// GET, new URL endpoint in security
+        	response = rh.executeGetRequest("/_opendistro/_security/api/user", new Header[0]);
+        	Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
 		// no username given
 		response = rh.executePutRequest("/_opendistro/_security/api/user/", "{\"hash\": \"123\"}", new Header[0]);
@@ -104,28 +106,30 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 
         // -- PATCH
         // PATCH on non-existing resource
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/imnothere", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
-        // PATCH read only resource, must be forbidden
-        rh.sendHTTPClientCertificate = true;
-        response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/sarek", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        // PATCH read only resource, must be forbidden,
+        // but SuperAdmin can PATCH read-only resource
+        rh.sendAdminCertificate = true;
+        response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/sarek",
+				"[{ \"op\": \"add\", \"path\": \"/roles\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         // PATCH hidden resource, must be not found
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/q", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // PATCH value of hidden flag, must fail with validation error
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/test", "[{ \"op\": \"add\", \"path\": \"/hidden\", \"value\": true }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         Assert.assertTrue(response.getBody().matches(".*\"invalid_keys\"\\s*:\\s*\\{\\s*\"keys\"\\s*:\\s*\"hidden\"\\s*\\}.*"));
 
         // PATCH password
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/test", "[{ \"op\": \"add\", \"path\": \"/password\", \"value\": \"neu\" }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rh.executeGetRequest("/_opendistro/_security/api/internalusers/test", new Header[0]);
@@ -136,29 +140,36 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 
         // -- PATCH on whole config resource
         // PATCH on non-existing resource
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/imnothere/a\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
-        // PATCH read only resource, must be forbidden
-        rh.sendHTTPClientCertificate = true;
+        // PATCH read only resource, must be forbidden,
+        // but SuperAdmin can PATCH read only resouce
+        rh.sendAdminCertificate = true;
+        response = rh.executePatchRequest("/_opendistro/_security/api/internalusers",
+				"[{ \"op\": \"add\", \"path\": \"/sarek/roles\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        rh.sendAdminCertificate = false;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/sarek/a\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
 
         // PATCH hidden resource, must be bad request
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/q/a\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         // PATCH value of hidden flag, must fail with validation error
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/test/hidden\", \"value\": true }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         Assert.assertTrue(response.getBody().matches(".*\"invalid_keys\"\\s*:\\s*\\{\\s*\"keys\"\\s*:\\s*\"hidden\"\\s*\\}.*"));
 
         // PATCH
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/bulknew1\", \"value\": {\"password\": \"bla\", \"roles\": [\"vulcan\"] } }]", new Header[0]);
+
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rh.executeGetRequest("/_opendistro/_security/api/internalusers/bulknew1", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
@@ -174,26 +185,27 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		// check access not allowed
 		checkGeneralAccess(HttpStatus.SC_UNAUTHORIZED, "nagilum", "nagilum");
 
-		// add/update user, user is read only, forbidden
-		rh.sendHTTPClientCertificate = true;
-		addUserWithHash("sarek", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m",
-				HttpStatus.SC_FORBIDDEN);
+        // add/update user, user is read only, forbidden
+        // SuperAdmin can add read only users
+        rh.sendAdminCertificate = true;
+        addUserWithHash("sarek", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m",
+                HttpStatus.SC_OK);
 
         // add/update user, user is hidden, forbidden
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
         addUserWithHash("q", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m",
                 HttpStatus.SC_FORBIDDEN);
 
-		// add users
-		rh.sendHTTPClientCertificate = true;
-		addUserWithHash("nagilum", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m",
-				HttpStatus.SC_CREATED);
+        	// add users
+        	rh.sendAdminCertificate = true;
+        	addUserWithHash("nagilum", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m",
+                HttpStatus.SC_CREATED);
 
 		// access must be allowed now
 		checkGeneralAccess(HttpStatus.SC_OK, "nagilum", "nagilum");
 
 		// try remove user, no username
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 		response = rh.executeDeleteRequest("/_opendistro/_security/api/user", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
@@ -203,7 +215,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 
 		// try remove readonly user
 		response = rh.executeDeleteRequest("/_opendistro/_security/api/user/sarek", new Header[0]);
-		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         // try remove hidden user
         response = rh.executeDeleteRequest("/_opendistro/_security/api/user/q", new Header[0]);
@@ -213,21 +225,21 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		deleteUser("nagilum");
 
 		// Access must be forbidden now
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 		checkGeneralAccess(HttpStatus.SC_UNAUTHORIZED, "nagilum", "nagilum");
 
 		// use password instead of hash
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 		addUserWithPassword("nagilum", "correctpassword", HttpStatus.SC_CREATED);
 
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 		checkGeneralAccess(HttpStatus.SC_UNAUTHORIZED, "nagilum", "wrongpassword");
 		checkGeneralAccess(HttpStatus.SC_OK, "nagilum", "correctpassword");
 
 		deleteUser("nagilum");
 
 		// Check unchanged password functionality
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		// new user, password or hash is mandatory
 		addUserWithoutPasswordOrHash("nagilum", new String[] { "starfleet" }, HttpStatus.SC_BAD_REQUEST);
@@ -248,38 +260,38 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		setupStarfleetIndex();
 
 		// wrong datatypes in roles file
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 		response = rh.executePutRequest("/_opendistro/_security/api/user/picard", FileHelper.loadFile("restapi/users_wrong_datatypes.json"), new Header[0]);
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
 		Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 		Assert.assertEquals(AbstractConfigurationValidator.ErrorType.WRONG_DATATYPE.getMessage(), settings.get("reason"));
 		Assert.assertTrue(settings.get("roles").equals("Array expected"));
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 		response = rh.executePutRequest("/_opendistro/_security/api/user/picard", FileHelper.loadFile("restapi/users_wrong_datatypes.json"), new Header[0]);
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
 		Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 		Assert.assertEquals(AbstractConfigurationValidator.ErrorType.WRONG_DATATYPE.getMessage(), settings.get("reason"));
 		Assert.assertTrue(settings.get("roles").equals("Array expected"));
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 		response = rh.executePutRequest("/_opendistro/_security/api/user/picard", FileHelper.loadFile("restapi/users_wrong_datatypes2.json"), new Header[0]);
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
 		Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 		Assert.assertEquals(AbstractConfigurationValidator.ErrorType.WRONG_DATATYPE.getMessage(), settings.get("reason"));
 		Assert.assertTrue(settings.get("password").equals("String expected"));
 		Assert.assertTrue(settings.get("roles") == null);
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 		response = rh.executePutRequest("/_opendistro/_security/api/user/picard", FileHelper.loadFile("restapi/users_wrong_datatypes3.json"), new Header[0]);
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
 		Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 		Assert.assertEquals(AbstractConfigurationValidator.ErrorType.WRONG_DATATYPE.getMessage(), settings.get("reason"));
 		Assert.assertTrue(settings.get("roles").equals("Array expected"));
-		rh.sendHTTPClientCertificate = false;
+		rh.sendAdminCertificate = false;
 
 		// use backendroles when creating user. User picard does not exist in
 		// the internal user DB
@@ -303,7 +315,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "ships", 0);
 		checkWriteAccess(HttpStatus.SC_CREATED, "picard", "picard", "sf", "ships", 1);
 
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 		response = rh.executeGetRequest("/_opendistro/_security/api/user/picard", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
@@ -336,7 +348,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		setup(nodeSettings);
 
 		rh.keystore = "restapi/kirk-keystore.jks";
-		rh.sendHTTPClientCertificate = true;
+		rh.sendAdminCertificate = true;
 
 		// initial configuration, 5 users
 		HttpResponse response = rh
@@ -407,10 +419,10 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 	@Test
     public void testUserApiWithDots() throws Exception {
 
-        setup();
+	setup();
 
         rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendHTTPClientCertificate = true;
+        rh.sendAdminCertificate = true;
 
         // initial configuration, 5 users
         HttpResponse response = rh
@@ -432,5 +444,38 @@ public class UserApiTest extends AbstractRestApiUnitTest {
                 HttpStatus.SC_CREATED, true);
 
 	}
+
+    @Test
+    public void testUserApiForNonSuperAdmin() throws Exception {
+
+        setupWithRestRoles();
+
+        rh.keystore = "restapi/kirk-keystore.jks";
+        rh.sendAdminCertificate = false;
+        rh.sendHTTPClientCredentials = true;
+
+        HttpResponse response;
+
+        response = rh.executeGetRequest("/_opendistro/_security/api/user" , new Header[0]);
+
+        // Delete read only user
+        response = rh.executeDeleteRequest("/_opendistro/_security/api/internalusers/sarek" , new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // Put read only users
+		response = rh.executePutRequest("/_opendistro/_security/api/internalusers/sarek", "{\"hash\": \"123\"}", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // Patch single read only user
+		response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/sarek",
+				"[{ \"op\": \"add\", \"path\": \"/roles\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // Patch multiple read only users
+		response = rh.executePatchRequest("/_opendistro/_security/api/internalusers",
+				"[{ \"op\": \"add\", \"path\": \"/sarek/roles\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+    }
 
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/rest/RestHelper.java
@@ -43,6 +43,9 @@ import javax.net.ssl.SSLContext;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
@@ -56,6 +59,7 @@ import org.apache.http.config.SocketConfig;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
@@ -73,8 +77,9 @@ public class RestHelper {
 	
 	public boolean enableHTTPClientSSL = true;
 	public boolean enableHTTPClientSSLv3Only = false;
-	public boolean sendHTTPClientCertificate = false;
+	public boolean sendAdminCertificate = false;
 	public boolean trustHTTPServerCertificate = true;
+	public boolean sendHTTPClientCredentials = false;
 	public String keystore = "node-0-keystore.jks";
 	public final String prefix;
 	//public String truststore = "truststore.jks";
@@ -195,6 +200,13 @@ public class RestHelper {
 
 		final HttpClientBuilder hcb = HttpClients.custom();
 
+		if (sendHTTPClientCredentials) {
+			CredentialsProvider provider = new BasicCredentialsProvider();
+			UsernamePasswordCredentials credentials = new UsernamePasswordCredentials("sarek", "sarek");
+			provider.setCredentials(AuthScope.ANY, credentials);
+			hcb.setDefaultCredentialsProvider(provider);
+		}
+
 		if (enableHTTPClientSSL) {
 
 			log.debug("Configure HTTP client with SSL");
@@ -218,7 +230,7 @@ public class RestHelper {
 				sslContextbBuilder.loadTrustMaterial(myTrustStore, null);
 			}
 
-			if (sendHTTPClientCertificate) {
+			if (sendAdminCertificate) {
 				sslContextbBuilder.loadKeyMaterial(keyStore, "changeit".toCharArray());
 			}
 


### PR DESCRIPTION
Functionality :- Allow SuperAdmin to update/delete/add read only config such as action_groups, roles, roles_mapping, internal_users

Fixed readonly check for AccountAPI