### PR TITLE
[Optimization] Faster resolve index pattern - fixes bulk requests against aliases to long index series with 1 write index

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
@@ -319,7 +319,8 @@ public final class IndexResolverReplacer implements DCFListener {
         final AtomicBoolean isIndicesRequest = new AtomicBoolean();
 
         getOrReplaceAllIndices(request, new IndicesProvider() {
-            // resolve cache helps us big time on bulk requests
+            // resolve cache - keep track of already completed resolve index requests
+            // help us big time for bulk requests
             final Set<IndexResolveKey> resolvedBefore = new HashSet<>();
 
             @Override
@@ -327,7 +328,7 @@ public final class IndexResolverReplacer implements DCFListener {
                 final IndicesOptions indicesOptions = indicesOptionsFrom(localRequest);
                 final boolean isSearchOrFieldCapabilities = localRequest instanceof FieldCapabilitiesRequest || localRequest instanceof SearchRequest;
                 final IndexResolveKey key = new IndexResolveKey(indicesOptions, isSearchOrFieldCapabilities, original);
-                // skip the whole thing if we have seen this exact resolveIndexPatterns result
+                // skip the whole thing if we have seen this exact resolveIndexPatterns request
                 if (!resolvedBefore.contains(key)) {
                     final Resolved iResolved = resolveIndexPatterns(key.opts, key.isSearchOrFieldCapabilities, key.original);
                     resolvedBefore.add(key);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
@@ -226,18 +226,16 @@ public final class IndexResolverReplacer implements DCFListener {
         else {
 
             ClusterState state = clusterService.state();
-
-            final SortedMap<String, AliasOrIndex> lookup = state.metaData().getAliasAndIndexLookup();
-            final List<String> aliases = lookup.entrySet().stream().filter(e -> e.getValue().isAlias()).map(e -> e.getKey())
-                    .collect(Collectors.toList());
-
             Set<String> dateResolvedLocalRequestedPatterns = localRequestedPatterns
                             .stream()
                             .map(resolver::resolveDateMathExpression)
                             .collect(Collectors.toSet());
             //fill matchingAliases
-            matchingAliases = aliases
+            final SortedMap<String, AliasOrIndex> lookup = state.metaData().getAliasAndIndexLookup();
+            matchingAliases = lookup.entrySet()
                     .stream()
+                    .filter(e -> e.getValue().isAlias())
+                    .map(Map.Entry::getKey)
                     .filter(alias -> WildcardMatcher.matchAny(dateResolvedLocalRequestedPatterns, alias))
                     .collect(Collectors.toSet());
 


### PR DESCRIPTION
So continuing with my PR https://github.com/opendistro-for-elasticsearch/security/pull/198

I decided to reproduce performance problem and have hit a much bigger one.

Test setup is 
300 indices of 10 documents each, logstash-100 ... logstash-400 , all have alias logstash-alias pointing to them (is_write_index: false)

1 target index logstash-1 (alias logstash-alias, is_write_index: true)

Profiler https://github.com/jvm-profiling-tools/async-profiler is attached as follows:
```
./profiler.sh -d 30 -e cpu -f ~/new.svg -i 900000 `ps aux | grep elastic | awk '{ print $2; exit }'`
```

The dataset is one of http_logs files from ES Rally benchmark tool, see https://github.com/elastic/rally-tracks/tree/master/http_logs

(I used tar.gz distro and removed perf analyzer plugin at some point b/c I thought it was adding overhead, not really but it's missing from flame graphs for this reason)

The following series of flames is how the big chunk of CPU time on the *left*  slowly melts from ~65 to 5%.


![original](https://user-images.githubusercontent.com/281770/75635285-e42e3400-5c25-11ea-9f92-687352653ac7.png)

![latest](https://user-images.githubusercontent.com/281770/75635290-ec866f00-5c25-11ea-8026-6ee732f268e1.png)

![latest-2](https://user-images.githubusercontent.com/281770/75635292-f019f600-5c25-11ea-9dcd-af187623f6d9.png)
![latest-3](https://user-images.githubusercontent.com/281770/75635295-f314e680-5c25-11ea-8fff-bbb9ba4425d6.png)

![latest-4](https://user-images.githubusercontent.com/281770/75635299-f7410400-5c25-11ea-9cb9-bc99624dcc5c.png)

![latest-5](https://user-images.githubusercontent.com/281770/75635301-f9a35e00-5c25-11ea-876b-768e994b9ca9.png)

The last 2 flamegraphs include my patch for impliesTypePerm because at that point impliesTypePerm finally become a significant portion of CPU time.


Full interactive flamegraphs are in zip file.

[flame-graphs.zip](https://github.com/opendistro-for-elasticsearch/security/files/4272522/flame-graphs.zip)
