### PR TITLE
Add workflow in order to generate PR automatically for child branches…

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,35 @@
+name: Auto Merge
+
+on:
+  pull_request:
+    branches:
+      - opendistro-*
+    types:
+      - labeled
+      - reopened
+      - edited
+  pull_request_review:
+    types:
+      - submitted
+  status: {}
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'automerge')
+    steps:
+      - name: 'Wait for status checks'
+        id: waitforstatuschecks
+        uses: "WyriHaximus/github-action-wait-for-status@master"
+        with:
+          ignoreActions: automerge
+          checkInterval: 13
+        env:
+          GITHUB_TOKEN: "${{ secrets.PAT }}"
+      - name: 'Merge'
+        uses: "pascalgn/automerge-action@master"
+        if: steps.waitforstatuschecks.outputs.status == 'success'
+        env:
+          GITHUB_TOKEN: "${{ secrets.PAT }}"
+          MERGE_LABELS: automerge
+          MERGE_FORKS: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,33 @@
+name: Create Backporting PRs
+
+on:
+  pull_request:
+    branches:
+      - master
+    types: [closed]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'backport')
+    strategy:
+      matrix:
+        branch: [opendistro-1.0, opendistro-1.1, opendistro-1.2, opendistro-1.3, opendistro-1.4, opendistro-1.5]
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+        with:
+          ref: ${{ matrix.branch }}
+      - name: Get changes
+        run: |
+          git config --global user.email "opendistro-for-elasticsearch-security+github@amazon.com"
+          git config --global user.name "opendistroforelasticsearch-security"
+          git fetch origin
+          git cherry-pick ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v2
+        with:
+          branch-suffix: short-commit-hash
+          token: ${{ secrets.PAT }}
+          labels: automerge


### PR DESCRIPTION
Add workflow in order to generate PR automatically for child branches whenever there is a merge event on master

will work with opendistroforelasticsearch-security bot 

auto-merge will only run on opendistro branch and not on master 

