### PR TITLE
AuditLog: Refactor to use AuditCategory enum

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AbstractAuditLog.java
@@ -132,7 +132,7 @@ public abstract class AbstractAuditLog implements AuditLog {
 
         final List<String> disabledRestCategoriesList = settings.getAsList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES, DEFAULT_DISABLED_CATEGORIES);
 
-        if (disabledRestCategoriesList.size() == 1 && "NONE".equalsIgnoreCase(disabledRestCategoriesList.get(0))) {
+        if (disabledRestCategoriesList.isEmpty() || (disabledRestCategoriesList.size() == 1 && "NONE".equalsIgnoreCase(disabledRestCategoriesList.get(0)))) {
             disabledRestCategories = EnumSet.noneOf(AuditCategory.class);
         } else {
             disabledRestCategories = AuditCategory.parse(disabledRestCategoriesList);
@@ -144,7 +144,7 @@ public abstract class AbstractAuditLog implements AuditLog {
 
         final List<String> disabledTransportCategoriesList = settings.getAsList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES, DEFAULT_DISABLED_CATEGORIES);
 
-        if (disabledTransportCategoriesList.size() == 1 && "NONE".equalsIgnoreCase(disabledTransportCategoriesList.get(0))) {
+        if (disabledTransportCategoriesList.isEmpty() || (disabledTransportCategoriesList.size() == 1 && "NONE".equalsIgnoreCase(disabledTransportCategoriesList.get(0)))) {
             disabledTransportCategories = EnumSet.noneOf(AuditCategory.class);
         } else {
             disabledTransportCategories = AuditCategory.parse(disabledTransportCategoriesList);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AbstractAuditLog.java
@@ -25,6 +25,7 @@ import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,7 +68,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequest;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog;
-import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage.Category;
 import com.amazon.opendistroforelasticsearch.security.compliance.ComplianceConfig;
 import com.amazon.opendistroforelasticsearch.security.dlic.rest.support.Utils;
 import com.amazon.opendistroforelasticsearch.security.support.Base64Helper;
@@ -80,6 +80,8 @@ import com.flipkart.zjsonpatch.JsonDiff;
 import com.google.common.io.BaseEncoding;
 
 public abstract class AbstractAuditLog implements AuditLog {
+
+    private static final List<String> DEFAULT_DISABLED_CATEGORIES = Arrays.asList(AuditCategory.AUTHENTICATED.toString(), AuditCategory.GRANTED_PRIVILEGES.toString());
 
     protected final Logger log = LogManager.getLogger(this.getClass());
     protected final ThreadPool threadPool;
@@ -97,9 +99,8 @@ public abstract class AbstractAuditLog implements AuditLog {
     private List<String> ignoredComplianceUsersForRead;
     private List<String> ignoredComplianceUsersForWrite;
     private final List<String> ignoreAuditRequests;
-    private final List<String> disabledRestCategories;
-    private final List<String> disabledTransportCategories;
-    private final List<String> defaultDisabledCategories = Arrays.asList(Category.AUTHENTICATED.toString(), Category.GRANTED_PRIVILEGES.toString());
+    private final EnumSet<AuditCategory> disabledRestCategories;
+    private final EnumSet<AuditCategory> disabledTransportCategories;
     private final List<String> defaultIgnoredUsers = Arrays.asList("kibanaserver");
     private final boolean excludeSensitiveHeaders;
 
@@ -129,27 +130,15 @@ public abstract class AbstractAuditLog implements AuditLog {
         restAuditingEnabled = settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_REST, true);
         transportAuditingEnabled = settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_TRANSPORT, true);
 
-        disabledRestCategories = new ArrayList<>(settings.getAsList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES, defaultDisabledCategories).stream()
-                .map(c->c.toUpperCase()).collect(Collectors.toList()));
+        disabledRestCategories = AuditCategory.parse(getConfigList(
+                settings,
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES,
+                DEFAULT_DISABLED_CATEGORIES));
 
-        if(disabledRestCategories.size() == 1 && "NONE".equals(disabledRestCategories.get(0))) {
-            disabledRestCategories.clear();
-        }
-
-        if (disabledRestCategories.size() > 0) {
-            log.info("Configured categories on rest layer to ignore: {}", disabledRestCategories);
-        }
-
-        disabledTransportCategories = new ArrayList<>(settings.getAsList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES, defaultDisabledCategories).stream()
-                .map(c->c.toUpperCase()).collect(Collectors.toList()));
-
-        if(disabledTransportCategories.size() == 1 && "NONE".equals(disabledTransportCategories.get(0))) {
-            disabledTransportCategories.clear();
-        }
-
-        if (disabledTransportCategories.size() > 0) {
-            log.info("Configured categories on transport layer to ignore: {}", disabledTransportCategories);
-        }
+        disabledTransportCategories = AuditCategory.parse(getConfigList(
+                settings,
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES,
+                DEFAULT_DISABLED_CATEGORIES));
 
         logRequestBody = settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_LOG_REQUEST_BODY, true);
         resolveIndices = settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_RESOLVE_INDICES, true);
@@ -184,44 +173,34 @@ public abstract class AbstractAuditLog implements AuditLog {
             log.info("Configured Users to ignore for write compliance events: {}", ignoredComplianceUsersForWrite);
         }
 
-
-
         ignoreAuditRequests = settings.getAsList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_REQUESTS, Collections.emptyList());
         if (ignoreAuditRequests.size() > 0) {
             log.info("Configured Requests to ignore: {}", ignoreAuditRequests);
         }
 
-        // check if some categories are invalid
-        for (String event : disabledRestCategories) {
-        	try {
-        		AuditMessage.Category.valueOf(event.toUpperCase());
-        	} catch(Exception iae) {
-        		log.error("Unkown category {}, please check opendistro_security.audit.config.disabled_categories settings", event);
-        	}
-		}
-
-        // check if some categories are invalid
-        for (String event : disabledTransportCategories) {
-            try {
-                AuditMessage.Category.valueOf(event.toUpperCase());
-            } catch(Exception iae) {
-                log.error("Unkown category {}, please check opendistro_security.audit.config.disabled_categories settings", event);
-            }
-        }
-
         this.excludeSensitiveHeaders = settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_EXCLUDE_SENSITIVE_HEADERS, true);
+    }
+
+    private static List<String> getConfigList(final Settings settings,
+                                              final String key,
+                                              final List<String> defaultList) {
+        List<String> list = settings.getAsList(key, defaultList);
+        if (list.size() == 1 && "NONE".equals(list.get(0))) {
+            return Collections.emptyList();
+        }
+        return list;
     }
 
     @Override
     public void logFailedLogin(String effectiveUser, boolean securityadmin, String initiatingUser, TransportRequest request, Task task) {
         final String action = null;
 
-        if(!checkTransportFilter(Category.FAILED_LOGIN, action, effectiveUser, request)) {
+        if(!checkTransportFilter(AuditCategory.FAILED_LOGIN, action, effectiveUser, request)) {
             return;
         }
 
         final TransportAddress remoteAddress = getRemoteAddress();
-        final List<AuditMessage> msgs = RequestResolver.resolve(Category.FAILED_LOGIN, getOrigin(), action, null, effectiveUser, securityadmin, initiatingUser, remoteAddress, request, getThreadContextHeaders(), task, resolver, clusterService, settings, logRequestBody, resolveIndices, resolveBulkRequests, opendistrosecurityIndex, excludeSensitiveHeaders, null);
+        final List<AuditMessage> msgs = RequestResolver.resolve(AuditCategory.FAILED_LOGIN, getOrigin(), action, null, effectiveUser, securityadmin, initiatingUser, remoteAddress, request, getThreadContextHeaders(), task, resolver, clusterService, settings, logRequestBody, resolveIndices, resolveBulkRequests, opendistrosecurityIndex, excludeSensitiveHeaders, null);
 
         for(AuditMessage msg: msgs) {
             save(msg);
@@ -232,11 +211,11 @@ public abstract class AbstractAuditLog implements AuditLog {
     @Override
     public void logFailedLogin(String effectiveUser, boolean securityadmin, String initiatingUser, RestRequest request) {
 
-        if(!checkRestFilter(Category.FAILED_LOGIN, effectiveUser, request)) {
+        if(!checkRestFilter(AuditCategory.FAILED_LOGIN, effectiveUser, request)) {
             return;
         }
 
-        AuditMessage msg = new AuditMessage(Category.FAILED_LOGIN, clusterService, getOrigin(), Origin.REST);
+        AuditMessage msg = new AuditMessage(AuditCategory.FAILED_LOGIN, clusterService, getOrigin(), Origin.REST);
         TransportAddress remoteAddress = getRemoteAddress();
         msg.addRemoteAddress(remoteAddress);
         if(request != null && logRequestBody && request.hasContentOrSourceParam()) {
@@ -259,12 +238,12 @@ public abstract class AbstractAuditLog implements AuditLog {
     @Override
     public void logSucceededLogin(String effectiveUser, boolean securityadmin, String initiatingUser, TransportRequest request, String action, Task task) {
 
-        if(!checkTransportFilter(Category.AUTHENTICATED, action, effectiveUser, request)) {
+        if(!checkTransportFilter(AuditCategory.AUTHENTICATED, action, effectiveUser, request)) {
             return;
         }
 
         final TransportAddress remoteAddress = getRemoteAddress();
-        final List<AuditMessage> msgs = RequestResolver.resolve(Category.AUTHENTICATED, getOrigin(), action, null, effectiveUser, securityadmin, initiatingUser,remoteAddress, request, getThreadContextHeaders(), task, resolver, clusterService, settings, logRequestBody, resolveIndices, resolveBulkRequests, opendistrosecurityIndex, excludeSensitiveHeaders, null);
+        final List<AuditMessage> msgs = RequestResolver.resolve(AuditCategory.AUTHENTICATED, getOrigin(), action, null, effectiveUser, securityadmin, initiatingUser,remoteAddress, request, getThreadContextHeaders(), task, resolver, clusterService, settings, logRequestBody, resolveIndices, resolveBulkRequests, opendistrosecurityIndex, excludeSensitiveHeaders, null);
 
         for(AuditMessage msg: msgs) {
             save(msg);
@@ -274,11 +253,11 @@ public abstract class AbstractAuditLog implements AuditLog {
     @Override
     public void logSucceededLogin(String effectiveUser, boolean securityadmin, String initiatingUser, RestRequest request) {
 
-        if(!checkRestFilter(Category.AUTHENTICATED, effectiveUser, request)) {
+        if(!checkRestFilter(AuditCategory.AUTHENTICATED, effectiveUser, request)) {
             return;
         }
 
-        AuditMessage msg = new AuditMessage(Category.AUTHENTICATED, clusterService, getOrigin(), Origin.REST);
+        AuditMessage msg = new AuditMessage(AuditCategory.AUTHENTICATED, clusterService, getOrigin(), Origin.REST);
         TransportAddress remoteAddress = getRemoteAddress();
         msg.addRemoteAddress(remoteAddress);
         if(request != null && logRequestBody && request.hasContentOrSourceParam()) {
@@ -299,11 +278,11 @@ public abstract class AbstractAuditLog implements AuditLog {
 
     @Override
     public void logMissingPrivileges(String privilege, String effectiveUser, RestRequest request) {
-        if(!checkRestFilter(Category.MISSING_PRIVILEGES, effectiveUser, request)) {
+        if(!checkRestFilter(AuditCategory.MISSING_PRIVILEGES, effectiveUser, request)) {
             return;
         }
 
-        AuditMessage msg = new AuditMessage(Category.MISSING_PRIVILEGES, clusterService, getOrigin(), Origin.REST);
+        AuditMessage msg = new AuditMessage(AuditCategory.MISSING_PRIVILEGES, clusterService, getOrigin(), Origin.REST);
         TransportAddress remoteAddress = getRemoteAddress();
         msg.addRemoteAddress(remoteAddress);
         if(request != null && logRequestBody && request.hasContentOrSourceParam()) {
@@ -323,12 +302,12 @@ public abstract class AbstractAuditLog implements AuditLog {
     public void logMissingPrivileges(String privilege, TransportRequest request, Task task) {
         final String action = null;
 
-        if(!checkTransportFilter(Category.MISSING_PRIVILEGES, privilege, getUser(), request)) {
+        if(!checkTransportFilter(AuditCategory.MISSING_PRIVILEGES, privilege, getUser(), request)) {
             return;
         }
 
         final TransportAddress remoteAddress = getRemoteAddress();
-        final List<AuditMessage> msgs = RequestResolver.resolve(Category.MISSING_PRIVILEGES, getOrigin(), action, privilege, getUser(), null, null, remoteAddress, request, getThreadContextHeaders(), task, resolver, clusterService, settings, logRequestBody, resolveIndices, resolveBulkRequests, opendistrosecurityIndex, excludeSensitiveHeaders, null);
+        final List<AuditMessage> msgs = RequestResolver.resolve(AuditCategory.MISSING_PRIVILEGES, getOrigin(), action, privilege, getUser(), null, null, remoteAddress, request, getThreadContextHeaders(), task, resolver, clusterService, settings, logRequestBody, resolveIndices, resolveBulkRequests, opendistrosecurityIndex, excludeSensitiveHeaders, null);
 
         for(AuditMessage msg: msgs) {
             save(msg);
@@ -339,12 +318,12 @@ public abstract class AbstractAuditLog implements AuditLog {
     public void logGrantedPrivileges(String privilege, TransportRequest request, Task task) {
         final String action = null;
 
-        if(!checkTransportFilter(Category.GRANTED_PRIVILEGES, privilege, getUser(), request)) {
+        if(!checkTransportFilter(AuditCategory.GRANTED_PRIVILEGES, privilege, getUser(), request)) {
             return;
         }
 
         final TransportAddress remoteAddress = getRemoteAddress();
-        final List<AuditMessage> msgs = RequestResolver.resolve(Category.GRANTED_PRIVILEGES, getOrigin(), action, privilege, getUser(), null, null, remoteAddress, request, getThreadContextHeaders(), task, resolver, clusterService, settings, logRequestBody, resolveIndices, resolveBulkRequests, opendistrosecurityIndex, excludeSensitiveHeaders, null);
+        final List<AuditMessage> msgs = RequestResolver.resolve(AuditCategory.GRANTED_PRIVILEGES, getOrigin(), action, privilege, getUser(), null, null, remoteAddress, request, getThreadContextHeaders(), task, resolver, clusterService, settings, logRequestBody, resolveIndices, resolveBulkRequests, opendistrosecurityIndex, excludeSensitiveHeaders, null);
 
         for(AuditMessage msg: msgs) {
             save(msg);
@@ -354,12 +333,12 @@ public abstract class AbstractAuditLog implements AuditLog {
     @Override
     public void logBadHeaders(TransportRequest request, String action, Task task) {
 
-        if(!checkTransportFilter(Category.BAD_HEADERS, action, getUser(), request)) {
+        if(!checkTransportFilter(AuditCategory.BAD_HEADERS, action, getUser(), request)) {
             return;
         }
 
         final TransportAddress remoteAddress = getRemoteAddress();
-        final List<AuditMessage> msgs = RequestResolver.resolve(Category.BAD_HEADERS, getOrigin(), action, null, getUser(), null, null, remoteAddress, request, getThreadContextHeaders(), task, resolver, clusterService, settings, logRequestBody, resolveIndices, resolveBulkRequests, opendistrosecurityIndex, excludeSensitiveHeaders, null);
+        final List<AuditMessage> msgs = RequestResolver.resolve(AuditCategory.BAD_HEADERS, getOrigin(), action, null, getUser(), null, null, remoteAddress, request, getThreadContextHeaders(), task, resolver, clusterService, settings, logRequestBody, resolveIndices, resolveBulkRequests, opendistrosecurityIndex, excludeSensitiveHeaders, null);
 
         for(AuditMessage msg: msgs) {
             save(msg);
@@ -369,11 +348,11 @@ public abstract class AbstractAuditLog implements AuditLog {
     @Override
     public void logBadHeaders(RestRequest request) {
 
-        if(!checkRestFilter(Category.BAD_HEADERS, getUser(), request)) {
+        if(!checkRestFilter(AuditCategory.BAD_HEADERS, getUser(), request)) {
             return;
         }
 
-        AuditMessage msg = new AuditMessage(Category.BAD_HEADERS, clusterService, getOrigin(), Origin.REST);
+        AuditMessage msg = new AuditMessage(AuditCategory.BAD_HEADERS, clusterService, getOrigin(), Origin.REST);
         TransportAddress remoteAddress = getRemoteAddress();
         msg.addRemoteAddress(remoteAddress);
         if(request != null && logRequestBody && request.hasContentOrSourceParam()) {
@@ -393,12 +372,12 @@ public abstract class AbstractAuditLog implements AuditLog {
     @Override
     public void logSecurityIndexAttempt(TransportRequest request, String action, Task task) {
 
-        if(!checkTransportFilter(Category.OPENDISTRO_SECURITY_INDEX_ATTEMPT, action, getUser(), request)) {
+        if(!checkTransportFilter(AuditCategory.OPENDISTRO_SECURITY_INDEX_ATTEMPT, action, getUser(), request)) {
             return;
         }
 
         final TransportAddress remoteAddress = getRemoteAddress();
-        final List<AuditMessage> msgs = RequestResolver.resolve(Category.OPENDISTRO_SECURITY_INDEX_ATTEMPT, getOrigin(), action, null, getUser(), false, null, remoteAddress, request, getThreadContextHeaders(), task, resolver, clusterService, settings, logRequestBody, resolveIndices, resolveBulkRequests, opendistrosecurityIndex, excludeSensitiveHeaders, null);
+        final List<AuditMessage> msgs = RequestResolver.resolve(AuditCategory.OPENDISTRO_SECURITY_INDEX_ATTEMPT, getOrigin(), action, null, getUser(), false, null, remoteAddress, request, getThreadContextHeaders(), task, resolver, clusterService, settings, logRequestBody, resolveIndices, resolveBulkRequests, opendistrosecurityIndex, excludeSensitiveHeaders, null);
 
         for(AuditMessage msg: msgs) {
             save(msg);
@@ -408,13 +387,13 @@ public abstract class AbstractAuditLog implements AuditLog {
     @Override
     public void logSSLException(TransportRequest request, Throwable t, String action, Task task) {
 
-        if(!checkTransportFilter(Category.SSL_EXCEPTION, action, getUser(), request)) {
+        if(!checkTransportFilter(AuditCategory.SSL_EXCEPTION, action, getUser(), request)) {
             return;
         }
 
         final TransportAddress remoteAddress = getRemoteAddress();
 
-        final List<AuditMessage> msgs = RequestResolver.resolve(Category.SSL_EXCEPTION, Origin.TRANSPORT, action, null, getUser(), false, null, remoteAddress, request,
+        final List<AuditMessage> msgs = RequestResolver.resolve(AuditCategory.SSL_EXCEPTION, Origin.TRANSPORT, action, null, getUser(), false, null, remoteAddress, request,
                 getThreadContextHeaders(), task, resolver, clusterService, settings, logRequestBody, resolveIndices, resolveBulkRequests, opendistrosecurityIndex, excludeSensitiveHeaders, t);
 
         for(AuditMessage msg: msgs) {
@@ -425,11 +404,11 @@ public abstract class AbstractAuditLog implements AuditLog {
     @Override
     public void logSSLException(RestRequest request, Throwable t) {
 
-        if(!checkRestFilter(Category.SSL_EXCEPTION, getUser(), request)) {
+        if(!checkRestFilter(AuditCategory.SSL_EXCEPTION, getUser(), request)) {
             return;
         }
 
-        AuditMessage msg = new AuditMessage(Category.SSL_EXCEPTION, clusterService, Origin.REST, Origin.REST);
+        AuditMessage msg = new AuditMessage(AuditCategory.SSL_EXCEPTION, clusterService, Origin.REST, Origin.REST);
 
         TransportAddress remoteAddress = getRemoteAddress();
         msg.addRemoteAddress(remoteAddress);
@@ -460,7 +439,7 @@ public abstract class AbstractAuditLog implements AuditLog {
             return;
         }
 
-        Category category = opendistrosecurityIndex.equals(index)?Category.COMPLIANCE_INTERNAL_CONFIG_READ:Category.COMPLIANCE_DOC_READ;
+        AuditCategory category = opendistrosecurityIndex.equals(index)? AuditCategory.COMPLIANCE_INTERNAL_CONFIG_READ: AuditCategory.COMPLIANCE_DOC_READ;
 
         String effectiveUser = getUser();
         if(!checkComplianceFilter(category, effectiveUser, getOrigin())) {
@@ -519,7 +498,7 @@ public abstract class AbstractAuditLog implements AuditLog {
             return;
         }
 
-        Category category = opendistrosecurityIndex.equals(shardId.getIndexName())?Category.COMPLIANCE_INTERNAL_CONFIG_WRITE:Category.COMPLIANCE_DOC_WRITE;
+        AuditCategory category = opendistrosecurityIndex.equals(shardId.getIndexName())? AuditCategory.COMPLIANCE_INTERNAL_CONFIG_WRITE: AuditCategory.COMPLIANCE_DOC_WRITE;
 
         String effectiveUser = getUser();
 
@@ -612,11 +591,11 @@ public abstract class AbstractAuditLog implements AuditLog {
 
         String effectiveUser = getUser();
 
-        if(!checkComplianceFilter(Category.COMPLIANCE_DOC_WRITE, effectiveUser, getOrigin())) {
+        if(!checkComplianceFilter(AuditCategory.COMPLIANCE_DOC_WRITE, effectiveUser, getOrigin())) {
             return;
         }
 
-        AuditMessage msg = new AuditMessage(Category.COMPLIANCE_DOC_WRITE, clusterService, getOrigin(), null);
+        AuditMessage msg = new AuditMessage(AuditCategory.COMPLIANCE_DOC_WRITE, clusterService, getOrigin(), null);
         TransportAddress remoteAddress = getRemoteAddress();
         msg.addRemoteAddress(remoteAddress);
         msg.addEffectiveUser(effectiveUser);
@@ -632,7 +611,7 @@ public abstract class AbstractAuditLog implements AuditLog {
     @Override
     public void logExternalConfig(Settings settings, Environment environment) {
 
-        if(!checkComplianceFilter(Category.COMPLIANCE_EXTERNAL_CONFIG, null, getOrigin())) {
+        if(!checkComplianceFilter(AuditCategory.COMPLIANCE_EXTERNAL_CONFIG, null, getOrigin())) {
             return;
         }
 
@@ -659,7 +638,7 @@ public abstract class AbstractAuditLog implements AuditLog {
         });
 
         final String sha256 = DigestUtils.sha256Hex(configAsMap.toString()+envAsMap.toString()+propsAsMap.toString());
-        AuditMessage msg = new AuditMessage(Category.COMPLIANCE_EXTERNAL_CONFIG, clusterService, null, null);
+        AuditMessage msg = new AuditMessage(AuditCategory.COMPLIANCE_EXTERNAL_CONFIG, clusterService, null, null);
 
         try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
             builder.startObject();
@@ -723,7 +702,7 @@ public abstract class AbstractAuditLog implements AuditLog {
         return threadPool.getThreadContext().getHeaders();
     }
 
-    private boolean checkTransportFilter(final Category category, final String action, final String effectiveUser, TransportRequest request) {
+    private boolean checkTransportFilter(final AuditCategory category, final String action, final String effectiveUser, TransportRequest request) {
 
         if(log.isTraceEnabled()) {
             log.trace("Check category:{}, action:{}, effectiveUser:{}, request:{}", category, action, effectiveUser, request==null?null:request.getClass().getSimpleName());
@@ -732,9 +711,9 @@ public abstract class AbstractAuditLog implements AuditLog {
 
         if(!transportAuditingEnabled) {
             //ignore for certain categories
-            if(category != Category.FAILED_LOGIN
-                    && category != Category.MISSING_PRIVILEGES
-                    && category != Category.OPENDISTRO_SECURITY_INDEX_ATTEMPT) {
+            if(category != AuditCategory.FAILED_LOGIN
+                    && category != AuditCategory.MISSING_PRIVILEGES
+                    && category != AuditCategory.OPENDISTRO_SECURITY_INDEX_ATTEMPT) {
 
                 return false;
             }
@@ -777,7 +756,7 @@ public abstract class AbstractAuditLog implements AuditLog {
             return false;
         }
 
-        if (!disabledTransportCategories.contains(category.toString())) {
+        if (!disabledTransportCategories.contains(category)) {
             return true;
         } else {
             if(log.isTraceEnabled()) {
@@ -795,19 +774,19 @@ public abstract class AbstractAuditLog implements AuditLog {
 
     }
 
-    private boolean checkComplianceFilter(final Category category, final String effectiveUser, Origin origin) {
+    private boolean checkComplianceFilter(final AuditCategory category, final String effectiveUser, Origin origin) {
         if(log.isTraceEnabled()) {
             log.trace("Check for COMPLIANCE category:{}, effectiveUser:{}, origin: {}", category, effectiveUser, origin);
         }
 
-        if(origin == Origin.LOCAL && effectiveUser == null && category != Category.COMPLIANCE_EXTERNAL_CONFIG) {
+        if(origin == Origin.LOCAL && effectiveUser == null && category != AuditCategory.COMPLIANCE_EXTERNAL_CONFIG) {
             if(log.isTraceEnabled()) {
                 log.trace("Skipped compliance log message because of null user and local origin");
             }
             return false;
         }
 
-        if(category == Category.COMPLIANCE_DOC_READ || category == Category.COMPLIANCE_INTERNAL_CONFIG_READ) {
+        if(category == AuditCategory.COMPLIANCE_DOC_READ || category == AuditCategory.COMPLIANCE_INTERNAL_CONFIG_READ) {
             if (ignoredComplianceUsersForRead.size() > 0 && effectiveUser != null
                     && WildcardMatcher.matchAny(ignoredComplianceUsersForRead, effectiveUser)) {
 
@@ -818,7 +797,7 @@ public abstract class AbstractAuditLog implements AuditLog {
             }
         }
 
-        if(category == Category.COMPLIANCE_DOC_WRITE || category == Category.COMPLIANCE_INTERNAL_CONFIG_WRITE) {
+        if(category == AuditCategory.COMPLIANCE_DOC_WRITE || category == AuditCategory.COMPLIANCE_INTERNAL_CONFIG_WRITE) {
             if (ignoredComplianceUsersForWrite.size() > 0 && effectiveUser != null
                     && WildcardMatcher.matchAny(ignoredComplianceUsersForWrite, effectiveUser)) {
 
@@ -833,16 +812,16 @@ public abstract class AbstractAuditLog implements AuditLog {
     }
 
 
-    private boolean checkRestFilter(final Category category, final String effectiveUser, RestRequest request) {
+    private boolean checkRestFilter(final AuditCategory category, final String effectiveUser, RestRequest request) {
         if(log.isTraceEnabled()) {
             log.trace("Check for REST category:{}, effectiveUser:{}, request:{}", category, effectiveUser, request==null?null:request.path());
         }
 
         if(!restAuditingEnabled) {
             //ignore for certain categories
-            if(category != Category.FAILED_LOGIN
-                    && category != Category.MISSING_PRIVILEGES
-                    && category != Category.OPENDISTRO_SECURITY_INDEX_ATTEMPT) {
+            if(category != AuditCategory.FAILED_LOGIN
+                    && category != AuditCategory.MISSING_PRIVILEGES
+                    && category != AuditCategory.OPENDISTRO_SECURITY_INDEX_ATTEMPT) {
 
                 return false;
             }
@@ -868,7 +847,7 @@ public abstract class AbstractAuditLog implements AuditLog {
             return false;
         }
 
-        if (!disabledRestCategories.contains(category.toString())) {
+        if (!disabledRestCategories.contains(category)) {
             return true;
         } else {
             if(log.isTraceEnabled()) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditCategory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditCategory.java
@@ -21,12 +21,11 @@ public enum AuditCategory {
 
     public static EnumSet<AuditCategory> parse(final Collection<String> categories) {
         EnumSet<AuditCategory> set = EnumSet.noneOf(AuditCategory.class);
-        if (categories == null)
+        if (categories.isEmpty())
             return set;
 
         return categories
                 .stream()
-                .filter(Objects::nonNull)
                 .map(String::toUpperCase)
                 .map(AuditCategory::valueOf)
                 .collect(Collectors.toCollection(() -> set));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditCategory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditCategory.java
@@ -1,0 +1,34 @@
+package com.amazon.opendistroforelasticsearch.security.auditlog.impl;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public enum AuditCategory {
+    BAD_HEADERS,
+    FAILED_LOGIN,
+    MISSING_PRIVILEGES,
+    GRANTED_PRIVILEGES,
+    OPENDISTRO_SECURITY_INDEX_ATTEMPT,
+    SSL_EXCEPTION,
+    AUTHENTICATED,
+    COMPLIANCE_DOC_READ,
+    COMPLIANCE_DOC_WRITE,
+    COMPLIANCE_EXTERNAL_CONFIG,
+    COMPLIANCE_INTERNAL_CONFIG_READ,
+    COMPLIANCE_INTERNAL_CONFIG_WRITE;
+
+    public static EnumSet<AuditCategory> parse(final Collection<String> categories) {
+        EnumSet<AuditCategory> set = EnumSet.noneOf(AuditCategory.class);
+        if (categories == null)
+            return set;
+
+        return categories
+                .stream()
+                .filter(Objects::nonNull)
+                .map(String::toUpperCase)
+                .map(AuditCategory::valueOf)
+                .collect(Collectors.toCollection(() -> set));
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditMessage.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditMessage.java
@@ -106,9 +106,9 @@ public final class AuditMessage {
 
     private static final DateTimeFormatter DEFAULT_FORMAT = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
     private final Map<String, Object> auditInfo = new HashMap<String, Object>(50);
-    private final Category msgCategory;
+    private final AuditCategory msgCategory;
 
-    public AuditMessage(final Category msgCategory, final ClusterService clusterService, final Origin origin, final Origin layer) {
+    public AuditMessage(final AuditCategory msgCategory, final ClusterService clusterService, final Origin origin, final Origin layer) {
         this.msgCategory = Objects.requireNonNull(msgCategory);
         final String currentTime = currentTime();
         auditInfo.put(FORMAT_VERSION, 4);
@@ -356,7 +356,7 @@ public final class AuditMessage {
         return (String) this.auditInfo.get(TRANSPORT_REQUEST_TYPE);
     }
 
-	public Category getCategory() {
+	public AuditCategory getCategory() {
 		return msgCategory;
 	}
 
@@ -423,20 +423,4 @@ public final class AuditMessage {
 
         return String.valueOf(object);
     }
-
-	public static enum Category {
-        BAD_HEADERS,
-        FAILED_LOGIN,
-        MISSING_PRIVILEGES,
-        GRANTED_PRIVILEGES,
-        OPENDISTRO_SECURITY_INDEX_ATTEMPT,
-        SSL_EXCEPTION,
-        AUTHENTICATED,
-        COMPLIANCE_DOC_READ,
-        COMPLIANCE_DOC_WRITE,
-        COMPLIANCE_EXTERNAL_CONFIG,
-        COMPLIANCE_INTERNAL_CONFIG_READ,
-        COMPLIANCE_INTERNAL_CONFIG_WRITE
-    }
-
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/RequestResolver.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/RequestResolver.java
@@ -59,7 +59,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportRequest;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog.Origin;
-import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage.Category;
+import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditCategory;
 import com.amazon.opendistroforelasticsearch.security.dlic.rest.support.Utils;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 
@@ -68,7 +68,7 @@ public final class RequestResolver {
     private static final Logger log = LogManager.getLogger(RequestResolver.class);
 
     public static List<AuditMessage> resolve(
-            final Category category,
+            final AuditCategory category,
             final Origin origin,
             final String action,
             final String privilege,
@@ -125,9 +125,9 @@ public final class RequestResolver {
 
         if(request instanceof BulkShardRequest) {
 
-            if(category != Category.FAILED_LOGIN
-                    && category != Category.MISSING_PRIVILEGES
-                    && category != Category.OPENDISTRO_SECURITY_INDEX_ATTEMPT) {
+            if(category != AuditCategory.FAILED_LOGIN
+                    && category != AuditCategory.MISSING_PRIVILEGES
+                    && category != AuditCategory.OPENDISTRO_SECURITY_INDEX_ATTEMPT) {
 
                 return Collections.emptyList();
             }
@@ -156,7 +156,7 @@ public final class RequestResolver {
     }
 
 
-    private static AuditMessage resolveInner(final Category category,
+    private static AuditMessage resolveInner(final AuditCategory category,
             final String effectiveUser,
             final Boolean securityadmin,
             final String initiatingUser,

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/routing/AuditMessageRouter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/routing/AuditMessageRouter.java
@@ -31,7 +31,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage;
-import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage.Category;
+import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditCategory;
 import com.amazon.opendistroforelasticsearch.security.auditlog.sink.AuditLogSink;
 import com.amazon.opendistroforelasticsearch.security.auditlog.sink.SinkProvider;
 import com.amazon.opendistroforelasticsearch.security.compliance.ComplianceConfig;
@@ -42,7 +42,7 @@ public class AuditMessageRouter {
 
 	protected final Logger log = LogManager.getLogger(this.getClass());
 	final AuditLogSink defaultSink;
-	final Map<Category, List<AuditLogSink>> categorySinks = new EnumMap<>(Category.class);
+	final Map<AuditCategory, List<AuditLogSink>> categorySinks = new EnumMap<>(AuditCategory.class);
 	final SinkProvider sinkProvider;
 	final AsyncStoragePool storagePool;
 	final boolean enabled;
@@ -117,7 +117,7 @@ public class AuditMessageRouter {
 				log.trace("Setting up routes for endpoint {}, configuraton is {}", routesEntry.getKey(), routesEntry.getValue());
 				String categoryName = routesEntry.getKey();
 				try {
-					Category category = Category.valueOf(categoryName.toUpperCase());
+					AuditCategory category = AuditCategory.valueOf(categoryName.toUpperCase());
 					// warn for duplicate definitions
 					if (categorySinks.get(category) != null) {
 						log.warn("Duplicate routing configuration detected for category {}, skipping.", category);
@@ -134,11 +134,11 @@ public class AuditMessageRouter {
 
 					}
 				} catch (Exception e ) {
-					log.error("Invalid category '{}' found in routing configuration. Must be one of: {}", categoryName, Category.values());
+					log.error("Invalid category '{}' found in routing configuration. Must be one of: {}", categoryName, AuditCategory.values());
 				}
 			}
 			// for all non-configured categories we automatically set up the default endpoint
-			for(Category category : Category.values()) {
+			for(AuditCategory category : AuditCategory.values()) {
 				if (!categorySinks.containsKey(category)) {
 					if (log.isDebugEnabled()) {
 						log.debug("No endpoint configured for category {}, adding default endpoint", category);
@@ -149,7 +149,7 @@ public class AuditMessageRouter {
 		}
 	}
 
-	private final List<AuditLogSink> createSinksForCategory(Category category, Settings configuration) {
+	private final List<AuditLogSink> createSinksForCategory(AuditCategory category, Settings configuration) {
 		List<AuditLogSink> sinksForCategory = new LinkedList<>();
 		List<String> sinks = configuration.getAsList("endpoints");
 		if (sinks == null || sinks.isEmpty()) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/helper/MockAuditMessageFactory.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/helper/MockAuditMessageFactory.java
@@ -27,15 +27,15 @@ import org.elasticsearch.common.transport.TransportAddress;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog.Origin;
 import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage;
-import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage.Category;
+import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditCategory;
 
 public class MockAuditMessageFactory {
 
 	public static AuditMessage validAuditMessage() {
-		return validAuditMessage(Category.FAILED_LOGIN);
+		return validAuditMessage(AuditCategory.FAILED_LOGIN);
 	}
 
-	public static AuditMessage validAuditMessage(Category category) {
+	public static AuditMessage validAuditMessage(AuditCategory category) {
 
 	    ClusterService cs = mock(ClusterService.class);
 	    DiscoveryNode dn = mock(DiscoveryNode.class);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditCategoryTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditCategoryTest.java
@@ -1,0 +1,78 @@
+package com.amazon.opendistroforelasticsearch.security.auditlog.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+
+import static com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditCategory.AUTHENTICATED;
+import static com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditCategory.BAD_HEADERS;
+
+@RunWith(Enclosed.class)
+public class AuditCategoryTest {
+
+    @RunWith(Parameterized.class)
+    public static class AuditCategoryParseTest {
+
+        private final List<String> input;
+        private final EnumSet<AuditCategory> expected;
+
+        public AuditCategoryParseTest(List<String> input, EnumSet<AuditCategory> expected) {
+            this.input = input;
+            this.expected = expected;
+        }
+
+        @Parameterized.Parameters
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][]{
+                    {null, EnumSet.noneOf(AuditCategory.class)},
+                    {Arrays.asList(), EnumSet.noneOf(AuditCategory.class)},
+                    {Arrays.asList("BAD_HEADERS"), EnumSet.of(BAD_HEADERS)},
+                    {Arrays.asList("bad_headers"), EnumSet.of(BAD_HEADERS)},
+                    {Arrays.asList("bAd_HeAdErS"), EnumSet.of(BAD_HEADERS)},
+                    {Arrays.asList("bAd_HeAdErS"), EnumSet.of(BAD_HEADERS)},
+                    {Arrays.asList("BAD_HEADERS", "AUTHENTICATED"), EnumSet.of(BAD_HEADERS, AUTHENTICATED)},
+                    {Arrays.asList("BAD_HEADERS", "FAILED_LOGIN", "MISSING_PRIVILEGES", "GRANTED_PRIVILEGES",
+                            "OPENDISTRO_SECURITY_INDEX_ATTEMPT", "SSL_EXCEPTION", "AUTHENTICATED",
+                            "COMPLIANCE_DOC_READ", "COMPLIANCE_DOC_WRITE", "COMPLIANCE_EXTERNAL_CONFIG",
+                            "COMPLIANCE_INTERNAL_CONFIG_READ", "COMPLIANCE_INTERNAL_CONFIG_WRITE"
+                    ), EnumSet.allOf(AuditCategory.class)},
+            });
+        }
+
+        @Test
+        public void testAuditCategoryEnumSetGenerationWhenEmpty() {
+            EnumSet<AuditCategory> categories = AuditCategory.parse(input);
+            Assert.assertEquals(categories, expected);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class AuditCategoryExceptionTest {
+
+        private final List<String> input;
+
+        public AuditCategoryExceptionTest(List<String> input) {
+            this.input = input;
+        }
+
+        @Parameterized.Parameters
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][]{
+                    {Arrays.asList("BAD_INPUT")},
+                    {Arrays.asList("BAD_HEADERS", "bad_category", "AUTHENTICATED")},
+            });
+        }
+
+        @Test(expected = IllegalArgumentException.class)
+        public void testAuditCategoryEnumSetGenerationWhenEmpty() {
+            AuditCategory.parse(input);
+        }
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditCategoryTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditCategoryTest.java
@@ -31,7 +31,6 @@ public class AuditCategoryTest {
         @Parameterized.Parameters
         public static Collection<Object[]> data() {
             return Arrays.asList(new Object[][]{
-                    {null, EnumSet.noneOf(AuditCategory.class)},
                     {Arrays.asList(), EnumSet.noneOf(AuditCategory.class)},
                     {Arrays.asList("BAD_HEADERS"), EnumSet.of(BAD_HEADERS)},
                     {Arrays.asList("bad_headers"), EnumSet.of(BAD_HEADERS)},
@@ -73,6 +72,11 @@ public class AuditCategoryTest {
         @Test(expected = IllegalArgumentException.class)
         public void testAuditCategoryEnumSetGenerationWhenEmpty() {
             AuditCategory.parse(input);
+        }
+
+        @Test(expected = NullPointerException.class)
+        public void testNullPointerExceptionForNullInput() {
+            AuditCategory.parse(null);
         }
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/routing/FallbackTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/routing/FallbackTest.java
@@ -29,8 +29,7 @@ import com.amazon.opendistroforelasticsearch.security.auditlog.helper.FailingSin
 import com.amazon.opendistroforelasticsearch.security.auditlog.helper.LoggingSink;
 import com.amazon.opendistroforelasticsearch.security.auditlog.helper.MockAuditMessageFactory;
 import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage;
-import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage.Category;
-import com.amazon.opendistroforelasticsearch.security.auditlog.routing.AuditMessageRouter;
+import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditCategory;
 import com.amazon.opendistroforelasticsearch.security.auditlog.sink.AuditLogSink;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.test.helper.file.FileHelper;
@@ -45,11 +44,11 @@ public class FallbackTest extends AbstractAuditlogiUnitTest {
 
 		AuditMessageRouter router = createMessageRouterComplianceEnabled(settings);
 
-		AuditMessage msg = MockAuditMessageFactory.validAuditMessage(Category.MISSING_PRIVILEGES);
+		AuditMessage msg = MockAuditMessageFactory.validAuditMessage(AuditCategory.MISSING_PRIVILEGES);
 		router.route(msg);
 
 		// endpoint 1 is failing, endoint2 and default work
-		List<AuditLogSink> sinks = router.categorySinks.get(Category.MISSING_PRIVILEGES);
+		List<AuditLogSink> sinks = router.categorySinks.get(AuditCategory.MISSING_PRIVILEGES);
 		Assert.assertEquals(3, sinks.size());
 		// this sink has failed, message must be logged to fallback sink
 		AuditLogSink sink = sinks.get(0);
@@ -75,9 +74,9 @@ public class FallbackTest extends AbstractAuditlogiUnitTest {
 
 		// has only one end point which fails
 		router = createMessageRouterComplianceEnabled(settings);
-		msg = MockAuditMessageFactory.validAuditMessage(Category.COMPLIANCE_DOC_READ);
+		msg = MockAuditMessageFactory.validAuditMessage(AuditCategory.COMPLIANCE_DOC_READ);
 		router.route(msg);
-		sinks = router.categorySinks.get(Category.COMPLIANCE_DOC_READ);
+		sinks = router.categorySinks.get(AuditCategory.COMPLIANCE_DOC_READ);
 		sink = sinks.get(0);
 		Assert.assertEquals("endpoint3", sink.getName());
 		Assert.assertEquals(FailingSink.class, sink.getClass());
@@ -89,9 +88,9 @@ public class FallbackTest extends AbstractAuditlogiUnitTest {
 
 		// has only default which succeeds
 		router = createMessageRouterComplianceEnabled(settings);
-		msg = MockAuditMessageFactory.validAuditMessage(Category.COMPLIANCE_DOC_WRITE);
+		msg = MockAuditMessageFactory.validAuditMessage(AuditCategory.COMPLIANCE_DOC_WRITE);
 		router.route(msg);
-		sinks = router.categorySinks.get(Category.COMPLIANCE_DOC_WRITE);
+		sinks = router.categorySinks.get(AuditCategory.COMPLIANCE_DOC_WRITE);
 		sink = sinks.get(0);
 		Assert.assertEquals("default", sink.getName());
 		Assert.assertEquals(LoggingSink.class, sink.getClass());
@@ -107,9 +106,9 @@ public class FallbackTest extends AbstractAuditlogiUnitTest {
 
 		// test non configured categories, must be logged to default only
 		router = createMessageRouterComplianceEnabled(settings);
-		msg = MockAuditMessageFactory.validAuditMessage(Category.FAILED_LOGIN);
+		msg = MockAuditMessageFactory.validAuditMessage(AuditCategory.FAILED_LOGIN);
 		router.route(msg);
-		sinks = router.categorySinks.get(Category.FAILED_LOGIN);
+		sinks = router.categorySinks.get(AuditCategory.FAILED_LOGIN);
 		sink = sinks.get(0);
 		Assert.assertEquals("default", sink.getName());
 		Assert.assertEquals(LoggingSink.class, sink.getClass());
@@ -117,11 +116,11 @@ public class FallbackTest extends AbstractAuditlogiUnitTest {
 		Assert.assertEquals(1, loggingSkin.messages.size());
 		Assert.assertEquals(msg, loggingSkin.messages.get(0));
 		// all others must be empty
-		assertLoggingSinksEmpty(router, Category.FAILED_LOGIN);
+		assertLoggingSinksEmpty(router, AuditCategory.FAILED_LOGIN);
 
 	}
 
-	private void assertLoggingSinksEmpty(AuditMessageRouter router, Category exclude) {
+	private void assertLoggingSinksEmpty(AuditMessageRouter router, AuditCategory exclude) {
 		// get all sinks
 		List<AuditLogSink> allSinks = router.categorySinks.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
 		allSinks = allSinks.stream().filter(sink -> (sink instanceof LoggingSink)).collect(Collectors.toList());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/routing/PerfTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/routing/PerfTest.java
@@ -24,8 +24,7 @@ import com.amazon.opendistroforelasticsearch.security.auditlog.AbstractAuditlogi
 import com.amazon.opendistroforelasticsearch.security.auditlog.helper.LoggingSink;
 import com.amazon.opendistroforelasticsearch.security.auditlog.helper.MockAuditMessageFactory;
 import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage;
-import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage.Category;
-import com.amazon.opendistroforelasticsearch.security.auditlog.routing.AuditMessageRouter;
+import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditCategory;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.test.helper.file.FileHelper;
 
@@ -45,7 +44,7 @@ public class PerfTest extends AbstractAuditlogiUnitTest {
 		AuditMessageRouter router = createMessageRouterComplianceEnabled(settings);
 		int limit = 150000;
 		while(limit > 0) {
-			AuditMessage msg = MockAuditMessageFactory.validAuditMessage(Category.MISSING_PRIVILEGES);
+			AuditMessage msg = MockAuditMessageFactory.validAuditMessage(AuditCategory.MISSING_PRIVILEGES);
 			router.route(msg);
 			limit--;
 		}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/routing/RouterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/routing/RouterTest.java
@@ -27,8 +27,7 @@ import com.amazon.opendistroforelasticsearch.security.auditlog.AbstractAuditlogi
 import com.amazon.opendistroforelasticsearch.security.auditlog.helper.LoggingSink;
 import com.amazon.opendistroforelasticsearch.security.auditlog.helper.MockAuditMessageFactory;
 import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage;
-import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage.Category;
-import com.amazon.opendistroforelasticsearch.security.auditlog.routing.AuditMessageRouter;
+import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditCategory;
 import com.amazon.opendistroforelasticsearch.security.auditlog.sink.AuditLogSink;
 import com.amazon.opendistroforelasticsearch.security.auditlog.sink.DebugSink;
 import com.amazon.opendistroforelasticsearch.security.auditlog.sink.ExternalESSink;
@@ -47,7 +46,7 @@ public class RouterTest extends AbstractAuditlogiUnitTest{
 		Assert.assertEquals("default", router.defaultSink.getName());
 		Assert.assertEquals(ExternalESSink.class, router.defaultSink.getClass());
 		// test category sinks
-		List<AuditLogSink> sinks = router.categorySinks.get(AuditMessage.Category.MISSING_PRIVILEGES);
+		List<AuditLogSink> sinks = router.categorySinks.get(AuditCategory.MISSING_PRIVILEGES);
 		Assert.assertNotNull(sinks);
 		// 3, since we include default as well
 		Assert.assertEquals(3, sinks.size());
@@ -57,7 +56,7 @@ public class RouterTest extends AbstractAuditlogiUnitTest{
 		Assert.assertEquals(ExternalESSink.class, sinks.get(1).getClass());
 		Assert.assertEquals("default", sinks.get(2).getName());
 		Assert.assertEquals(ExternalESSink.class, sinks.get(2).getClass());
-		sinks = router.categorySinks.get(AuditMessage.Category.COMPLIANCE_DOC_READ);
+		sinks = router.categorySinks.get(AuditCategory.COMPLIANCE_DOC_READ);
 		// 1, since we do not include default
 		Assert.assertEquals(1, sinks.size());
 		Assert.assertEquals("endpoint3", sinks.get(0).getName());
@@ -75,35 +74,35 @@ public class RouterTest extends AbstractAuditlogiUnitTest{
                 .build();
 
 		AuditMessageRouter router = createMessageRouterComplianceEnabled(settings);
-        AuditMessage msg = MockAuditMessageFactory.validAuditMessage(Category.MISSING_PRIVILEGES);
+        AuditMessage msg = MockAuditMessageFactory.validAuditMessage(AuditCategory.MISSING_PRIVILEGES);
         router.route(msg);
-        testMessageDeliveredForCategory(router, msg, Category.MISSING_PRIVILEGES, "endpoint1", "endpoint2", "default");
+        testMessageDeliveredForCategory(router, msg, AuditCategory.MISSING_PRIVILEGES, "endpoint1", "endpoint2", "default");
 
         router = createMessageRouterComplianceEnabled(settings);
-        msg = MockAuditMessageFactory.validAuditMessage(Category.COMPLIANCE_DOC_READ);
+        msg = MockAuditMessageFactory.validAuditMessage(AuditCategory.COMPLIANCE_DOC_READ);
         router.route(msg);
-        testMessageDeliveredForCategory(router, msg, Category.COMPLIANCE_DOC_READ, "endpoint3");
+        testMessageDeliveredForCategory(router, msg, AuditCategory.COMPLIANCE_DOC_READ, "endpoint3");
 
         router = createMessageRouterComplianceEnabled(settings);
-        msg = MockAuditMessageFactory.validAuditMessage(Category.COMPLIANCE_DOC_WRITE);
+        msg = MockAuditMessageFactory.validAuditMessage(AuditCategory.COMPLIANCE_DOC_WRITE);
         router.route(msg);
-        testMessageDeliveredForCategory(router, msg, Category.COMPLIANCE_DOC_WRITE, "default");
+        testMessageDeliveredForCategory(router, msg, AuditCategory.COMPLIANCE_DOC_WRITE, "default");
 
         router = createMessageRouterComplianceEnabled(settings);
-        msg = MockAuditMessageFactory.validAuditMessage(Category.FAILED_LOGIN);
+        msg = MockAuditMessageFactory.validAuditMessage(AuditCategory.FAILED_LOGIN);
         router.route(msg);
-        testMessageDeliveredForCategory(router, msg, Category.FAILED_LOGIN, "default");
+        testMessageDeliveredForCategory(router, msg, AuditCategory.FAILED_LOGIN, "default");
 
         router = createMessageRouterComplianceEnabled(settings);
-        msg = MockAuditMessageFactory.validAuditMessage(Category.GRANTED_PRIVILEGES);
+        msg = MockAuditMessageFactory.validAuditMessage(AuditCategory.GRANTED_PRIVILEGES);
         router.route(msg);
-        testMessageDeliveredForCategory(router, msg, Category.GRANTED_PRIVILEGES, "default");
+        testMessageDeliveredForCategory(router, msg, AuditCategory.GRANTED_PRIVILEGES, "default");
 
     }
 
-    private void testMessageDeliveredForCategory(AuditMessageRouter router, AuditMessage msg, Category categoryToCheck, String ... sinkNames) {
-    	Map<Category, List<AuditLogSink>> sinksForCategory = router.categorySinks;
-    	for(Category category : Category.values()) {
+    private void testMessageDeliveredForCategory(AuditMessageRouter router, AuditMessage msg, AuditCategory categoryToCheck, String ... sinkNames) {
+    	Map<AuditCategory, List<AuditLogSink>> sinksForCategory = router.categorySinks;
+    	for(AuditCategory category : AuditCategory.values()) {
     		if (category.equals(categoryToCheck)) {
     			List<AuditLogSink> sinks = sinksForCategory.get(category);
     			// each sink must contain our message

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/routing/RoutingConfigurationTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/routing/RoutingConfigurationTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.AbstractAuditlogiUnitTest;
 import com.amazon.opendistroforelasticsearch.security.auditlog.helper.MockAuditMessageFactory;
-import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage;
+import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditCategory;
 import com.amazon.opendistroforelasticsearch.security.auditlog.sink.AuditLogSink;
 import com.amazon.opendistroforelasticsearch.security.auditlog.sink.DebugSink;
 import com.amazon.opendistroforelasticsearch.security.auditlog.sink.ExternalESSink;
@@ -41,7 +41,7 @@ public class RoutingConfigurationTest extends AbstractAuditlogiUnitTest{
 		Assert.assertEquals("default", router.defaultSink.getName());
 		Assert.assertEquals(ExternalESSink.class, router.defaultSink.getClass());
 		// test category sinks
-		List<AuditLogSink> sinks = router.categorySinks.get(AuditMessage.Category.MISSING_PRIVILEGES);
+		List<AuditLogSink> sinks = router.categorySinks.get(AuditCategory.MISSING_PRIVILEGES);
 		Assert.assertNotNull(sinks);
 		// 3, since we include default as well
 		Assert.assertEquals(3, sinks.size());
@@ -51,7 +51,7 @@ public class RoutingConfigurationTest extends AbstractAuditlogiUnitTest{
 		Assert.assertEquals(ExternalESSink.class, sinks.get(1).getClass());
 		Assert.assertEquals("default", sinks.get(2).getName());
 		Assert.assertEquals(ExternalESSink.class, sinks.get(2).getClass());
-		sinks = router.categorySinks.get(AuditMessage.Category.COMPLIANCE_DOC_READ);
+		sinks = router.categorySinks.get(AuditCategory.COMPLIANCE_DOC_READ);
 		// 1, since we do not include default
 		Assert.assertEquals(1, sinks.size());
 		Assert.assertEquals("endpoint3", sinks.get(0).getName());
@@ -78,19 +78,19 @@ public class RoutingConfigurationTest extends AbstractAuditlogiUnitTest{
 		Assert.assertEquals(InternalESSink.class, router.defaultSink.getClass());
 		// missing configuration for endpoint2 / External ES. Fallback to
 		// localhost
-		List<AuditLogSink> sinks = router.categorySinks.get(AuditMessage.Category.MISSING_PRIVILEGES);
+		List<AuditLogSink> sinks = router.categorySinks.get(AuditCategory.MISSING_PRIVILEGES);
 		// 2 valid endpoints
 		Assert.assertEquals(2, sinks.size());
 		Assert.assertEquals("endpoint1", sinks.get(0).getName());
 		Assert.assertEquals(InternalESSink.class, sinks.get(0).getClass());
 		Assert.assertEquals("endpoint3", sinks.get(1).getName());
 		Assert.assertEquals(DebugSink.class, sinks.get(1).getClass());
-		sinks = router.categorySinks.get(AuditMessage.Category.COMPLIANCE_DOC_WRITE);
+		sinks = router.categorySinks.get(AuditCategory.COMPLIANCE_DOC_WRITE);
 		Assert.assertEquals(1, sinks.size());
 		Assert.assertEquals("default", sinks.get(0).getName());
 		Assert.assertEquals(InternalESSink.class, sinks.get(0).getClass());
 		// no valid end points for category, must use default
-		sinks = router.categorySinks.get(AuditMessage.Category.COMPLIANCE_DOC_READ);
+		sinks = router.categorySinks.get(AuditCategory.COMPLIANCE_DOC_READ);
 		Assert.assertEquals("default", sinks.get(0).getName());
 		Assert.assertEquals(InternalESSink.class, sinks.get(0).getClass());
 	}
@@ -102,7 +102,7 @@ public class RoutingConfigurationTest extends AbstractAuditlogiUnitTest{
 		// no default sink, we fall back to debug sink
 		Assert.assertEquals(DebugSink.class, router.defaultSink.getClass());
 
-		List<AuditLogSink> sinks = router.categorySinks.get(AuditMessage.Category.MISSING_PRIVILEGES);
+		List<AuditLogSink> sinks = router.categorySinks.get(AuditCategory.MISSING_PRIVILEGES);
 		// 3, since default is not valid but replaced with Debug
 		Assert.assertEquals(3, sinks.size());
 		Assert.assertEquals("default", sinks.get(0).getName());
@@ -112,7 +112,7 @@ public class RoutingConfigurationTest extends AbstractAuditlogiUnitTest{
 		Assert.assertEquals("endpoint2", sinks.get(2).getName());
 		Assert.assertEquals(ExternalESSink.class, sinks.get(2).getClass());
 
-		sinks = router.categorySinks.get(AuditMessage.Category.GRANTED_PRIVILEGES);
+		sinks = router.categorySinks.get(AuditCategory.GRANTED_PRIVILEGES);
 		Assert.assertEquals(3, sinks.size());
 		Assert.assertEquals("endpoint1", sinks.get(0).getName());
 		Assert.assertEquals(InternalESSink.class, sinks.get(0).getClass());
@@ -121,18 +121,18 @@ public class RoutingConfigurationTest extends AbstractAuditlogiUnitTest{
 		Assert.assertEquals("default", sinks.get(2).getName());
 		Assert.assertEquals(DebugSink.class, sinks.get(2).getClass());
 
-		sinks = router.categorySinks.get(AuditMessage.Category.AUTHENTICATED);
+		sinks = router.categorySinks.get(AuditCategory.AUTHENTICATED);
 		Assert.assertEquals(1, sinks.size());
 		Assert.assertEquals("endpoint1", sinks.get(0).getName());
 		Assert.assertEquals(InternalESSink.class, sinks.get(0).getClass());
 
 		// bad headers has no valid endpoint, so we use default
-		Assert.assertEquals("default", router.categorySinks.get(AuditMessage.Category.BAD_HEADERS).get(0).getName());
-		Assert.assertEquals(DebugSink.class, router.categorySinks.get(AuditMessage.Category.BAD_HEADERS).get(0).getClass());
+		Assert.assertEquals("default", router.categorySinks.get(AuditCategory.BAD_HEADERS).get(0).getName());
+		Assert.assertEquals(DebugSink.class, router.categorySinks.get(AuditCategory.BAD_HEADERS).get(0).getClass());
 
 		// failed login has no endpoint configuration, so we use default
-		Assert.assertEquals("default", router.categorySinks.get(AuditMessage.Category.FAILED_LOGIN).get(0).getName());
-		Assert.assertEquals(DebugSink.class, router.categorySinks.get(AuditMessage.Category.FAILED_LOGIN).get(0).getClass());
+		Assert.assertEquals("default", router.categorySinks.get(AuditCategory.FAILED_LOGIN).get(0).getName());
+		Assert.assertEquals(DebugSink.class, router.categorySinks.get(AuditCategory.FAILED_LOGIN).get(0).getClass());
 
 	}
 
@@ -143,7 +143,7 @@ public class RoutingConfigurationTest extends AbstractAuditlogiUnitTest{
 		// debug sink not valid, fallback to debug
 		Assert.assertEquals(DebugSink.class, router.defaultSink.getClass());
 
-		List<AuditLogSink> sinks = router.categorySinks.get(AuditMessage.Category.MISSING_PRIVILEGES);
+		List<AuditLogSink> sinks = router.categorySinks.get(AuditCategory.MISSING_PRIVILEGES);
 		// 2 valid endpoints in config, default falls back to debug
 		Assert.assertEquals(3, sinks.size());
 		Assert.assertEquals("endpoint2", sinks.get(0).getName());
@@ -153,13 +153,13 @@ public class RoutingConfigurationTest extends AbstractAuditlogiUnitTest{
 		Assert.assertEquals("default", sinks.get(2).getName());
 		Assert.assertEquals(DebugSink.class, sinks.get(2).getClass());
 
-		sinks = router.categorySinks.get(AuditMessage.Category.COMPLIANCE_DOC_WRITE);
+		sinks = router.categorySinks.get(AuditCategory.COMPLIANCE_DOC_WRITE);
 		Assert.assertEquals(1, sinks.size());
 		Assert.assertEquals("default", sinks.get(0).getName());
 		Assert.assertEquals(DebugSink.class, sinks.get(0).getClass());
 
 		// no valid endpoints for category, must fallback to default
-		sinks = router.categorySinks.get(AuditMessage.Category.COMPLIANCE_DOC_READ);
+		sinks = router.categorySinks.get(AuditCategory.COMPLIANCE_DOC_READ);
 		Assert.assertEquals("default", sinks.get(0).getName());
 		Assert.assertEquals(DebugSink.class, sinks.get(0).getClass());
 	}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/sink/KafkaSinkTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/sink/KafkaSinkTest.java
@@ -27,16 +27,12 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
 
 import scala.util.Random;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.AbstractAuditlogiUnitTest;
 import com.amazon.opendistroforelasticsearch.security.auditlog.helper.MockAuditMessageFactory;
-import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage.Category;
-import com.amazon.opendistroforelasticsearch.security.auditlog.sink.AuditLogSink;
-import com.amazon.opendistroforelasticsearch.security.auditlog.sink.KafkaSink;
-import com.amazon.opendistroforelasticsearch.security.auditlog.sink.SinkProvider;
+import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditCategory;
 import com.amazon.opendistroforelasticsearch.security.test.helper.file.FileHelper;
 
 public class KafkaSinkTest extends AbstractAuditlogiUnitTest {
@@ -57,7 +53,7 @@ public class KafkaSinkTest extends AbstractAuditlogiUnitTest {
 	        AuditLogSink sink = provider.getDefaultSink();
 	        try {
 	            Assert.assertEquals(KafkaSink.class, sink.getClass());
-    	        boolean success = sink.doStore(MockAuditMessageFactory.validAuditMessage(Category.MISSING_PRIVILEGES));
+    	        boolean success = sink.doStore(MockAuditMessageFactory.validAuditMessage(AuditCategory.MISSING_PRIVILEGES));
     	        Assert.assertTrue(success);
     	        ConsumerRecords<Long, String> records = consumer.poll(Duration.ofSeconds(10));
     	        Assert.assertEquals(1, records.count());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/sink/SinkProviderTLSTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/sink/SinkProviderTLSTest.java
@@ -35,9 +35,7 @@ import org.junit.Test;
 import com.amazon.opendistroforelasticsearch.security.auditlog.helper.MockAuditMessageFactory;
 import com.amazon.opendistroforelasticsearch.security.auditlog.helper.TestHttpHandler;
 import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage;
-import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage.Category;
-import com.amazon.opendistroforelasticsearch.security.auditlog.sink.SinkProvider;
-import com.amazon.opendistroforelasticsearch.security.auditlog.sink.WebhookSink;
+import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditCategory;
 import com.amazon.opendistroforelasticsearch.security.test.helper.file.FileHelper;
 
 public class SinkProviderTLSTest {
@@ -137,7 +135,7 @@ public class SinkProviderTLSTest {
 		Assert.assertTrue(in, in.contains(AuditMessage.REQUEST_LAYER));
 		Assert.assertTrue(in, in.contains(AuditMessage.TRANSPORT_REQUEST_TYPE));
 		Assert.assertTrue(in, in.contains(AuditMessage.UTC_TIMESTAMP));
-		Assert.assertTrue(in, in.contains(Category.FAILED_LOGIN.name()));
+		Assert.assertTrue(in, in.contains(AuditCategory.FAILED_LOGIN.name()));
 		Assert.assertTrue(in, in.contains("FAILED_LOGIN"));
 		Assert.assertTrue(in, in.contains("John Doe"));
 		Assert.assertTrue(in, in.contains("8.8.8.8"));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/sink/WebhookAuditLogTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/sink/WebhookAuditLogTest.java
@@ -39,9 +39,7 @@ import com.amazon.opendistroforelasticsearch.security.auditlog.helper.LoggingSin
 import com.amazon.opendistroforelasticsearch.security.auditlog.helper.MockAuditMessageFactory;
 import com.amazon.opendistroforelasticsearch.security.auditlog.helper.TestHttpHandler;
 import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage;
-import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage.Category;
-import com.amazon.opendistroforelasticsearch.security.auditlog.sink.AuditLogSink;
-import com.amazon.opendistroforelasticsearch.security.auditlog.sink.WebhookSink;
+import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditCategory;
 import com.amazon.opendistroforelasticsearch.security.auditlog.sink.WebhookSink.WebhookFormat;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.test.helper.file.FileHelper;
@@ -726,7 +724,7 @@ public class WebhookAuditLogTest {
 		Assert.assertTrue(in, in.contains(AuditMessage.REQUEST_LAYER));
 		Assert.assertTrue(in, in.contains(AuditMessage.TRANSPORT_REQUEST_TYPE));
 		Assert.assertTrue(in, in.contains(AuditMessage.UTC_TIMESTAMP));
-		Assert.assertTrue(in, in.contains(Category.FAILED_LOGIN.name()));
+		Assert.assertTrue(in, in.contains(AuditCategory.FAILED_LOGIN.name()));
 		Assert.assertTrue(in, in.contains("FAILED_LOGIN"));
 		Assert.assertTrue(in, in.contains("John Doe"));
 		Assert.assertTrue(in, in.contains("8.8.8.8"));


### PR DESCRIPTION
Changes:
- Pull out AuditCategory from AuditMessage 
- Use EnumSet for all categories instead of List of Strings 

No new functionality added.

Fixes: https://github.com/opendistro-for-elasticsearch/security/issues/323 