### PR TITLE
[Optimization] Memoize results of resolveIndexPatterns for Bulk requests

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
@@ -32,12 +32,10 @@ package com.amazon.opendistroforelasticsearch.security.resolver;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -161,7 +159,7 @@ public final class IndexResolverReplacer implements DCFListener {
         return false;
     }
 
-    private Resolved resolveIndexPatterns(final IndicesOptions indicesOptions, final Object request, final String... requestedPatterns0) {
+    private Resolved resolveIndexPatterns(final IndicesOptions indicesOptions, final boolean isSearchOrFieldsCapabilities, final String... requestedPatterns0) {
 
         if(log.isTraceEnabled()) {
             log.trace("resolve requestedPatterns: "+ Arrays.toString(requestedPatterns0));
@@ -179,8 +177,7 @@ public final class IndexResolverReplacer implements DCFListener {
 
         final RemoteClusterService remoteClusterService = OpenDistroSecurityPlugin.GuiceHolder.getRemoteClusterService();
 
-        if(remoteClusterService.isCrossClusterSearchEnabled() && request != null
-                && (request instanceof FieldCapabilitiesRequest || request instanceof SearchRequest)) {
+        if(remoteClusterService.isCrossClusterSearchEnabled() && isSearchOrFieldsCapabilities) {
             remoteIndices = new HashSet<>();
             final Map<String, OriginalIndices> remoteClusterIndices = OpenDistroSecurityPlugin.GuiceHolder.getRemoteClusterService()
                     .groupIndices(indicesOptions, requestedPatterns0, idx -> resolver.hasIndexOrAlias(idx, clusterService.state()));
@@ -316,6 +313,32 @@ public final class IndexResolverReplacer implements DCFListener {
         }, false);
     }
 
+    private static final class IndexResolveKey {
+        private final IndicesOptions opts;
+        private final boolean isSearchOrFieldCapabilities;
+        private final String[] original;
+        public IndexResolveKey(IndicesOptions opts, boolean isSearchOrFieldCapabilities, String[] original) {
+            this.opts = opts;
+            this.isSearchOrFieldCapabilities = isSearchOrFieldCapabilities;
+            this.original = original;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            IndexResolveKey that = (IndexResolveKey) o;
+            return isSearchOrFieldCapabilities == that.isSearchOrFieldCapabilities &&
+                    opts.equals(that.opts) &&
+                    Arrays.equals(original, that.original);
+        }
+
+        @Override
+        public int hashCode() {
+            return Boolean.hashCode(isSearchOrFieldCapabilities) + 31 * opts.hashCode() + 127*Arrays.hashCode(original);
+        }
+    }
+
     public Resolved resolveRequest(final Object request) {
         if(log.isDebugEnabled()) {
             log.debug("Resolve aliases, indices and types from {}", request.getClass().getSimpleName());
@@ -323,21 +346,26 @@ public final class IndexResolverReplacer implements DCFListener {
 
         final Resolved.Builder resolvedBuilder = new Resolved.Builder();
         final AtomicBoolean isIndicesRequest = new AtomicBoolean();
-        getOrReplaceAllIndices(request, new IndicesProvider() {
+        // set of previously resolved index requests to avoid resolving
+        // the same index more than once while processing bulk requests
+        final Set<IndexResolveKey> alreadyResolved = new HashSet<>();
 
-            @Override
-            public String[] provide(String[] original, Object localRequest, boolean supportsReplace) {
-                final IndicesOptions indicesOptions = indicesOptionsFrom(localRequest);
-                final Resolved iResolved = resolveIndexPatterns(indicesOptions, localRequest, original);
+        getOrReplaceAllIndices(request, (original, localRequest, supportsReplace) -> {
+            final IndicesOptions indicesOptions = indicesOptionsFrom(localRequest);
+            final boolean isSearchOrFieldCapabilities = localRequest instanceof FieldCapabilitiesRequest || localRequest instanceof SearchRequest;
+            final IndexResolveKey key = new IndexResolveKey(indicesOptions, isSearchOrFieldCapabilities, original);
+            // skip the whole thing if we have seen this exact resolveIndexPatterns request
+            if (!alreadyResolved.contains(key)) {
+                final Resolved iResolved = resolveIndexPatterns(key.opts, key.isSearchOrFieldCapabilities, key.original);
+                alreadyResolved.add(key);
                 resolvedBuilder.add(iResolved);
                 isIndicesRequest.set(true);
 
-                if(log.isTraceEnabled()) {
+                if (log.isTraceEnabled()) {
                     log.trace("Resolved patterns {} for {} ({}) to {}", original, localRequest.getClass().getSimpleName(), request.getClass().getSimpleName(), iResolved);
                 }
-
-                return IndicesProvider.NOOP;
             }
+            return IndicesProvider.NOOP;
         }, false);
 
         if(!isIndicesRequest.get()) {


### PR DESCRIPTION
Introduce per request resolve mask, this allows us to bypass the whole resolveIndexPatterns+builder.add combo
if multiple writes in one request go to the same alias/index. This is the common case in bulk indexing.

*Issue #, if available:*

*Description of changes:*

Split off from a bigger PR focused on solving perf problem with indexing to long chians of indices with a write alias to one of them.

https://github.com/opendistro-for-elasticsearch/security/pull/258

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
