### PR TITLE
Fix updating password hash without replacing the entry

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
@@ -35,6 +35,7 @@ import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -197,32 +198,27 @@ public class AccountApiAction extends AbstractApiAction {
 
         final SecurityJsonNode securityJsonNode = new SecurityJsonNode(content);
         final String currentPassword = content.get("current_password").asText();
-        final String hash = ((Hashed) internalUser.getCEntry(username)).getHash();
+        final Hashed internalUserEntry = (Hashed) internalUser.getCEntry(username);
+        final String hash = internalUserEntry.getHash();
 
         if (hash == null || !OpenBSDBCrypt.checkPassword(hash, currentPassword.toCharArray())) {
             badRequestResponse(channel, "Could not validate your current password.");
             return;
         }
 
-        ObjectNode contentAsNode = (ObjectNode) content;
-        contentAsNode.remove("current_password");
-
         // if password is set, it takes precedence over hash
-        final String plainTextPassword = securityJsonNode.get("password").asString();
-        final String origHash = securityJsonNode.get("hash").asString();
-        if (plainTextPassword != null && plainTextPassword.length() > 0) {
-            contentAsNode.remove("password");
-            contentAsNode.put("hash", hash(plainTextPassword.toCharArray()));
-        } else if (origHash != null && origHash.length() > 0) {
-            contentAsNode.remove("password");
-        } else if (plainTextPassword != null && plainTextPassword.isEmpty() && origHash == null) {
-            contentAsNode.remove("password");
+        final String providedPassword = securityJsonNode.get("password").asString();
+        final String providedHash = securityJsonNode.get("hash").asString();
+        if (Strings.isNullOrEmpty(providedPassword) && Strings.isNullOrEmpty(providedHash)) {
+            badRequestResponse(channel, "Both provided password and hash cannot be null/empty.");
+            return;
         }
 
-        internalUser.remove(username);
+        final String newHash = Strings.isNullOrEmpty(providedPassword)
+                ? providedHash
+                : hash(providedPassword.toCharArray());
 
-        // checks complete, update the user
-        internalUser.putCObject(username, DefaultObjectMapper.readTree(contentAsNode, internalUser.getImplementingClass()));
+        internalUserEntry.setHash(newHash);
 
         saveAnUpdateConfigs(client, request, CType.INTERNALUSERS, internalUser, new OnSucessActionListener<IndexResponse>(channel) {
             @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/AccountValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/AccountValidator.java
@@ -27,5 +27,7 @@ public class AccountValidator extends CredentialsValidator {
         super(request, ref, esSettings, param);
         allowedKeys.put("current_password", DataType.STRING);
         mandatoryKeys.add("current_password");
+        mandatoryOrKeys.add("hash");
+        mandatoryOrKeys.add("password");
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/AccountValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/AccountValidator.java
@@ -27,7 +27,5 @@ public class AccountValidator extends CredentialsValidator {
         super(request, ref, esSettings, param);
         allowedKeys.put("current_password", DataType.STRING);
         mandatoryKeys.add("current_password");
-        mandatoryOrKeys.add("hash");
-        mandatoryOrKeys.add("password");
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/Hashed.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/Hashed.java
@@ -1,8 +1,8 @@
 package com.amazon.opendistroforelasticsearch.security.securityconf;
 
 public interface Hashed {
-    
-    public String getHash();
-    public void clearHash();
 
+    String getHash();
+    void setHash(String hash);
+    void clearHash();
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
@@ -170,7 +170,7 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
         setup();
         final String testUsername = "test";
         final String testPassword = "test-password";
-        final String newPassword = "test-password";
+        final String newPassword = "new-password";
         final String createInternalUserPayload = "{\n" +
                 "  \"password\": \"" + testPassword + "\",\n" +
                 "  \"backend_roles\": [\"test-backend-role-1\"],\n" +

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
@@ -24,6 +24,8 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static org.junit.Assert.*;
 
 public class AccountApiTest extends AbstractRestApiUnitTest {
@@ -94,6 +96,16 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
         response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader(testUser, testPass));
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
+        // test - bad request as hash/password is missing
+        payload = "{\"current_password\":\"" + testPass + "\"}";
+        response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader(testUser, testPass));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+
+        // test - bad request as hash/password is empty
+        payload = "{\"password\":\"" + "" + "\", \"current_password\":\"" + testPass + "\"}";
+        response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader(testUser, testPass));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+
         // test - bad request as invalid parameters are present
         payload = "{\"password\":\"new-pass\", \"current_password\":\"" + testPass + "\", \"backend_roles\": []}";
         response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader(testUser, testPass));
@@ -150,5 +162,46 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
         payload = "{\"password\":\"" + testPass + "\", \"current_password\":\"" + "admin" + "\"}";
         response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader("admin", "admin"));
         assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    public void testPutAccountRetainsAccountInformation() throws Exception {
+        // arrange
+        setup();
+        final String testUsername = "test";
+        final String testPassword = "test-password";
+        final String newPassword = "test-password";
+        final String createInternalUserPayload = "{\n" +
+                "  \"password\": \"" + testPassword + "\",\n" +
+                "  \"backend_roles\": [\"test-backend-role-1\"],\n" +
+                "  \"opendistro_security_roles\": [\"all_access\"],\n" +
+                "  \"attributes\": {\n" +
+                "    \"attribute1\": \"value1\"\n" +
+                "  }\n" +
+                "}";
+        final String changePasswordPayload = "{\"password\":\"" + newPassword + "\", \"current_password\":\"" + testPassword + "\"}";
+        final String internalUserEndpoint = "/_opendistro/_security/api/internalusers/" + testUsername;
+
+        // create user
+        rh.sendAdminCertificate = true;
+        HttpResponse response = rh.executePutRequest(internalUserEndpoint, createInternalUserPayload);
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        rh.sendAdminCertificate = false;
+
+        // change password to new-password
+        response = rh.executePutRequest(ENDPOINT, changePasswordPayload, encodeBasicHeader(testUsername, testPassword));
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        // assert account information has not changed
+        rh.sendAdminCertificate = true;
+        response = rh.executeGetRequest(internalUserEndpoint);
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Settings responseBody = Settings.builder()
+                .loadFromSource(response.getBody(), XContentType.JSON)
+                .build()
+                .getAsSettings(testUsername);
+        assertTrue(responseBody.getAsList("backend_roles").contains("test-backend-role-1"));
+        assertTrue(responseBody.getAsList("opendistro_security_roles").contains("all_access"));
+        assertEquals(responseBody.getAsSettings("attributes").get("attribute1"), "value1");
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
@@ -101,8 +101,18 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
         response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader(testUser, testPass));
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
-        // test - bad request as hash/password is empty
+        // test - bad request as password is empty
         payload = "{\"password\":\"" + "" + "\", \"current_password\":\"" + testPass + "\"}";
+        response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader(testUser, testPass));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+
+        // test - bad request as hash is empty
+        payload = "{\"hash\":\"" + "" + "\", \"current_password\":\"" + testPass + "\"}";
+        response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader(testUser, testPass));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+
+        // test - bad request as hash and password are empty
+        payload = "{\"hash\": \"\", \"password\": \"\", \"current_password\":\"" + testPass + "\"}";
         response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader(testUser, testPass));
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 


### PR DESCRIPTION
Bug:
- Updating user hash was replacing the entire entry causing it to lose the roles attached to it directly from internal users api.
- Not returning bad request when both password and hash are not provided or empty 
