### PR TITLE
Upgrade checkout action to v2 to fix "fatal: reference is not a tree" issue

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ jobs:
         java-version: 11.0.x
 
     - name: Checkout security
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         java-version: 11.0.x
 
     - name: Checkout security
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Checkstyle
       run: mvn checkstyle:checkstyle


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
