### PR TITLE
OpenSSL is no longer required for unit/integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,20 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: opendistroforelasticsearch/security-maven:v1
 
     steps:
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11.0.x
 
     - name: Checkout security
       uses: actions/checkout@v1
 
     - name: Checkstyle
       run: mvn checkstyle:checkstyle
-      
+
     - name: Test
       run: mvn test
 
@@ -29,7 +33,7 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-    
+
     - name: Package
       run: mvn clean package -Padvanced -DskipTests
 


### PR DESCRIPTION
*Description of changes:*

As security plugin dropped support for openssl, it is no longer necessary to have it installed and configured during unit and integration tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
