### PR TITLE
Increase http client timeout from 5 to 10 seconds to avoid unit test failures

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/httpclient/HttpClient.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/httpclient/HttpClient.java
@@ -253,7 +253,7 @@ public class HttpClient implements Closeable {
         }
 
         // TODO: set a timeout until we have a proper way to deal with back pressure
-        int timeout = 5;
+        int timeout = 10;
 
         RequestConfig config = RequestConfig.custom()
           .setConnectTimeout(timeout * 1000)


### PR DESCRIPTION
*Description of changes:*

Increased REST request timeout in http client from 5 to 10 seconds to avoid unit test failures


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
