### PR TITLE
set OPENDISTRO_SECURITY_TEST_OPENSSL_OPT back to true during unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       run: mvn checkstyle:checkstyle
 
     - name: Test
-      run: mvn test
+      run: OPENDISTRO_SECURITY_TEST_OPENSSL_OPT=true mvn test
 
     - name: Coverage
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
*Description of changes:*

OPENDISTRO_SECURITY_TEST_OPENSSL_OPT should be set to `true` to make openssl optional. I missed it in d5b14637.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
