### PR TITLE
Fix the security plugin so that we can use X-Opaque-Id

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/transport/OpenDistroSecurityInterceptor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/transport/OpenDistroSecurityInterceptor.java
@@ -137,7 +137,6 @@ public class OpenDistroSecurityInterceptor {
                             || (k.equals("_opendistro_security_source_field_context") && ! (request instanceof SearchRequest) && !(request instanceof GetRequest))
                             || k.startsWith("_opendistro_security_trace")
                             || k.startsWith(ConfigConstants.OPENDISTRO_SECURITY_INITIAL_ACTION_CLASS_HEADER)
-                            || k.equals(Task.X_OPAQUE_ID)
             )));
 
             if (OpenDistroSecurityPlugin.GuiceHolder.getRemoteClusterService().isCrossClusterSearchEnabled()

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/TaskTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/TaskTests.java
@@ -42,5 +42,6 @@ public class TaskTests extends SingleClusterTest {
                 , new BasicHeader(Task.X_OPAQUE_ID, "myOpaqueId12"))).getStatusCode());
         System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().split("X-Opaque-Id").length > 2);
+        Assert.assertTrue(!res.getBody().contains("failures"));
     }
 }


### PR DESCRIPTION
*Description of changes:*

The X-Opaque-Id header, when provided on the HTTP request header, would cause security plugin throws an exception. When a search request comes in, the security plugin stashes the context, hoping to start with a brand new, empty one, and re-insert headers in a whitelist (mostly security plugin headers). X-Opaque-Id is whitelisted too and re-inserted to the header. However, when we stash context, ES leaves out everything except X-Opaque-id. Thus, when we re-insert X-Opaque-id, we get exception indicating an X-Opaque-id is already present. This PR removes X-Opaque-Id from the security plugin's whitelisted headers.

This PR also fixes a test related to X-Opaque-Id: previously, it won't expose the bug, now it will.

Testing done:
- manually verified the fix mitigates the issue in a cluster.
- fix a test to expose this issue.

*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/security/issues/342

From the above issue, you can find the output of related test output before/after the fix to see the difference. Plus, from the link to the stash method 's code, you can see that opaque-id is already copied.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
