### PR TITLE
Migrate dynamic config from listener pattern to publish/subscribe event bus

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
@@ -65,23 +65,22 @@ import com.amazon.opendistroforelasticsearch.security.auth.blocking.ClientBlockR
 import com.amazon.opendistroforelasticsearch.security.auth.internal.NoOpAuthenticationBackend;
 import com.amazon.opendistroforelasticsearch.security.configuration.AdminDNs;
 import com.amazon.opendistroforelasticsearch.security.http.XFFResolver;
-import com.amazon.opendistroforelasticsearch.security.securityconf.ConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigFactory.DCFListener;
 import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.InternalUsersModel;
 import com.amazon.opendistroforelasticsearch.security.ssl.util.Utils;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.HTTPHelper;
 import com.amazon.opendistroforelasticsearch.security.user.AuthCredentials;
 import com.amazon.opendistroforelasticsearch.security.user.User;
+
 import com.google.common.base.Strings;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.Multimap;
+import com.google.common.eventbus.Subscribe;
 
-public class BackendRegistry implements DCFListener {
+public class BackendRegistry {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
     private SortedSet<AuthDomain> restAuthDomains;
@@ -207,8 +206,8 @@ public class BackendRegistry implements DCFListener {
         transportImpersonationCache.invalidateAll();
     }
 
-    @Override
-    public void onChanged(ConfigModel cm, DynamicConfigModel dcm, InternalUsersModel ium) {
+    @Subscribe
+    public void onDynamicConfigModelChanged(DynamicConfigModel dcm) {
 
         invalidateCache();
         transportUsernameAttribute = dcm.getTransportUsernameAttribute();// config.dynamic.transport_userrname_attribute;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/internal/InternalAuthenticationBackend.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/internal/InternalAuthenticationBackend.java
@@ -44,14 +44,13 @@ import org.elasticsearch.ElasticsearchSecurityException;
 
 import com.amazon.opendistroforelasticsearch.security.auth.AuthenticationBackend;
 import com.amazon.opendistroforelasticsearch.security.auth.AuthorizationBackend;
-import com.amazon.opendistroforelasticsearch.security.securityconf.ConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigFactory.DCFListener;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
 import com.amazon.opendistroforelasticsearch.security.securityconf.InternalUsersModel;
 import com.amazon.opendistroforelasticsearch.security.user.AuthCredentials;
 import com.amazon.opendistroforelasticsearch.security.user.User;
 
-public class InternalAuthenticationBackend implements AuthenticationBackend, AuthorizationBackend, DCFListener {
+import com.google.common.eventbus.Subscribe;
+
+public class InternalAuthenticationBackend implements AuthenticationBackend, AuthorizationBackend {
 
     private InternalUsersModel internalUsersModel;
 
@@ -164,8 +163,8 @@ public class InternalAuthenticationBackend implements AuthenticationBackend, Aut
 
     }
 
-    @Override
-    public void onChanged(ConfigModel cf, DynamicConfigModel dcf, InternalUsersModel ium) {
+    @Subscribe
+    public void onInternalUsersModelChanged(InternalUsersModel ium) {
         this.internalUsersModel = ium;
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/CompatConfig.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/CompatConfig.java
@@ -35,13 +35,12 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 
-import com.amazon.opendistroforelasticsearch.security.securityconf.ConfigModel;
 import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.InternalUsersModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigFactory.DCFListener;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 
-public class CompatConfig implements DCFListener {
+import com.google.common.eventbus.Subscribe;
+
+public class CompatConfig {
 
     private final Logger log = LogManager.getLogger(getClass());
     private final Settings staticSettings;
@@ -52,8 +51,8 @@ public class CompatConfig implements DCFListener {
         this.staticSettings = environment.settings(); 
     }
     
-    @Override
-    public void onChanged(ConfigModel cm, DynamicConfigModel dcm, InternalUsersModel ium) {
+    @Subscribe
+    public void onDynamicConfigModelChanged(DynamicConfigModel dcm) {
         this.dcm = dcm;
         log.debug("dynamicSecurityConfig updated?: {}", (dcm != null));
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityIndexSearcherWrapper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityIndexSearcherWrapper.java
@@ -36,9 +36,6 @@ import java.util.Set;
 
 import com.amazon.opendistroforelasticsearch.security.privileges.PrivilegesEvaluator;
 import com.amazon.opendistroforelasticsearch.security.securityconf.ConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigFactory;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.InternalUsersModel;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -54,7 +51,9 @@ import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.HeaderHelper;
 import com.amazon.opendistroforelasticsearch.security.user.User;
 
-public class OpenDistroSecurityIndexSearcherWrapper implements CheckedFunction<DirectoryReader, DirectoryReader, IOException>, DynamicConfigFactory.DCFListener  {
+import com.google.common.eventbus.Subscribe;
+
+public class OpenDistroSecurityIndexSearcherWrapper implements CheckedFunction<DirectoryReader, DirectoryReader, IOException>  {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
     protected final ThreadContext threadContext;
@@ -79,8 +78,8 @@ public class OpenDistroSecurityIndexSearcherWrapper implements CheckedFunction<D
         this.protectedIndexEnabled = settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ENABLED_KEY, ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ENABLED_DEFAULT);
     }
 
-    @Override
-    public void onChanged(ConfigModel cm, DynamicConfigModel dcm, InternalUsersModel ium) {
+    @Subscribe
+    public void onConfigModelChanged(ConfigModel cm) {
         this.configModel = cm;
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/http/XFFResolver.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/http/XFFResolver.java
@@ -41,13 +41,12 @@ import org.elasticsearch.http.netty4.Netty4HttpChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import com.amazon.opendistroforelasticsearch.security.securityconf.ConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigFactory.DCFListener;
 import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.InternalUsersModel;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 
-public class XFFResolver implements DCFListener {
+import com.google.common.eventbus.Subscribe;
+
+public class XFFResolver {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
     private volatile boolean enabled;
@@ -94,8 +93,8 @@ public class XFFResolver implements DCFListener {
         }
     }
 
-    @Override
-    public void onChanged(ConfigModel cm, DynamicConfigModel dcm, InternalUsersModel ium) {
+    @Subscribe
+    public void onDynamicConfigModelChanged(DynamicConfigModel dcm) {
         enabled = dcm.isXffEnabled();
         if(enabled) {
             detector = new RemoteIpDetector();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
@@ -82,16 +82,15 @@ import com.amazon.opendistroforelasticsearch.security.configuration.Configuratio
 import com.amazon.opendistroforelasticsearch.security.resolver.IndexResolverReplacer;
 import com.amazon.opendistroforelasticsearch.security.resolver.IndexResolverReplacer.Resolved;
 import com.amazon.opendistroforelasticsearch.security.securityconf.ConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigFactory.DCFListener;
 import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.InternalUsersModel;
 import com.amazon.opendistroforelasticsearch.security.securityconf.SecurityRoles;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 import com.amazon.opendistroforelasticsearch.security.user.User;
 
+import com.google.common.eventbus.Subscribe;
 
-public class PrivilegesEvaluator implements DCFListener {
+public class PrivilegesEvaluator {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
     protected final Logger actionTrace = LogManager.getLogger("opendistro_security_action_trace");
@@ -146,11 +145,14 @@ public class PrivilegesEvaluator implements DCFListener {
         this.advancedModulesEnabled = advancedModulesEnabled;
     }
 
+    @Subscribe
+    public void onConfigModelChanged(ConfigModel configModel) {
+        this.configModel = configModel;
+    }
 
-    @Override
-    public void onChanged(ConfigModel cm, DynamicConfigModel dcm, InternalUsersModel ium) {
+    @Subscribe
+    public void onDynamicConfigModelChanged(DynamicConfigModel dcm) {
         this.dcm = dcm;
-        this.configModel = cm;
     }
 
     private SecurityRoles getSecurityRoles(Set<String> roles) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
@@ -94,16 +94,14 @@ import org.elasticsearch.transport.TransportRequest;
 
 import com.amazon.opendistroforelasticsearch.security.OpenDistroSecurityPlugin;
 import com.amazon.opendistroforelasticsearch.security.configuration.ClusterInfoHolder;
-import com.amazon.opendistroforelasticsearch.security.securityconf.ConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigFactory.DCFListener;
 import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.InternalUsersModel;
 import com.amazon.opendistroforelasticsearch.security.support.SnapshotRestoreHelper;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.eventbus.Subscribe;
 
-public final class IndexResolverReplacer implements DCFListener {
+public final class IndexResolverReplacer {
 
     private static final Set<String> NULL_SET = new HashSet<>(Collections.singleton(null));
     private final Logger log = LogManager.getLogger(this.getClass());
@@ -778,8 +776,8 @@ public final class IndexResolverReplacer implements DCFListener {
         }
     }
 
-    @Override
-    public void onChanged(ConfigModel cm, DynamicConfigModel dcm, InternalUsersModel ium) {
+    @Subscribe
+    public void onDynamicConfigModelChanged(DynamicConfigModel dcm) {
         respectRequestIndicesOptions = dcm.isRespectRequestIndicesEnabled();
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigFactory.java
@@ -2,7 +2,6 @@ package com.amazon.opendistroforelasticsearch.security.securityconf;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +34,8 @@ import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.RoleM
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.RoleV7;
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.TenantV7;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+
+import com.google.common.eventbus.EventBus;
 
 public class DynamicConfigFactory implements Initializable, ConfigurationChangeListener {
 
@@ -81,7 +82,7 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
     protected final Logger log = LogManager.getLogger(this.getClass());
     private final ConfigurationRepository cr;
     private final AtomicBoolean initialized = new AtomicBoolean();
-    private final List<DCFListener> listeners = new ArrayList<>();
+    private final EventBus eventBus = new EventBus("DynamicConfig");
     private final Settings esSettings;
     private final Path configPath;
     private final InternalAuthenticationBackend iab = new InternalAuthenticationBackend();
@@ -141,6 +142,9 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
             
         }
 
+        final DynamicConfigModel dcm;
+        final InternalUsersModel ium;
+        final ConfigModel cm;
         if(config.getImplementingClass() == ConfigV7.class) {
                 //statics
                 
@@ -180,29 +184,23 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
             
 
             //rebuild v7 Models
-            DynamicConfigModel dcm = new DynamicConfigModelV7(getConfigV7(config), esSettings, configPath, iab);
-            InternalUsersModel ium = new InternalUsersModelV7((SecurityDynamicConfiguration<InternalUserV7>) internalusers);
-            ConfigModel cm = new ConfigModelV7((SecurityDynamicConfiguration<RoleV7>) roles,(SecurityDynamicConfiguration<RoleMappingsV7>)rolesmapping, (SecurityDynamicConfiguration<ActionGroupsV7>)actionGroups, (SecurityDynamicConfiguration<TenantV7>) tenants,dcm, esSettings);
+            dcm = new DynamicConfigModelV7(getConfigV7(config), esSettings, configPath, iab);
+            ium = new InternalUsersModelV7((SecurityDynamicConfiguration<InternalUserV7>) internalusers);
+            cm = new ConfigModelV7((SecurityDynamicConfiguration<RoleV7>) roles,(SecurityDynamicConfiguration<RoleMappingsV7>)rolesmapping, (SecurityDynamicConfiguration<ActionGroupsV7>)actionGroups, (SecurityDynamicConfiguration<TenantV7>) tenants,dcm, esSettings);
 
-            //notify listeners
-            
-            for(DCFListener listener: listeners) {
-                listener.onChanged(cm, dcm, ium);
-            }
-        
         } else {
 
             //rebuild v6 Models
-            DynamicConfigModel dcmv6 = new DynamicConfigModelV6(getConfigV6(config), esSettings, configPath, iab);
-            InternalUsersModel iumv6 = new InternalUsersModelV6((SecurityDynamicConfiguration<InternalUserV6>) internalusers);
-            ConfigModel cmv6 = new ConfigModelV6((SecurityDynamicConfiguration<RoleV6>) roles, (SecurityDynamicConfiguration<ActionGroupsV6>)actionGroups, (SecurityDynamicConfiguration<RoleMappingsV6>)rolesmapping, dcmv6, esSettings);
+            dcm = new DynamicConfigModelV6(getConfigV6(config), esSettings, configPath, iab);
+            ium = new InternalUsersModelV6((SecurityDynamicConfiguration<InternalUserV6>) internalusers);
+            cm = new ConfigModelV6((SecurityDynamicConfiguration<RoleV6>) roles, (SecurityDynamicConfiguration<ActionGroupsV6>)actionGroups, (SecurityDynamicConfiguration<RoleMappingsV6>)rolesmapping, dcm, esSettings);
             
-            //notify listeners
-            
-            for(DCFListener listener: listeners) {
-                listener.onChanged(cmv6, dcmv6, iumv6);
-            }
         }
+
+        //notify subscribers
+        eventBus.post(cm);
+        eventBus.post(dcm);
+        eventBus.post(ium);
 
         initialized.set(true);
         
@@ -225,12 +223,12 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
         return initialized.get();
     }
     
-    public void registerDCFListener(DCFListener listener) {
-        listeners.add(listener);
+    public void registerDCFListener(Object listener) {
+        eventBus.register(listener);
     }
-    
-    public static interface DCFListener {
-        void onChanged(ConfigModel cm, DynamicConfigModel dcm, InternalUsersModel ium);
+
+    public void unregisterDCFListener(Object listener) {
+        eventBus.unregister(listener);
     }
     
     private static class InternalUsersModelV7 extends InternalUsersModel {


### PR DESCRIPTION
*Issue #, if available: n/a

*Description of changes: publish/subscribe event bus is more flexible and will require less changes in the future. Please see [Event Bus](https://github.com/google/guava/wiki/EventBusExplained)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
