### PR TITLE
Switch from Guava EventBus to Greenrobot EventBus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,12 @@
             <version>${guava.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.greenrobot</groupId>
+            <artifactId>eventbus</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+
         <!-- Apache commons cli -->
         <dependency>
             <groupId>commons-cli</groupId>

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
@@ -59,6 +59,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequest;
+import org.greenrobot.eventbus.Subscribe;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog;
 import com.amazon.opendistroforelasticsearch.security.auth.blocking.ClientBlockRegistry;
@@ -78,7 +79,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.Multimap;
-import com.google.common.eventbus.Subscribe;
 
 public class BackendRegistry {
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/internal/InternalAuthenticationBackend.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/internal/InternalAuthenticationBackend.java
@@ -47,8 +47,7 @@ import com.amazon.opendistroforelasticsearch.security.auth.AuthorizationBackend;
 import com.amazon.opendistroforelasticsearch.security.securityconf.InternalUsersModel;
 import com.amazon.opendistroforelasticsearch.security.user.AuthCredentials;
 import com.amazon.opendistroforelasticsearch.security.user.User;
-
-import com.google.common.eventbus.Subscribe;
+import org.greenrobot.eventbus.Subscribe;
 
 public class InternalAuthenticationBackend implements AuthenticationBackend, AuthorizationBackend {
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/CompatConfig.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/CompatConfig.java
@@ -34,11 +34,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
+import org.greenrobot.eventbus.Subscribe;
 
 import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
-
-import com.google.common.eventbus.Subscribe;
 
 public class CompatConfig {
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityIndexSearcherWrapper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityIndexSearcherWrapper.java
@@ -46,12 +46,11 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
+import org.greenrobot.eventbus.Subscribe;
 
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.HeaderHelper;
 import com.amazon.opendistroforelasticsearch.security.user.User;
-
-import com.google.common.eventbus.Subscribe;
 
 public class OpenDistroSecurityIndexSearcherWrapper implements CheckedFunction<DirectoryReader, DirectoryReader, IOException>  {
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/http/XFFResolver.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/http/XFFResolver.java
@@ -40,11 +40,10 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.http.netty4.Netty4HttpChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.greenrobot.eventbus.Subscribe;
 
 import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
-
-import com.google.common.eventbus.Subscribe;
 
 public class XFFResolver {
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
@@ -75,6 +75,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.greenrobot.eventbus.Subscribe;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog;
 import com.amazon.opendistroforelasticsearch.security.configuration.ClusterInfoHolder;
@@ -87,8 +88,6 @@ import com.amazon.opendistroforelasticsearch.security.securityconf.SecurityRoles
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 import com.amazon.opendistroforelasticsearch.security.user.User;
-
-import com.google.common.eventbus.Subscribe;
 
 public class PrivilegesEvaluator {
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
@@ -91,6 +91,7 @@ import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotUtils;
 import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.TransportRequest;
+import org.greenrobot.eventbus.Subscribe;
 
 import com.amazon.opendistroforelasticsearch.security.OpenDistroSecurityPlugin;
 import com.amazon.opendistroforelasticsearch.security.configuration.ClusterInfoHolder;
@@ -99,7 +100,6 @@ import com.amazon.opendistroforelasticsearch.security.support.SnapshotRestoreHel
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.eventbus.Subscribe;
 
 public final class IndexResolverReplacer {
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigFactory.java
@@ -12,6 +12,8 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.EventBusBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.amazon.opendistroforelasticsearch.security.DefaultObjectMapper;
@@ -35,10 +37,9 @@ import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.RoleV
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.TenantV7;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 
-import com.google.common.eventbus.EventBus;
-
 public class DynamicConfigFactory implements Initializable, ConfigurationChangeListener {
 
+    public static final EventBusBuilder EVENT_BUS_BUILDER = EventBus.builder();
     private static SecurityDynamicConfiguration<RoleV7> staticRoles = SecurityDynamicConfiguration.empty();
     private static SecurityDynamicConfiguration<ActionGroupsV7> staticActionGroups = SecurityDynamicConfiguration.empty();
     private static SecurityDynamicConfiguration<TenantV7> staticTenants = SecurityDynamicConfiguration.empty();
@@ -82,7 +83,7 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
     protected final Logger log = LogManager.getLogger(this.getClass());
     private final ConfigurationRepository cr;
     private final AtomicBoolean initialized = new AtomicBoolean();
-    private final EventBus eventBus = new EventBus("DynamicConfig");
+    private final EventBus eventBus = EVENT_BUS_BUILDER.build();
     private final Settings esSettings;
     private final Path configPath;
     private final InternalAuthenticationBackend iab = new InternalAuthenticationBackend();


### PR DESCRIPTION
*Issue #, if available: #369

*Description of changes: Guava EventBus implementation tries to find all possible Subscribers and requires "accessDeclaredMembers" runtime permission for all classes that the object being registered with the EventBus inherits from. That includes `java.lang.Object` that is available in multiple protection domains and for some domains ES does not grant the necessary permission. Instead of Guava, we may use an alternate implementation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
