### PR TITLE
Remove invalid option.

### DIFF
--- a/securityconfig/elasticsearch.yml.example
+++ b/securityconfig/elasticsearch.yml.example
@@ -71,9 +71,6 @@ opendistro_security.roles_mapping_resolution: MAPPING_ONLY
 # Tune threadpool max size queue length, default is 100000
 #opendistro_security.audit.threadpool.max_queue_len: 100000
 
-# If enable_request_details is true then the audit log event will also contain
-# details like the search query. Default is false. 
-#opendistro_security.audit.enable_request_details: true
 # Ignore users, e.g. do not log audit requests from that users (default: no ignored users)
 #opendistro_security.audit.ignore_users: ['kibanaserver','some*user','/also.*regex possible/']"
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/IgnoreAuditUsersTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/IgnoreAuditUsersTest.java
@@ -75,7 +75,6 @@ public class IgnoreAuditUsersTest {
         Settings settings = Settings.builder()
                 .put("opendistro_security.audit.ignore_users", ignoreUser)
                 .put("opendistro_security.audit.type", TestAuditlogImpl.class.getName())
-                .put("opendistro_security.audit.enable_request_details", true)
                 .build();
         AbstractAuditLog al = new AuditLogImpl(settings, null, null, newThreadPool(ConfigConstants.OPENDISTRO_SECURITY_USER, ignoreUserObj), null, cs);
         TestAuditlogImpl.clear();
@@ -126,7 +125,6 @@ public class IgnoreAuditUsersTest {
         Settings settings = Settings.builder()
                 .put("opendistro_security.audit.type", TestAuditlogImpl.class.getName())
                 .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_TRANSPORT, true)
-                .put("opendistro_security.audit.enable_request_details", true)
                 .putList("opendistro_security.audit.ignore_users", "*")
                 .build();
 


### PR DESCRIPTION
`opendistro_security.audit.enable_request_details` is not valid anymore.

I tried with ODFE 1.6.0 and ES gives the following error:

```
[2020-04-10T16:52:22,592][ERROR][o.e.b.Bootstrap          ] [data01] Exception
java.lang.IllegalArgumentException: unknown setting [opendistro_security.audit.enable_request_details] did you mean any of [opendistro_security.audit.enable_rest, opendistro_security.audit.enable_transport, opendistro_security.audit.log_request_body]?
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.