### PR TITLE
Changing file permissions for securityconfig files

### DIFF
--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -27,9 +27,16 @@
             <outputDirectory>${file.separator}</outputDirectory>
             <includes>
                 <include>tools/**</include>
+            </includes>
+            <fileMode>0750</fileMode>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}</directory>
+            <outputDirectory>${file.separator}</outputDirectory>
+            <includes>
                 <include>securityconfig/**</include>
             </includes>
-            <fileMode>0755</fileMode>
+            <fileMode>0640</fileMode>
         </fileSet>
         <fileSet>
             <outputDirectory>${file.separator}</outputDirectory>

--- a/src/main/assemblies/securityadmin-standalone.xml
+++ b/src/main/assemblies/securityadmin-standalone.xml
@@ -13,7 +13,7 @@
       <includes>
         <include>tools/**</include>
       </includes>
-      <fileMode>0755</fileMode>
+      <fileMode>0750</fileMode>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}</directory>
@@ -21,7 +21,7 @@
       <includes>
         <include>securityconfig/**</include>
       </includes>
-      <fileMode>0755</fileMode>
+      <fileMode>0640</fileMode>
     </fileSet>
   </fileSets>
   <dependencySets>


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* Updated securityconfig yml file permissions to disable files being world-readable and executable by default.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
