### PR TITLE
Run maven in batch mode during Github workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,9 +19,16 @@ jobs:
     - name: Checkout security
       uses: actions/checkout@v2
 
+    - name: Cache Maven packages
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+
     - name: Build
       run: |
-        mvn clean package -Padvanced -DskipTests
+        mvn -B clean package -Padvanced -DskipTests
         artifact_zip=`ls $(pwd)/target/releases/opendistro_security-*.zip | grep -v admin-standalone`
         ./gradlew build buildDeb buildRpm --no-daemon -ParchivePath=$artifact_zip -Dbuild.snapshot=false
         mkdir artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,18 @@ jobs:
     - name: Checkout security
       uses: actions/checkout@v2
 
+    - name: Cache Maven packages
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+
     - name: Checkstyle
-      run: mvn checkstyle:checkstyle
+      run: mvn -B checkstyle:checkstyle
 
     - name: Test
-      run: OPENDISTRO_SECURITY_TEST_OPENSSL_OPT=true mvn test
+      run: OPENDISTRO_SECURITY_TEST_OPENSSL_OPT=true mvn -B test
 
     - name: Coverage
       uses: codecov/codecov-action@v1
@@ -35,7 +42,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Package
-      run: mvn clean package -Padvanced -DskipTests
+      run: mvn -B clean package -Padvanced -DskipTests
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Run maven in batch mode during Github workflows
- Cache artifacts on Github for faster CI builds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
