### PR TITLE
opendistro-1.1 backport] Implement APIs and datamodel to configure nodes_dn dynamically

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@opendistro-for-elasticsearch/security

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@opendistro-for-elasticsearch/security
+* @opendistro-for-elasticsearch/security

--- a/legacy/securityconfig_v6/nodes_dn.yml
+++ b/legacy/securityconfig_v6/nodes_dn.yml
@@ -1,0 +1,6 @@
+---
+# Define nodesdn mapping name and corresponding values after removing "{}"
+# cluster1:
+#   nodes_dn:
+#       - CN=*.example.com
+{}

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,12 @@
             <version>${guava.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.greenrobot</groupId>
+            <artifactId>eventbus</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+
         <!-- Apache commons cli -->
         <dependency>
             <groupId>commons-cli</groupId>

--- a/securityconfig/elasticsearch.yml.example
+++ b/securityconfig/elasticsearch.yml.example
@@ -14,10 +14,23 @@ opendistro_security.advanced_modules_enabled: true
 
 # Specify a list of DNs which denote the other nodes in the cluster.
 # This settings support wildcards and regular expressions
-# This setting only has effect if 'opendistro_security.cert.intercluster_request_evaluator_class' is not set.
+# The list of DNs are also read from security index **in addition** to the yml configuration if
+# opendistro_security.nodes_dn_dynamic_config_enabled is true.
+# NOTE: This setting only has effect if 'opendistro_security.cert.intercluster_request_evaluator_class' is not set.
 opendistro_security.nodes_dn:
   - "CN=*.example.com, OU=SSL, O=Test, L=Test, C=DE"
   - "CN=node.other.com, OU=SSL, O=Test, L=Test, C=DE"
+
+# The nodes_dn_dynamic_config_enabled settings is geared towards cross_cluster usecases where there is a need to
+# manage the whitelisted nodes_dn without having to restart the nodes everytime a new cross_cluster remote is configured
+# Setting nodes_dn_dynamic_config_enabled to true enables **super-admin callable** /_opendistro/_security/api/nodesdn APIs
+# which provide means to update/retrieve nodesdn dynamically.
+#
+# NOTE: The overall whitelisted nodes_dn evaluated comes from both the opendistro_security.nodes_dn and the ones stored
+# in security index.
+# (default: false)
+# NOTE2: This setting only has effect if 'opendistro_security.cert.intercluster_request_evaluator_class' is not set.
+opendistro_security.nodes_dn_dynamic_config_enabled: false
 
 # Defines the DNs (distinguished names) of certificates
 # to which admin privileges should be assigned (mandatory)

--- a/securityconfig/nodes_dn.yml
+++ b/securityconfig/nodes_dn.yml
@@ -1,0 +1,8 @@
+_meta:
+  type: "nodesdn"
+  config_version: 2
+
+# Define nodesdn mapping name and corresponding values
+# cluster1:
+#   nodes_dn:
+#       - CN=*.example.com

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -800,6 +800,13 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
                 interClusterRequestEvaluator, cs, Objects.requireNonNull(sslExceptionHandler), Objects.requireNonNull(cih));
         components.add(principalExtractor);
 
+        // NOTE: We need to create DefaultInterClusterRequestEvaluator before creating ConfigurationRepository since the latter requires security index to be accessible which means
+        // communciation with other nodes is already up. However for the communication to be up, there needs to be trusted nodes_dn. Hence the base values from elasticsearch.yml
+        // is used to first establish trust between same cluster nodes and there after dynamic config is loaded if enabled.
+        if (DEFAULT_INTERCLUSTER_REQUEST_EVALUATOR_CLASS.equals(className)) {
+            DefaultInterClusterRequestEvaluator e = (DefaultInterClusterRequestEvaluator) interClusterRequestEvaluator;
+            e.subscribeForChanges(dcf);
+        }
 
         components.add(adminDns);
         components.add(cr);
@@ -854,6 +861,8 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
     
             settings.add(Setting.simpleString(ConfigConstants.OPENDISTRO_SECURITY_CERT_INTERCLUSTER_REQUEST_EVALUATOR_CLASS, Property.NodeScope, Property.Filtered));
             settings.add(Setting.listSetting(ConfigConstants.OPENDISTRO_SECURITY_NODES_DN, Collections.emptyList(), Function.identity(), Property.NodeScope));//not filtered here
+
+            settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_NODES_DN_DYNAMIC_CONFIG_ENABLED, false, Property.NodeScope));//not filtered here
     
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_ENABLE_SNAPSHOT_RESTORE_PRIVILEGE, ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_ENABLE_SNAPSHOT_RESTORE_PRIVILEGE,
                     Property.NodeScope, Property.Filtered));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
@@ -59,6 +59,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequest;
+import org.greenrobot.eventbus.Subscribe;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog;
 import com.amazon.opendistroforelasticsearch.security.auth.blocking.ClientBlockRegistry;
@@ -78,7 +79,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.Multimap;
-import com.google.common.eventbus.Subscribe;
 
 public class BackendRegistry {
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
@@ -65,23 +65,22 @@ import com.amazon.opendistroforelasticsearch.security.auth.blocking.ClientBlockR
 import com.amazon.opendistroforelasticsearch.security.auth.internal.NoOpAuthenticationBackend;
 import com.amazon.opendistroforelasticsearch.security.configuration.AdminDNs;
 import com.amazon.opendistroforelasticsearch.security.http.XFFResolver;
-import com.amazon.opendistroforelasticsearch.security.securityconf.ConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigFactory.DCFListener;
 import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.InternalUsersModel;
 import com.amazon.opendistroforelasticsearch.security.ssl.util.Utils;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.HTTPHelper;
 import com.amazon.opendistroforelasticsearch.security.user.AuthCredentials;
 import com.amazon.opendistroforelasticsearch.security.user.User;
+
 import com.google.common.base.Strings;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.Multimap;
+import com.google.common.eventbus.Subscribe;
 
-public class BackendRegistry implements DCFListener {
+public class BackendRegistry {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
     private SortedSet<AuthDomain> restAuthDomains;
@@ -207,8 +206,8 @@ public class BackendRegistry implements DCFListener {
         transportImpersonationCache.invalidateAll();
     }
 
-    @Override
-    public void onChanged(ConfigModel cm, DynamicConfigModel dcm, InternalUsersModel ium) {
+    @Subscribe
+    public void onDynamicConfigModelChanged(DynamicConfigModel dcm) {
 
         invalidateCache();
         transportUsernameAttribute = dcm.getTransportUsernameAttribute();// config.dynamic.transport_userrname_attribute;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/internal/InternalAuthenticationBackend.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/internal/InternalAuthenticationBackend.java
@@ -47,8 +47,7 @@ import com.amazon.opendistroforelasticsearch.security.auth.AuthorizationBackend;
 import com.amazon.opendistroforelasticsearch.security.securityconf.InternalUsersModel;
 import com.amazon.opendistroforelasticsearch.security.user.AuthCredentials;
 import com.amazon.opendistroforelasticsearch.security.user.User;
-
-import com.google.common.eventbus.Subscribe;
+import org.greenrobot.eventbus.Subscribe;
 
 public class InternalAuthenticationBackend implements AuthenticationBackend, AuthorizationBackend {
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/internal/InternalAuthenticationBackend.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/internal/InternalAuthenticationBackend.java
@@ -44,14 +44,13 @@ import org.elasticsearch.ElasticsearchSecurityException;
 
 import com.amazon.opendistroforelasticsearch.security.auth.AuthenticationBackend;
 import com.amazon.opendistroforelasticsearch.security.auth.AuthorizationBackend;
-import com.amazon.opendistroforelasticsearch.security.securityconf.ConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigFactory.DCFListener;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
 import com.amazon.opendistroforelasticsearch.security.securityconf.InternalUsersModel;
 import com.amazon.opendistroforelasticsearch.security.user.AuthCredentials;
 import com.amazon.opendistroforelasticsearch.security.user.User;
 
-public class InternalAuthenticationBackend implements AuthenticationBackend, AuthorizationBackend, DCFListener {
+import com.google.common.eventbus.Subscribe;
+
+public class InternalAuthenticationBackend implements AuthenticationBackend, AuthorizationBackend {
 
     private InternalUsersModel internalUsersModel;
 
@@ -151,8 +150,8 @@ public class InternalAuthenticationBackend implements AuthenticationBackend, Aut
 
     }
 
-    @Override
-    public void onChanged(ConfigModel cf, DynamicConfigModel dcf, InternalUsersModel ium) {
+    @Subscribe
+    public void onInternalUsersModelChanged(InternalUsersModel ium) {
         this.internalUsersModel = ium;
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/CompatConfig.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/CompatConfig.java
@@ -35,13 +35,12 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 
-import com.amazon.opendistroforelasticsearch.security.securityconf.ConfigModel;
 import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.InternalUsersModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigFactory.DCFListener;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 
-public class CompatConfig implements DCFListener {
+import com.google.common.eventbus.Subscribe;
+
+public class CompatConfig {
 
     private final Logger log = LogManager.getLogger(getClass());
     private final Settings staticSettings;
@@ -52,8 +51,8 @@ public class CompatConfig implements DCFListener {
         this.staticSettings = environment.settings(); 
     }
     
-    @Override
-    public void onChanged(ConfigModel cm, DynamicConfigModel dcm, InternalUsersModel ium) {
+    @Subscribe
+    public void onDynamicConfigModelChanged(DynamicConfigModel dcm) {
         this.dcm = dcm;
         log.debug("dynamicSecurityConfig updated?: {}", (dcm != null));
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/CompatConfig.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/CompatConfig.java
@@ -34,11 +34,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
+import org.greenrobot.eventbus.Subscribe;
 
 import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
-
-import com.google.common.eventbus.Subscribe;
 
 public class CompatConfig {
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/ConfigurationRepository.java
@@ -52,9 +52,6 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
-import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -64,10 +61,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.concurrent.ThreadContext.StoredContext;
-import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog;
@@ -96,7 +90,7 @@ public class ConfigurationRepository {
     private final ComplianceConfig complianceConfig;
     private final ThreadPool threadPool;
     private DynamicConfigFactory dynamicConfigFactory;
-    private final int configVersion = 2;
+    private static final int DEFAULT_CONFIG_VERSION = 2;
     private final Thread bgThread;
     private final AtomicBoolean installDefaultConfig = new AtomicBoolean();
     private final boolean acceptInvalid;
@@ -146,14 +140,16 @@ public class ConfigurationRepository {
                                             .actionGet().isAcknowledged();
                                     LOGGER.info("Index {} created?: {}", opendistrosecurityIndex, ok);
                                     if(ok) {
-                                        ConfigHelper.uploadFile(client, cd+"config.yml", opendistrosecurityIndex, CType.CONFIG, configVersion);
-                                        ConfigHelper.uploadFile(client, cd+"roles.yml", opendistrosecurityIndex, CType.ROLES, configVersion);
-                                        ConfigHelper.uploadFile(client, cd+"roles_mapping.yml", opendistrosecurityIndex, CType.ROLESMAPPING, configVersion);
-                                        ConfigHelper.uploadFile(client, cd+"internal_users.yml", opendistrosecurityIndex, CType.INTERNALUSERS, configVersion);
-                                        ConfigHelper.uploadFile(client, cd+"action_groups.yml", opendistrosecurityIndex, CType.ACTIONGROUPS, configVersion);
-                                        if(configVersion == 2) {
-                                            ConfigHelper.uploadFile(client, cd+"tenants.yml", opendistrosecurityIndex, CType.TENANTS, configVersion);
+                                        ConfigHelper.uploadFile(client, cd+"config.yml", opendistrosecurityIndex, CType.CONFIG, DEFAULT_CONFIG_VERSION);
+                                        ConfigHelper.uploadFile(client, cd+"roles.yml", opendistrosecurityIndex, CType.ROLES, DEFAULT_CONFIG_VERSION);
+                                        ConfigHelper.uploadFile(client, cd+"roles_mapping.yml", opendistrosecurityIndex, CType.ROLESMAPPING, DEFAULT_CONFIG_VERSION);
+                                        ConfigHelper.uploadFile(client, cd+"internal_users.yml", opendistrosecurityIndex, CType.INTERNALUSERS, DEFAULT_CONFIG_VERSION);
+                                        ConfigHelper.uploadFile(client, cd+"action_groups.yml", opendistrosecurityIndex, CType.ACTIONGROUPS, DEFAULT_CONFIG_VERSION);
+                                        if(DEFAULT_CONFIG_VERSION == 2) {
+                                            ConfigHelper.uploadFile(client, cd+"tenants.yml", opendistrosecurityIndex, CType.TENANTS, DEFAULT_CONFIG_VERSION);
                                         }
+                                        final boolean populateEmptyIfFileMissing = true;
+                                        ConfigHelper.uploadFile(client, cd+"nodes_dn.yml", opendistrosecurityIndex, CType.NODESDN, DEFAULT_CONFIG_VERSION, populateEmptyIfFileMissing);
                                         LOGGER.info("Default config applied");
                                     } else {
                                         LOGGER.error("Can not create {} index", opendistrosecurityIndex);
@@ -376,5 +372,9 @@ public class ConfigurationRepository {
 
     private static String formatDate(long date) {
         return new SimpleDateFormat("yyyy-MM-dd", OpenDistroSecurityUtils.EN_Locale).format(new Date(date));
+    }
+
+    public static int getDefaultConfigVersion() {
+        return ConfigurationRepository.DEFAULT_CONFIG_VERSION;
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityIndexSearcherWrapper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityIndexSearcherWrapper.java
@@ -36,9 +36,6 @@ import java.util.Set;
 
 import com.amazon.opendistroforelasticsearch.security.privileges.PrivilegesEvaluator;
 import com.amazon.opendistroforelasticsearch.security.securityconf.ConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigFactory;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.InternalUsersModel;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -56,7 +53,9 @@ import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.HeaderHelper;
 import com.amazon.opendistroforelasticsearch.security.user.User;
 
-public class OpenDistroSecurityIndexSearcherWrapper extends IndexSearcherWrapper implements DynamicConfigFactory.DCFListener {
+import com.google.common.eventbus.Subscribe;
+
+public class OpenDistroSecurityIndexSearcherWrapper extends IndexSearcherWrapper {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
     protected final ThreadContext threadContext;
@@ -81,8 +80,8 @@ public class OpenDistroSecurityIndexSearcherWrapper extends IndexSearcherWrapper
         this.protectedIndexEnabled = settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ENABLED_KEY, ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ENABLED_DEFAULT);
     }
 
-    @Override
-    public void onChanged(ConfigModel cm, DynamicConfigModel dcm, InternalUsersModel ium) {
+    @Subscribe
+    public void onConfigModelChanged(ConfigModel cm) {
         this.configModel = cm;
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
@@ -194,6 +194,11 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 
 		final SecurityDynamicConfiguration<?> existingConfiguration = load(getConfigName(), false);
 
+		if (existingConfiguration.getSeqNo() < 0) {
+		    forbidden(channel, "Security index need to be updated to support '" + getConfigName().toLCString() + "'. Use OpenDistroSecurityAdmin to populate.");
+		    return;
+		}
+
 		if (isHidden(existingConfiguration, name)) {
 			forbidden(channel, "Resource '"+ name +"' is not available.");
 			return;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/Endpoint.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/Endpoint.java
@@ -28,5 +28,6 @@ public enum Endpoint {
 	AUTHTOKEN,
 	TENANTS,
 	MIGRATE,
-	VALIDATE;
+	VALIDATE,
+	NODESDN;
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/MigrateApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/MigrateApiAction.java
@@ -18,6 +18,7 @@ package com.amazon.opendistroforelasticsearch.security.dlic.rest.api;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.NodesDn;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
@@ -107,6 +108,7 @@ public class MigrateApiAction extends AbstractApiAction {
         final SecurityDynamicConfiguration<InternalUserV6> internalUsersV6 = (SecurityDynamicConfiguration<InternalUserV6>) load(CType.INTERNALUSERS, true);
         final SecurityDynamicConfiguration<RoleV6> rolesV6 = (SecurityDynamicConfiguration<RoleV6>) load(CType.ROLES, true);
         final SecurityDynamicConfiguration<RoleMappingsV6> rolesmappingV6 = (SecurityDynamicConfiguration<RoleMappingsV6>) load(CType.ROLESMAPPING, true);
+        final SecurityDynamicConfiguration<NodesDn> nodesDnV6 = (SecurityDynamicConfiguration<NodesDn>) load(CType.NODESDN, true);
 
         final SecurityDynamicConfiguration<ActionGroupsV7> actionGroupsV7 = Migration.migrateActionGroups(actionGroupsV6);
         final SecurityDynamicConfiguration<ConfigV7> configV7 = Migration.migrateConfig(configV6);
@@ -114,6 +116,7 @@ public class MigrateApiAction extends AbstractApiAction {
         final Tuple<SecurityDynamicConfiguration<RoleV7>, SecurityDynamicConfiguration<TenantV7>> rolesTenantsV7 = Migration.migrateRoles(rolesV6,
                 rolesmappingV6);
         final SecurityDynamicConfiguration<RoleMappingsV7> rolesmappingV7 = Migration.migrateRoleMappings(rolesmappingV6);
+        final SecurityDynamicConfiguration<NodesDn> nodesDnV7 = Migration.migrateNodesDn(nodesDnV6);
 
         final int replicas = cs.state().metaData().index(opendistroIndex).getNumberOfReplicas();
         final String autoExpandReplicas = cs.state().metaData().index(opendistroIndex).getSettings().get(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS);
@@ -157,6 +160,8 @@ public class MigrateApiAction extends AbstractApiAction {
                                                 XContentHelper.toXContent(rolesTenantsV7.v2(), XContentType.JSON, false)));
                                         br.add(new IndexRequest().id(CType.ROLESMAPPING.toLCString()).source(CType.ROLESMAPPING.toLCString(),
                                                 XContentHelper.toXContent(rolesmappingV7, XContentType.JSON, false)));
+                                        br.add(new IndexRequest().id(CType.NODESDN.toLCString()).source(CType.NODESDN.toLCString(),
+                                            XContentHelper.toXContent(nodesDnV7, XContentType.JSON, false)));
                                     } catch (final IOException e1) {
                                         log.error("Unable to create bulk request " + e1, e1);
                                         internalErrorResponse(channel, "Unable to create bulk request.");

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/NodesDnApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/NodesDnApiAction.java
@@ -1,0 +1,160 @@
+/*
+ * Portions Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.dlic.rest.api;
+
+import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog;
+import com.amazon.opendistroforelasticsearch.security.configuration.AdminDNs;
+import com.amazon.opendistroforelasticsearch.security.configuration.ConfigurationRepository;
+import com.amazon.opendistroforelasticsearch.security.dlic.rest.validation.AbstractConfigurationValidator;
+import com.amazon.opendistroforelasticsearch.security.dlic.rest.validation.NodesDnValidator;
+import com.amazon.opendistroforelasticsearch.security.privileges.PrivilegesEvaluator;
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.CType;
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.SecurityDynamicConfiguration;
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.NodesDn;
+import com.amazon.opendistroforelasticsearch.security.ssl.transport.PrincipalExtractor;
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestRequest.Method;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This class implements CRUD operations to manage dynamic NodesDn. The primary usecase is targeted at cross-cluster where
+ * in node restart can be avoided by populating the coordinating cluster's nodes_dn values.
+ *
+ * The APIs are only accessible to SuperAdmin since the configuration controls the core application layer trust validation.
+ * By default the APIs are disabled and can be enabled by a YML setting - {@link ConfigConstants#OPENDISTRO_SECURITY_NODES_DN_DYNAMIC_CONFIG_ENABLED}
+ *
+ * The backing data is stored in {@link ConfigConstants#OPENDISTRO_SECURITY_CONFIG_INDEX_NAME} which is populated during bootstrap.
+ * For existing clusters, {@link com.amazon.opendistroforelasticsearch.security.tools.OpenDistroSecurityAdmin} tool can
+ * be used to populate the index.
+ *
+ * See {@link com.amazon.opendistroforelasticsearch.security.dlic.rest.api.NodesDnApiTest} for usage examples.
+ */
+public class NodesDnApiAction extends PatchableResourceApiAction {
+    public static final String STATIC_ES_YML_NODES_DN = "STATIC_ES_YML_NODES_DN";
+    private final List<String> staticNodesDnFromEsYml;
+
+    @Inject
+    public NodesDnApiAction(final Settings settings, final Path configPath, final RestController controller, final Client client,
+        final AdminDNs adminDNs, final ConfigurationRepository cl, final ClusterService cs,
+        final PrincipalExtractor principalExtractor, final PrivilegesEvaluator evaluator, ThreadPool threadPool, AuditLog auditLog) {
+        super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
+        this.staticNodesDnFromEsYml = settings.getAsList(ConfigConstants.OPENDISTRO_SECURITY_NODES_DN, Collections.emptyList());
+    }
+
+    @Override
+    protected void registerHandlers(RestController controller, Settings settings) {
+        if (settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_NODES_DN_DYNAMIC_CONFIG_ENABLED, false)) {
+            controller.registerHandler(Method.GET, "/_opendistro/_security/api/nodesdn/{name}", this);
+            controller.registerHandler(Method.GET, "/_opendistro/_security/api/nodesdn/", this);
+            controller.registerHandler(Method.DELETE, "/_opendistro/_security/api/nodesdn/{name}", this);
+            controller.registerHandler(Method.PUT, "/_opendistro/_security/api/nodesdn/{name}", this);
+            controller.registerHandler(Method.PATCH, "/_opendistro/_security/api/nodesdn/", this);
+            controller.registerHandler(Method.PATCH, "/_opendistro/_security/api/nodesdn/{name}", this);
+        }
+    }
+
+    @Override
+    protected void handleApiRequest(RestChannel channel, RestRequest request, Client client) throws IOException {
+        if (!isSuperAdmin()) {
+            forbidden(channel, "API allowed only for admin.");
+            return;
+        }
+        super.handleApiRequest(channel, request, client);
+    }
+
+    protected void consumeParameters(final RestRequest request) {
+        request.param("name");
+        request.param("show_all");
+    }
+
+    @Override
+    protected boolean isReservedAndAccessible(SecurityDynamicConfiguration<?> existingConfiguration, String name) {
+        if (STATIC_ES_YML_NODES_DN.equals(name)) {
+            return false;
+        }
+        return super.isReservedAndAccessible(existingConfiguration, name);
+    }
+
+    @Override
+    protected void handleGet(final RestChannel channel, RestRequest request, Client client, final JsonNode content) throws IOException {
+        final String resourcename = request.param("name");
+
+        final SecurityDynamicConfiguration<?> configuration = load(getConfigName(), true);
+        filter(configuration);
+
+        // no specific resource requested, return complete config
+        if (resourcename == null || resourcename.length() == 0) {
+            final Boolean showAll = request.paramAsBoolean("show_all", Boolean.FALSE);
+            if (showAll) {
+                putStaticEntry(configuration);
+            }
+            successResponse(channel, configuration);
+            return;
+        }
+
+        if (!configuration.exists(resourcename)) {
+            notFound(channel, "Resource '" + resourcename + "' not found.");
+            return;
+        }
+
+        configuration.removeOthers(resourcename);
+        successResponse(channel, configuration);
+    }
+
+    private void putStaticEntry(SecurityDynamicConfiguration<?> configuration) {
+        if (NodesDn.class.equals(configuration.getImplementingClass())) {
+            NodesDn nodesDn = new NodesDn();
+            nodesDn.setNodesDn(staticNodesDnFromEsYml);
+            ((SecurityDynamicConfiguration<NodesDn>)configuration).putCEntry(STATIC_ES_YML_NODES_DN, nodesDn);
+        } else {
+            throw new RuntimeException("Unknown class type - " + configuration.getImplementingClass());
+        }
+    }
+
+    @Override
+    protected Endpoint getEndpoint() {
+        return Endpoint.NODESDN;
+    }
+
+    @Override
+    protected String getResourceName() {
+        return "nodesdn";
+    }
+
+    @Override
+    protected CType getConfigName() {
+        return CType.NODESDN;
+    }
+
+    @Override
+    protected AbstractConfigurationValidator getValidator(RestRequest request, BytesReference ref, Object... params) {
+        return new NodesDnValidator(request, ref, this.settings, params);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/OpenDistroSecurityRestApiActions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/OpenDistroSecurityRestApiActions.java
@@ -51,6 +51,7 @@ public class OpenDistroSecurityRestApiActions {
         handlers.add(new MigrateApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
         handlers.add(new ValidateApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
         handlers.add(new AccountApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
+        handlers.add(new NodesDnApiAction(settings, configPath, controller, client, adminDns, cr, cs, principalExtractor, evaluator, threadPool, auditLog));
         return Collections.unmodifiableCollection(handlers);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
@@ -73,6 +73,11 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
         String name = request.param("name");
         SecurityDynamicConfiguration<?> existingConfiguration = load(getConfigName(), false);
 
+        if (existingConfiguration.getSeqNo() < 0) {
+            forbidden(channel, "Config '" + getConfigName().toLCString() + "' isn't configured. Use OpenDistroSecurityAdmin to populate.");
+            return;
+        }
+
         JsonNode jsonPatch;
 
         try {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/ValidateApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/ValidateApiAction.java
@@ -18,6 +18,7 @@ package com.amazon.opendistroforelasticsearch.security.dlic.rest.api;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.NodesDn;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -91,6 +92,7 @@ public class ValidateApiAction extends AbstractApiAction {
             final SecurityDynamicConfiguration<InternalUserV6> internalUsersV6 = (SecurityDynamicConfiguration<InternalUserV6>) load(CType.INTERNALUSERS, true, acceptInvalid);
             final SecurityDynamicConfiguration<RoleV6> rolesV6 = (SecurityDynamicConfiguration<RoleV6>) load(CType.ROLES, true, acceptInvalid);
             final SecurityDynamicConfiguration<RoleMappingsV6> rolesmappingV6 = (SecurityDynamicConfiguration<RoleMappingsV6>) load(CType.ROLESMAPPING, true, acceptInvalid);
+            final SecurityDynamicConfiguration<NodesDn> nodesDnV6 = (SecurityDynamicConfiguration<NodesDn>) load(CType.NODESDN, true, acceptInvalid);
 
             final SecurityDynamicConfiguration<ActionGroupsV7> actionGroupsV7 = Migration.migrateActionGroups(actionGroupsV6);
             final SecurityDynamicConfiguration<ConfigV7> configV7 = Migration.migrateConfig(configV6);
@@ -98,6 +100,7 @@ public class ValidateApiAction extends AbstractApiAction {
             final Tuple<SecurityDynamicConfiguration<RoleV7>, SecurityDynamicConfiguration<TenantV7>> rolesTenantsV7 = Migration.migrateRoles(rolesV6,
                     rolesmappingV6);
             final SecurityDynamicConfiguration<RoleMappingsV7> rolesmappingV7 = Migration.migrateRoleMappings(rolesmappingV6);
+            final SecurityDynamicConfiguration<NodesDn> nodesDnV7 = Migration.migrateNodesDn(nodesDnV6);
 
             successResponse(channel, "OK.");
         } catch (Exception e) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/NodesDnValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/NodesDnValidator.java
@@ -1,0 +1,31 @@
+/*
+ * Portions Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.dlic.rest.validation;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestRequest;
+
+public class NodesDnValidator extends AbstractConfigurationValidator {
+
+    public NodesDnValidator(final RestRequest request, final BytesReference ref, final Settings esSettings, Object... param) {
+        super(request, ref, esSettings, param);
+        this.payloadMandatory = true;
+
+        allowedKeys.put("nodes_dn", DataType.ARRAY);
+        mandatoryKeys.add("nodes_dn");
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/http/XFFResolver.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/http/XFFResolver.java
@@ -41,13 +41,12 @@ import org.elasticsearch.http.netty4.Netty4HttpChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import com.amazon.opendistroforelasticsearch.security.securityconf.ConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigFactory.DCFListener;
 import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.InternalUsersModel;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 
-public class XFFResolver implements DCFListener {
+import com.google.common.eventbus.Subscribe;
+
+public class XFFResolver {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
     private volatile boolean enabled;
@@ -94,8 +93,8 @@ public class XFFResolver implements DCFListener {
         }
     }
 
-    @Override
-    public void onChanged(ConfigModel cm, DynamicConfigModel dcm, InternalUsersModel ium) {
+    @Subscribe
+    public void onDynamicConfigModelChanged(DynamicConfigModel dcm) {
         enabled = dcm.isXffEnabled();
         if(enabled) {
             detector = new RemoteIpDetector();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/http/XFFResolver.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/http/XFFResolver.java
@@ -40,11 +40,10 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.http.netty4.Netty4HttpChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.greenrobot.eventbus.Subscribe;
 
 import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
-
-import com.google.common.eventbus.Subscribe;
 
 public class XFFResolver {
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
@@ -82,16 +82,15 @@ import com.amazon.opendistroforelasticsearch.security.configuration.Configuratio
 import com.amazon.opendistroforelasticsearch.security.resolver.IndexResolverReplacer;
 import com.amazon.opendistroforelasticsearch.security.resolver.IndexResolverReplacer.Resolved;
 import com.amazon.opendistroforelasticsearch.security.securityconf.ConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigFactory.DCFListener;
 import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.InternalUsersModel;
 import com.amazon.opendistroforelasticsearch.security.securityconf.SecurityRoles;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 import com.amazon.opendistroforelasticsearch.security.user.User;
 
+import com.google.common.eventbus.Subscribe;
 
-public class PrivilegesEvaluator implements DCFListener {
+public class PrivilegesEvaluator {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
     protected final Logger actionTrace = LogManager.getLogger("opendistro_security_action_trace");
@@ -146,11 +145,14 @@ public class PrivilegesEvaluator implements DCFListener {
         this.advancedModulesEnabled = advancedModulesEnabled;
     }
 
+    @Subscribe
+    public void onConfigModelChanged(ConfigModel configModel) {
+        this.configModel = configModel;
+    }
 
-    @Override
-    public void onChanged(ConfigModel cm, DynamicConfigModel dcm, InternalUsersModel ium) {
+    @Subscribe
+    public void onDynamicConfigModelChanged(DynamicConfigModel dcm) {
         this.dcm = dcm;
-        this.configModel = cm;
     }
 
     private SecurityRoles getSecurityRoles(Set<String> roles) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
@@ -75,6 +75,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.greenrobot.eventbus.Subscribe;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog;
 import com.amazon.opendistroforelasticsearch.security.configuration.ClusterInfoHolder;
@@ -87,8 +88,6 @@ import com.amazon.opendistroforelasticsearch.security.securityconf.SecurityRoles
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 import com.amazon.opendistroforelasticsearch.security.user.User;
-
-import com.google.common.eventbus.Subscribe;
 
 public class PrivilegesEvaluator {
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
@@ -91,6 +91,7 @@ import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotUtils;
 import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.TransportRequest;
+import org.greenrobot.eventbus.Subscribe;
 
 import com.amazon.opendistroforelasticsearch.security.OpenDistroSecurityPlugin;
 import com.amazon.opendistroforelasticsearch.security.configuration.ClusterInfoHolder;
@@ -99,7 +100,6 @@ import com.amazon.opendistroforelasticsearch.security.support.SnapshotRestoreHel
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.eventbus.Subscribe;
 
 public final class IndexResolverReplacer {
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
@@ -94,16 +94,14 @@ import org.elasticsearch.transport.TransportRequest;
 
 import com.amazon.opendistroforelasticsearch.security.OpenDistroSecurityPlugin;
 import com.amazon.opendistroforelasticsearch.security.configuration.ClusterInfoHolder;
-import com.amazon.opendistroforelasticsearch.security.securityconf.ConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigFactory.DCFListener;
 import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
-import com.amazon.opendistroforelasticsearch.security.securityconf.InternalUsersModel;
 import com.amazon.opendistroforelasticsearch.security.support.SnapshotRestoreHelper;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.eventbus.Subscribe;
 
-public final class IndexResolverReplacer implements DCFListener {
+public final class IndexResolverReplacer {
 
     private static final Set<String> NULL_SET = new HashSet<>(Collections.singleton(null));
     private final Logger log = LogManager.getLogger(this.getClass());
@@ -782,8 +780,8 @@ public final class IndexResolverReplacer implements DCFListener {
         }
     }
 
-    @Override
-    public void onChanged(ConfigModel cm, DynamicConfigModel dcm, InternalUsersModel ium) {
+    @Subscribe
+    public void onDynamicConfigModelChanged(DynamicConfigModel dcm) {
         respectRequestIndicesOptions = dcm.isRespectRequestIndicesEnabled();
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigFactory.java
@@ -11,6 +11,8 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.EventBusBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.amazon.opendistroforelasticsearch.security.DefaultObjectMapper;
@@ -33,14 +35,14 @@ import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.RoleM
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.RoleV7;
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.TenantV7;
 
-import com.google.common.eventbus.EventBus;
-
 public class DynamicConfigFactory implements Initializable, ConfigurationChangeListener {
-    
+
     private static final SecurityDynamicConfiguration<RoleV7> staticRoles;
     private static final SecurityDynamicConfiguration<ActionGroupsV7> staticActionGroups;
     private static final SecurityDynamicConfiguration<TenantV7> staticTenants;
     
+    public static final EventBusBuilder EVENT_BUS_BUILDER = EventBus.builder();
+
     static {
         try {
             JsonNode staticRolesJsonNode = DefaultObjectMapper.YAML_MAPPER.readTree(DynamicConfigFactory.class.getResourceAsStream("/static_config/static_roles.yml"));
@@ -52,6 +54,7 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
         } catch (Exception e) {
             throw ExceptionsHelper.convertToRuntime(e);
         }
+
     }
     
     public static final SecurityDynamicConfiguration<RoleV7> getStaticRoles() {
@@ -85,7 +88,7 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
     protected final Logger log = LogManager.getLogger(this.getClass());
     private final ConfigurationRepository cr;
     private final AtomicBoolean initialized = new AtomicBoolean();
-    private final EventBus eventBus = new EventBus("DynamicConfig");
+    private final EventBus eventBus = EVENT_BUS_BUILDER.build();
     private final Settings esSettings;
     private final Path configPath;
     private final InternalAuthenticationBackend iab = new InternalAuthenticationBackend();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigFactory.java
@@ -3,8 +3,11 @@ package com.amazon.opendistroforelasticsearch.security.securityconf;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.NodesDn;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ExceptionsHelper;
@@ -114,7 +117,8 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
         SecurityDynamicConfiguration<?> roles = cr.getConfiguration(CType.ROLES);
         SecurityDynamicConfiguration<?> rolesmapping = cr.getConfiguration(CType.ROLESMAPPING);
         SecurityDynamicConfiguration<?> tenants = cr.getConfiguration(CType.TENANTS);
-        
+        SecurityDynamicConfiguration<?> nodesDn = cr.getConfiguration(CType.NODESDN);
+
         if(log.isDebugEnabled()) {
             String logmsg = "current config (because of "+typeToConfig.keySet()+")\n"+
             " actionGroups: "+actionGroups.getImplementingClass()+" with "+actionGroups.getCEntries().size()+" entries\n"+
@@ -122,7 +126,8 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
             " internalusers: "+internalusers.getImplementingClass()+" with "+internalusers.getCEntries().size()+" entries\n"+
             " roles: "+roles.getImplementingClass()+" with "+roles.getCEntries().size()+" entries\n"+
             " rolesmapping: "+rolesmapping.getImplementingClass()+" with "+rolesmapping.getCEntries().size()+" entries\n"+
-            " tenants: "+tenants.getImplementingClass()+" with "+tenants.getCEntries().size()+" entries";
+            " tenants: "+tenants.getImplementingClass()+" with "+tenants.getCEntries().size()+" entries\n"+
+            " nodesdn: "+nodesDn.getImplementingClass()+" with "+nodesDn.getCEntries().size()+" entries";
             log.debug(logmsg);
             
         }
@@ -130,6 +135,7 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
         final DynamicConfigModel dcm;
         final InternalUsersModel ium;
         final ConfigModel cm;
+        final NodesDnModel nm = new NodesDnModelImpl(nodesDn);
         if(config.getImplementingClass() == ConfigV7.class) {
                 //statics
                 
@@ -179,13 +185,14 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
             dcm = new DynamicConfigModelV6(getConfigV6(config), esSettings, configPath, iab);
             ium = new InternalUsersModelV6((SecurityDynamicConfiguration<InternalUserV6>) internalusers);
             cm = new ConfigModelV6((SecurityDynamicConfiguration<RoleV6>) roles, (SecurityDynamicConfiguration<ActionGroupsV6>)actionGroups, (SecurityDynamicConfiguration<RoleMappingsV6>)rolesmapping, dcm, esSettings);
-            
+
         }
 
         //notify subscribers
         eventBus.post(cm);
         eventBus.post(dcm);
         eventBus.post(ium);
+        eventBus.post(nm);
 
         initialized.set(true);
         
@@ -295,6 +302,23 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
             return tmp==null?null:tmp.getHash();
         }
         
+    }
+
+    private static class NodesDnModelImpl extends NodesDnModel {
+
+        SecurityDynamicConfiguration<NodesDn> configuration;
+
+        public NodesDnModelImpl(SecurityDynamicConfiguration<?> configuration) {
+            super();
+            this.configuration = null == configuration.getCType() ? SecurityDynamicConfiguration.empty() :
+                (SecurityDynamicConfiguration<NodesDn>)configuration;
+        }
+
+        @Override
+        public Map<String, List<String>> getNodesDn() {
+            return this.configuration.getCEntries().entrySet().stream().collect(
+                Collectors.toMap(Entry::getKey, entry -> entry.getValue().getNodesDn()));
+        }
     }
    
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigFactory.java
@@ -1,7 +1,6 @@
 package com.amazon.opendistroforelasticsearch.security.securityconf;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -33,6 +32,8 @@ import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.Inter
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.RoleMappingsV7;
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.RoleV7;
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.TenantV7;
+
+import com.google.common.eventbus.EventBus;
 
 public class DynamicConfigFactory implements Initializable, ConfigurationChangeListener {
     
@@ -84,7 +85,7 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
     protected final Logger log = LogManager.getLogger(this.getClass());
     private final ConfigurationRepository cr;
     private final AtomicBoolean initialized = new AtomicBoolean();
-    private final List<DCFListener> listeners = new ArrayList<>();
+    private final EventBus eventBus = new EventBus("DynamicConfig");
     private final Settings esSettings;
     private final Path configPath;
     private final InternalAuthenticationBackend iab = new InternalAuthenticationBackend();
@@ -123,6 +124,9 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
             
         }
 
+        final DynamicConfigModel dcm;
+        final InternalUsersModel ium;
+        final ConfigModel cm;
         if(config.getImplementingClass() == ConfigV7.class) {
                 //statics
                 
@@ -162,29 +166,23 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
             
 
             //rebuild v7 Models
-            DynamicConfigModel dcm = new DynamicConfigModelV7(getConfigV7(config), esSettings, configPath, iab);
-            InternalUsersModel ium = new InternalUsersModelV7((SecurityDynamicConfiguration<InternalUserV7>) internalusers);
-            ConfigModel cm = new ConfigModelV7((SecurityDynamicConfiguration<RoleV7>) roles,(SecurityDynamicConfiguration<RoleMappingsV7>)rolesmapping, (SecurityDynamicConfiguration<ActionGroupsV7>)actionGroups, (SecurityDynamicConfiguration<TenantV7>) tenants,dcm, esSettings);
+            dcm = new DynamicConfigModelV7(getConfigV7(config), esSettings, configPath, iab);
+            ium = new InternalUsersModelV7((SecurityDynamicConfiguration<InternalUserV7>) internalusers);
+            cm = new ConfigModelV7((SecurityDynamicConfiguration<RoleV7>) roles,(SecurityDynamicConfiguration<RoleMappingsV7>)rolesmapping, (SecurityDynamicConfiguration<ActionGroupsV7>)actionGroups, (SecurityDynamicConfiguration<TenantV7>) tenants,dcm, esSettings);
 
-            //notify listeners
-            
-            for(DCFListener listener: listeners) {
-                listener.onChanged(cm, dcm, ium);
-            }
-        
         } else {
 
             //rebuild v6 Models
-            DynamicConfigModel dcmv6 = new DynamicConfigModelV6(getConfigV6(config), esSettings, configPath, iab);
-            InternalUsersModel iumv6 = new InternalUsersModelV6((SecurityDynamicConfiguration<InternalUserV6>) internalusers);
-            ConfigModel cmv6 = new ConfigModelV6((SecurityDynamicConfiguration<RoleV6>) roles, (SecurityDynamicConfiguration<ActionGroupsV6>)actionGroups, (SecurityDynamicConfiguration<RoleMappingsV6>)rolesmapping, dcmv6, esSettings);
+            dcm = new DynamicConfigModelV6(getConfigV6(config), esSettings, configPath, iab);
+            ium = new InternalUsersModelV6((SecurityDynamicConfiguration<InternalUserV6>) internalusers);
+            cm = new ConfigModelV6((SecurityDynamicConfiguration<RoleV6>) roles, (SecurityDynamicConfiguration<ActionGroupsV6>)actionGroups, (SecurityDynamicConfiguration<RoleMappingsV6>)rolesmapping, dcm, esSettings);
             
-            //notify listeners
-            
-            for(DCFListener listener: listeners) {
-                listener.onChanged(cmv6, dcmv6, iumv6);
-            }
         }
+
+        //notify subscribers
+        eventBus.post(cm);
+        eventBus.post(dcm);
+        eventBus.post(ium);
 
         initialized.set(true);
         
@@ -207,12 +205,12 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
         return initialized.get();
     }
     
-    public void registerDCFListener(DCFListener listener) {
-        listeners.add(listener);
+    public void registerDCFListener(Object listener) {
+        eventBus.register(listener);
     }
-    
-    public static interface DCFListener {
-        void onChanged(ConfigModel cm, DynamicConfigModel dcm, InternalUsersModel ium);
+
+    public void unregisterDCFListener(Object listener) {
+        eventBus.unregister(listener);
     }
     
     private static class InternalUsersModelV7 extends InternalUsersModel {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/Migration.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/Migration.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.CType;
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.Meta;
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.NodesDn;
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v6.*;
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.*;
@@ -96,7 +97,20 @@ public class Migration {
         }
         return c7;
     }
-    
+
+    public static SecurityDynamicConfiguration<NodesDn> migrateNodesDn(SecurityDynamicConfiguration<NodesDn> nodesDn) {
+        final SecurityDynamicConfiguration<NodesDn> migrated = SecurityDynamicConfiguration.empty();
+        migrated.setCType(nodesDn.getCType());
+        migrated.set_meta(new Meta());
+        migrated.get_meta().setConfig_version(2);
+        migrated.get_meta().setType("nodesdn");
+
+        for(final Entry<String, NodesDn> entry: nodesDn.getCEntries().entrySet()) {
+            migrated.putCEntry(entry.getKey(), new NodesDn(entry.getValue()));
+        }
+        return migrated;
+    }
+
     public static SecurityDynamicConfiguration<InternalUserV7>  migrateInternalUsers(SecurityDynamicConfiguration<InternalUserV6> r6is) throws MigrationException {
         final SecurityDynamicConfiguration<InternalUserV7> i7 = SecurityDynamicConfiguration.empty();
         i7.setCType(r6is.getCType());

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/NodesDnModel.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/NodesDnModel.java
@@ -1,0 +1,23 @@
+/*
+ * Portions Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.securityconf;
+
+import java.util.List;
+import java.util.Map;
+
+public abstract class NodesDnModel {
+    public abstract Map<String, List<String>> getNodesDn();
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/CType.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/CType.java
@@ -29,7 +29,8 @@ public enum CType {
     CONFIG(toMap(1, ConfigV6.class, 2, ConfigV7.class)),
     ROLES(toMap(1, RoleV6.class, 2, RoleV7.class)), 
     ROLESMAPPING(toMap(1, RoleMappingsV6.class, 2, RoleMappingsV7.class)),
-    TENANTS(toMap(2, TenantV7.class));
+    TENANTS(toMap(2, TenantV7.class)),
+    NODESDN(toMap(1, NodesDn.class, 2, NodesDn.class));
 
     private Map<Integer, Class<?>> implementations;
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/NodesDn.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/NodesDn.java
@@ -1,0 +1,50 @@
+/*
+ * Portions Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.securityconf.impl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class NodesDn {
+    @JsonProperty(value = "nodes_dn")
+    private List<String> nodesDn;
+
+    public NodesDn() {
+        this.nodesDn = Collections.emptyList();
+    }
+
+    public NodesDn(NodesDn nodesDn) {
+        this.nodesDn = new ArrayList<>(nodesDn.getNodesDn());
+    }
+
+    @JsonProperty(value = "nodes_dn")
+    public List<String> getNodesDn() {
+        return this.nodesDn;
+    }
+
+    @JsonProperty(value = "nodes_dn")
+    public void setNodesDn(List<String> nodesDn) {
+        this.nodesDn = nodesDn;
+    }
+
+    @Override
+    public String toString() {
+        return "NodesDn [nodes_dn=" + nodesDn + ']';
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
@@ -188,6 +188,7 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_CERT_INTERCLUSTER_REQUEST_EVALUATOR_CLASS = "opendistro_security.cert.intercluster_request_evaluator_class";
     public static final String OPENDISTRO_SECURITY_ADVANCED_MODULES_ENABLED = "opendistro_security.advanced_modules_enabled";
     public static final String OPENDISTRO_SECURITY_NODES_DN = "opendistro_security.nodes_dn";
+    public static final String OPENDISTRO_SECURITY_NODES_DN_DYNAMIC_CONFIG_ENABLED = "opendistro_security.nodes_dn_dynamic_config_enabled";
     public static final String OPENDISTRO_SECURITY_DISABLED = "opendistro_security.disabled";
     public static final String OPENDISTRO_SECURITY_CACHE_TTL_MINUTES = "opendistro_security.cache.ttl_minutes";
     public static final String OPENDISTRO_SECURITY_ALLOW_UNSAFE_DEMOCERTIFICATES = "opendistro_security.allow_unsafe_democertificates";

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/tools/OpenDistroSecurityAdmin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/tools/OpenDistroSecurityAdmin.java
@@ -33,7 +33,6 @@ package com.amazon.opendistroforelasticsearch.security.tools;
 import java.io.ByteArrayInputStream;
 import java.io.Console;
 import java.io.File;
-import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Reader;
@@ -50,6 +49,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.NodesDn;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -553,7 +553,7 @@ public class OpenDistroSecurityAdmin {
 
             if(updateSettings != null) { 
                 Settings indexSettings = Settings.builder().put("index.number_of_replicas", updateSettings).build();
-                ConfigUpdateResponse res = tc.execute(ConfigUpdateAction.INSTANCE, new ConfigUpdateRequest(new String[]{"config","roles","rolesmapping","internalusers","actiongroups"})).actionGet();
+                ConfigUpdateResponse res = tc.execute(ConfigUpdateAction.INSTANCE, new ConfigUpdateRequest(getTypes(true))).actionGet();
                 if(res.hasFailures()) {
                     System.out.println("ERR: Unabe to reload config due to "+res.failures());
                 }
@@ -753,6 +753,9 @@ public class OpenDistroSecurityAdmin {
                 if(!legacy) {
                     success = retrieveFile(tc, cd+"security_tenants_"+date+".yml", index, "tenants", legacy) && success;
                 }
+
+                final boolean populateFileIfEmpty = true;
+                success = retrieveFile(tc, cd+"nodes_dn_"+date+".yml", index, "nodesdn", legacy, populateFileIfEmpty) && success;
                 return (success?0:-1);
             }
 
@@ -833,8 +836,13 @@ public class OpenDistroSecurityAdmin {
 
         return success && !response.hasFailures();
     }
-    
+
     private static boolean uploadFile(final Client tc, final String filepath, final String index, final String _id, final boolean legacy, boolean resolveEnvVars) {
+        return uploadFile(tc, filepath, index, _id, legacy, resolveEnvVars, false);
+    }
+
+    private static boolean uploadFile(final Client tc, final String filepath, final String index, final String _id, final boolean legacy, boolean resolveEnvVars,
+        final boolean populateEmptyIfMissing) {
         
         String type = "_doc";
         String id = _id;
@@ -861,7 +869,7 @@ public class OpenDistroSecurityAdmin {
         
         System.out.println("Will update '"+type+"/" + id + "' with " + filepath+" "+(legacy?"(legacy mode)":""));
         
-        try (Reader reader = new FileReader(filepath)) {
+        try (Reader reader = ConfigHelper.createFileOrStringReader(CType.fromString(_id), legacy ? 1 : 2, filepath, populateEmptyIfMissing)) {
             final String content = CharStreams.toString(reader);
             final String res = tc
                     .index(new IndexRequest(index).type(type).id(id).setRefreshPolicy(RefreshPolicy.IMMEDIATE)
@@ -880,8 +888,12 @@ public class OpenDistroSecurityAdmin {
 
         return false;
     }
-    
+
     private static boolean retrieveFile(final Client tc, final String filepath, final String index, final String _id, final boolean legacy) {
+        return retrieveFile(tc, filepath, index, _id, legacy, false);
+    }
+
+    private static boolean retrieveFile(final Client tc, final String filepath, final String index, final String _id, final boolean legacy, final boolean populateFileIfEmpty) {
         
         String type = "_doc";
         String id = _id;
@@ -897,36 +909,44 @@ public class OpenDistroSecurityAdmin {
 
             final GetResponse response = tc.get(new GetRequest(index).type(type).id(id).refresh(true).realtime(false)).actionGet();
 
-            if (response.isExists()) {
-                if(response.isSourceEmpty()) {
+            boolean isEmpty = !response.isExists() || response.isSourceEmpty();
+            String yaml;
+            if (isEmpty) {
+                if (populateFileIfEmpty) {
+                    yaml = ConfigHelper.createEmptySdcYaml(CType.fromString(_id), legacy ? 1 : 2);
+                } else {
                     System.out.println("   FAIL: Configuration for '"+_id+"' failed because of empty source");
                     return false;
                 }
-                
-                String yaml = convertToYaml(_id, response.getSourceAsBytesRef(), true);
-                
-                if(legacy) {
+            } else {
+                yaml = convertToYaml(_id, response.getSourceAsBytesRef(), true);
+
+                if (null == yaml) {
+                    System.out.println("ERR: YML conversion error for " + _id);
+                    return false;
+
+                }
+
+                if (legacy) {
                     try {
                         ConfigHelper.fromYamlString(yaml, CType.fromString(_id), 1, 0, 0);
                     } catch (Exception e) {
-                        System.out.println("ERR: Seems "+_id+" from cluster is not in legacy format: "+e);
+                        System.out.println("ERR: Seems " + _id + " from cluster is not in legacy format: " + e);
                         return false;
                     }
                 } else {
                     try {
                         ConfigHelper.fromYamlString(yaml, CType.fromString(_id), 2, 0, 0);
                     } catch (Exception e) {
-                        System.out.println("ERR: Seems "+_id+" from cluster is not in SG 7 format: "+e);
+                        System.out.println("ERR: Seems " + _id + " from cluster is not in SG 7 format: " + e);
                         return false;
                     }
                 }
-                
-                writer.write(yaml);
-                System.out.println("   SUCC: Configuration for '"+_id+"' stored in "+filepath);
-                return true;
-            } else {
-                System.out.println("   FAIL: Get configuration for '"+_id+"' because it does not exist");
             }
+
+            writer.write(yaml);
+            System.out.println("   SUCC: Configuration for '"+_id+"' stored in "+filepath);
+            return true;
         } catch (Exception e) {
             System.out.println("   FAIL: Get configuration for '"+_id+"' failed because of "+e.toString());
         }
@@ -956,7 +976,7 @@ public class OpenDistroSecurityAdmin {
     private static String convertToYaml(String type, BytesReference bytes, boolean prettyPrint) throws IOException {
         
         try (XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, OpenDistroSecurityDeprecationHandler.INSTANCE, bytes.streamInput())) {
-            
+
             parser.nextToken();
             parser.nextToken();
             
@@ -1189,7 +1209,8 @@ public class OpenDistroSecurityAdmin {
         if(!legacy) {
             success = retrieveFile(tc, backupDir.getAbsolutePath()+"/tenants.yml", index, "tenants", legacy) && success;
         }
-        
+        success = retrieveFile(tc, backupDir.getAbsolutePath()+"/nodes_dn.yml", index, "nodesdn", legacy, true) && success;
+
         return success?0:-1;
     }
     
@@ -1205,7 +1226,9 @@ public class OpenDistroSecurityAdmin {
         if(!legacy) {
             success = uploadFile(tc, cd+"tenants.yml", index, "tenants", legacy, resolveEnvVars) && success;
         }
-        
+
+        success = uploadFile(tc, cd+"nodes_dn.yml", index, "nodesdn", legacy, resolveEnvVars, true) && success;
+
         if(!success) {
             System.out.println("ERR: cannot upload configuration, see errors above");
             return -1;
@@ -1244,13 +1267,18 @@ public class OpenDistroSecurityAdmin {
             SecurityDynamicConfiguration<RoleMappingsV6> rolesmappingV6 = SecurityDynamicConfiguration.fromNode(DefaultObjectMapper.YAML_MAPPER.readTree(new File(backupDir,"roles_mapping.yml")), CType.ROLESMAPPING, 1, 0, 0);
             Tuple<SecurityDynamicConfiguration<RoleV7>, SecurityDynamicConfiguration<TenantV7>> rolesTenantsV7 = Migration.migrateRoles(SecurityDynamicConfiguration.fromNode(DefaultObjectMapper.YAML_MAPPER.readTree(new File(backupDir,"roles.yml")), CType.ROLES, 1, 0, 0), rolesmappingV6);
             SecurityDynamicConfiguration<RoleMappingsV7> rolesmappingV7 = Migration.migrateRoleMappings(rolesmappingV6);
-            
+            SecurityDynamicConfiguration<NodesDn> nodesDn =
+                Migration.migrateNodesDn(SecurityDynamicConfiguration.fromNode(
+                    DefaultObjectMapper.YAML_MAPPER.readTree(ConfigHelper.createFileOrStringReader(CType.NODESDN, 1, new File(backupDir,"nodes_dn.yml").getAbsolutePath(), true)),
+                    CType.NODESDN, 1, 0, 0));
+
             DefaultObjectMapper.YAML_MAPPER.writeValue(new File(v7Dir, "/action_groups.yml"), actionGroupsV7);
             DefaultObjectMapper.YAML_MAPPER.writeValue(new File(v7Dir, "/config.yml"), configV7);
             DefaultObjectMapper.YAML_MAPPER.writeValue(new File(v7Dir, "/internal_users.yml"), internalUsersV7);
             DefaultObjectMapper.YAML_MAPPER.writeValue(new File(v7Dir, "/roles.yml"), rolesTenantsV7.v1());
             DefaultObjectMapper.YAML_MAPPER.writeValue(new File(v7Dir, "/tenants.yml"), rolesTenantsV7.v2());
             DefaultObjectMapper.YAML_MAPPER.writeValue(new File(v7Dir, "/roles_mapping.yml"), rolesmappingV7);
+            DefaultObjectMapper.YAML_MAPPER.writeValue(new File(v7Dir, "/nodes_dn.yml"), nodesDn);
         } catch (Exception e) {
             System.out.println("ERR: Unable to migrate config files due to "+e);
             e.printStackTrace();
@@ -1264,9 +1292,9 @@ public class OpenDistroSecurityAdmin {
         System.out.println("  done");
         
         System.out.println("-> Upload new configuration into Elasticsearch cluster");
-        
+
         int uploadResult = upload(tc, index, v7Dir.getAbsolutePath()+"/", false, nodesInfo, resolveEnvVars);
-        
+
         if(uploadResult == 0) {
             System.out.println("  done");
         }else {
@@ -1335,7 +1363,7 @@ public class OpenDistroSecurityAdmin {
     
     private static String[] getTypes(boolean legacy) {
         if(legacy) {
-            return new String[]{"config","roles","rolesmapping","internalusers","actiongroups"};
+            return new String[]{"config","roles","rolesmapping","internalusers","actiongroups","nodesdn"};
         }
         return CType.lcStringValues().toArray(new String[0]);
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/transport/DefaultInterClusterRequestEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/transport/DefaultInterClusterRequestEvaluator.java
@@ -37,7 +37,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigFactory;
+import com.amazon.opendistroforelasticsearch.security.securityconf.NodesDnModel;
+import com.google.common.collect.ImmutableList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
@@ -46,16 +51,36 @@ import org.elasticsearch.transport.TransportRequest;
 
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
+import org.greenrobot.eventbus.Subscribe;
 
 public final class DefaultInterClusterRequestEvaluator implements InterClusterRequestEvaluator {
 
     private final Logger log = LogManager.getLogger(this.getClass());
     private final String certOid;
-    private final List<String> nodesDn;
+    private final List<String> staticNodesDnFromEsYml;
+    private boolean dynamicNodesDnConfigEnabled;
+    private volatile Map<String, List<String>> dynamicNodesDn;
 
     public DefaultInterClusterRequestEvaluator(final Settings settings) {
         this.certOid = settings.get(ConfigConstants.OPENDISTRO_SECURITY_CERT_OID, "1.2.3.4.5.5");
-        this.nodesDn = settings.getAsList(ConfigConstants.OPENDISTRO_SECURITY_NODES_DN, Collections.emptyList());
+        this.staticNodesDnFromEsYml = settings.getAsList(ConfigConstants.OPENDISTRO_SECURITY_NODES_DN, Collections.emptyList());
+        this.dynamicNodesDnConfigEnabled = settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_NODES_DN_DYNAMIC_CONFIG_ENABLED, false);
+        this.dynamicNodesDn = Collections.emptyMap();
+    }
+
+    public void subscribeForChanges(DynamicConfigFactory dynamicConfigFactory) {
+        if (this.dynamicNodesDnConfigEnabled) {
+            dynamicConfigFactory.registerDCFListener(this);
+        }
+    }
+
+    private List<String> getNodesDnToEvaluate() {
+        ImmutableList.Builder<String> retVal = ImmutableList.<String>builder()
+            .addAll(this.staticNodesDnFromEsYml);
+        if (dynamicNodesDnConfigEnabled) {
+            retVal.addAll(dynamicNodesDn.values().stream().flatMap(Collection::stream).collect(Collectors.toList()));
+        }
+        return retVal.build();
     }
 
     @Override
@@ -68,6 +93,8 @@ public final class DefaultInterClusterRequestEvaluator implements InterClusterRe
             principals[0] = principal;
             principals[1] = principal.replace(" ","");
         }
+
+        List<String> nodesDn = this.getNodesDnToEvaluate();
         
         if (principals[0] != null && WildcardMatcher.matchAny(nodesDn, principals, true)) {
             
@@ -139,4 +166,8 @@ public final class DefaultInterClusterRequestEvaluator implements InterClusterRe
         return false;
     }
 
+    @Subscribe
+    public void onNodesDnModelChanged(NodesDnModel nm) {
+        this.dynamicNodesDn = Collections.unmodifiableMap(nm.getNodesDn());
+    }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
@@ -82,6 +82,10 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
 	}
 
 	protected final void setupWithRestRoles() throws Exception {
+        setupWithRestRoles(null);
+    }
+
+	protected final void setupWithRestRoles(Settings nodeOverride) throws Exception {
 		Settings.Builder builder = Settings.builder();
 
 		builder.put("opendistro_security.ssl.http.enabled", true)
@@ -102,6 +106,10 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
 		builder.put("opendistro_security.restapi.endpoints_disabled.opendistro_security_role_klingons.ROLESMAPPING.1", "DELETE");
 
 		builder.put("opendistro_security.restapi.endpoints_disabled.opendistro_security_role_vulcans.CONFIG.0", "*");
+
+		if (null != nodeOverride) {
+			builder.put(nodeOverride);
+		}
 
 		setup(Settings.EMPTY, new DynamicSecurityConfig(), builder.build(), init);
 		rh = restHelper();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/NodesDnApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/NodesDnApiTest.java
@@ -1,0 +1,195 @@
+/*
+ * Portions Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.dlic.rest.api;
+
+import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditCategory;
+import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage;
+import com.amazon.opendistroforelasticsearch.security.auditlog.integration.TestAuditlogImpl;
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper.HttpResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.apache.http.Header;
+import org.apache.http.HttpStatus;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class NodesDnApiTest extends AbstractRestApiUnitTest {
+    private HttpResponse response;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private <T> JsonNode asJsonNode(T t) throws Exception {
+        return OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(t));
+    }
+
+    private Map<String, List<String>> nodesDnEntry(String...nodesDn) {
+        return ImmutableMap.of("nodes_dn", Arrays.asList(nodesDn));
+    }
+
+    private void testCrudScenarios(final int expectedStatus, final Header... headers) throws Exception {
+        response = rh.executeGetRequest("_opendistro/_security/api/nodesdn?show_all=true", headers);
+        assertThat(response.getStatusCode(), equalTo(expectedStatus));
+        if (expectedStatus == HttpStatus.SC_OK) {
+            JsonNode expected = asJsonNode(ImmutableMap.of(
+                "cluster1", nodesDnEntry("cn=popeye"),
+                NodesDnApiAction.STATIC_ES_YML_NODES_DN, nodesDnEntry("CN=example.com")));
+
+            JsonNode node = OBJECT_MAPPER.readTree(response.getBody());
+            assertThat(node, equalTo(asJsonNode(expected)));
+        }
+
+        response = rh.executeGetRequest("_opendistro/_security/api/nodesdn?show_all=false", headers);
+        assertThat(response.getBody(), response.getStatusCode(), equalTo(expectedStatus));
+        if (expectedStatus == HttpStatus.SC_OK) {
+            JsonNode expected = asJsonNode(ImmutableMap.of("cluster1", nodesDnEntry("cn=popeye")));
+            JsonNode node = OBJECT_MAPPER.readTree(response.getBody());
+            assertThat(node, equalTo(asJsonNode(expected)));
+        }
+
+        response = rh.executeGetRequest("_opendistro/_security/api/nodesdn", headers);
+        assertThat(response.getBody(), response.getStatusCode(), equalTo(expectedStatus));
+        if (expectedStatus == HttpStatus.SC_OK) {
+            JsonNode expected = asJsonNode(ImmutableMap.of("cluster1", nodesDnEntry("cn=popeye")));
+            JsonNode node = OBJECT_MAPPER.readTree(response.getBody());
+            assertThat(node, equalTo(asJsonNode(expected)));
+        }
+
+        response = rh.executeGetRequest("_opendistro/_security/api/nodesdn/cluster1", headers);
+        assertThat(response.getBody(), response.getStatusCode(), equalTo(expectedStatus));
+        if (expectedStatus == HttpStatus.SC_OK) {
+            JsonNode expected = asJsonNode(ImmutableMap.of("cluster1", nodesDnEntry("cn=popeye")));
+            JsonNode node = OBJECT_MAPPER.readTree(response.getBody());
+            assertThat(node, equalTo(asJsonNode(expected)));
+        }
+
+        response = rh.executePutRequest("_opendistro/_security/api/nodesdn/cluster1", "{\"nodes_dn\": [\"cn=popeye\"]}", headers);
+        assertThat(response.getBody(), response.getStatusCode(), equalTo(expectedStatus));
+
+        response = rh.executePatchRequest("/_opendistro/_security/api/nodesdn/cluster1", "[{ \"op\": \"add\", \"path\": \"/nodes_dn/-\", \"value\": \"bluto\" }]", headers);
+        assertThat(response.getBody(), response.getStatusCode(), equalTo(expectedStatus));
+
+        response = rh.executePatchRequest("/_opendistro/_security/api/nodesdn", "[{ \"op\": \"remove\", \"path\": \"/cluster1/nodes_dn/0\"}]", headers);
+        assertThat(response.getBody(), response.getStatusCode(), equalTo(expectedStatus));
+
+        response = rh.executeDeleteRequest("_opendistro/_security/api/nodesdn/cluster1", headers);
+        assertThat(response.getBody(), response.getStatusCode(), equalTo(expectedStatus));
+    }
+
+    @Test
+    public void testNodesDnApiWithDynamicConfigDisabled() throws Exception {
+        setup();
+        rh.keystore = "restapi/kirk-keystore.jks";
+        rh.sendAdminCertificate = true;
+
+        testCrudScenarios(HttpStatus.SC_BAD_REQUEST);
+    }
+
+    @Test
+    public void testNodesDnApi() throws Exception {
+        Settings settings = Settings.builder().put(ConfigConstants.OPENDISTRO_SECURITY_NODES_DN_DYNAMIC_CONFIG_ENABLED, true)
+            .putList(ConfigConstants.OPENDISTRO_SECURITY_NODES_DN, "CN=example.com")
+            .build();
+        setupWithRestRoles(settings);
+
+        final Header adminCredsHeader = encodeBasicHeader("admin", "admin");
+        final Header nonAdminCredsHeader = encodeBasicHeader("sarek", "sarek");
+
+        {
+            // No creds, no admin certificate - UNAUTHORIZED
+            rh.keystore = "restapi/kirk-keystore.jks";
+            rh.sendAdminCertificate = false;
+            testCrudScenarios(HttpStatus.SC_UNAUTHORIZED);
+        }
+
+        {
+            // admin creds, no admin certificate - FORBIDDEN
+            rh.keystore = "restapi/kirk-keystore.jks";
+            rh.sendAdminCertificate = false;
+            testCrudScenarios(HttpStatus.SC_FORBIDDEN, adminCredsHeader);
+        }
+
+        {
+            // any creds, admin certificate - OK
+            rh.keystore = "restapi/kirk-keystore.jks";
+            rh.sendAdminCertificate = true;
+            testCrudScenarios(HttpStatus.SC_OK, nonAdminCredsHeader);
+        }
+
+        {
+            // any creds, admin certificate, disallowed key - OK
+            rh.keystore = "restapi/kirk-keystore.jks";
+            rh.sendAdminCertificate = true;
+
+            final int expectedStatus = HttpStatus.SC_FORBIDDEN;
+
+            response = rh.executePutRequest("_opendistro/_security/api/nodesdn/" + NodesDnApiAction.STATIC_ES_YML_NODES_DN, "{\"nodes_dn\": [\"cn=popeye\"]}", nonAdminCredsHeader);
+            assertThat(response.getBody(), response.getStatusCode(), equalTo(expectedStatus));
+
+            response = rh.executePatchRequest("/_opendistro/_security/api/nodesdn/" + NodesDnApiAction.STATIC_ES_YML_NODES_DN,
+                "[{ \"op\": \"add\", \"path\": \"/nodes_dn/-\", \"value\": \"bluto\" }]" , nonAdminCredsHeader);
+            assertThat(response.getBody(), response.getStatusCode(), equalTo(expectedStatus));
+
+            response = rh.executeDeleteRequest("_opendistro/_security/api/nodesdn/" + NodesDnApiAction.STATIC_ES_YML_NODES_DN, nonAdminCredsHeader);
+            assertThat(response.getBody(), response.getStatusCode(), equalTo(expectedStatus));
+        }
+    }
+
+    @Test
+    public void testNodesDnApiAuditComplianceLogging() throws Exception {
+        Settings settings = Settings.builder().put(ConfigConstants.OPENDISTRO_SECURITY_NODES_DN_DYNAMIC_CONFIG_ENABLED, true)
+            .putList(ConfigConstants.OPENDISTRO_SECURITY_NODES_DN, "CN=example.com")
+            .put("opendistro_security.audit.type", TestAuditlogImpl.class.getName())
+            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_TRANSPORT, false)
+            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_REST, false)
+            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_RESOLVE_BULK_REQUESTS, false)
+            .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_LOG_DIFFS, true)
+            .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_EXTERNAL_CONFIG_ENABLED, false)
+            .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_INTERNAL_CONFIG_ENABLED, true)
+            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
+            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
+            .build();
+        setupWithRestRoles(settings);
+        TestAuditlogImpl.clear();
+
+        final Header nonAdminCredsHeader = encodeBasicHeader("sarek", "sarek");
+
+        {
+            // any creds, admin certificate - OK
+            rh.keystore = "restapi/kirk-keystore.jks";
+            rh.sendAdminCertificate = true;
+            testCrudScenarios(HttpStatus.SC_OK, nonAdminCredsHeader);
+        }
+
+        System.out.println(TestAuditlogImpl.sb.toString());
+
+        final Map<AuditCategory, Long> expectedCategoryCounts = ImmutableMap.of(
+            AuditCategory.COMPLIANCE_INTERNAL_CONFIG_READ, 4L,
+            AuditCategory.COMPLIANCE_INTERNAL_CONFIG_WRITE, 4L);
+        Map<AuditCategory, Long> actualCategoryCounts = TestAuditlogImpl.messages.stream().collect(Collectors.groupingBy(AuditMessage::getCategory, Collectors.counting()));
+
+        assertThat(actualCategoryCounts, equalTo(expectedCategoryCounts));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/NodesDnApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/NodesDnApiTest.java
@@ -15,7 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.security.dlic.rest.api;
 
-import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditCategory;
+import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage.Category;
 import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditMessage;
 import com.amazon.opendistroforelasticsearch.security.auditlog.integration.TestAuditlogImpl;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
@@ -185,10 +185,10 @@ public class NodesDnApiTest extends AbstractRestApiUnitTest {
 
         System.out.println(TestAuditlogImpl.sb.toString());
 
-        final Map<AuditCategory, Long> expectedCategoryCounts = ImmutableMap.of(
-            AuditCategory.COMPLIANCE_INTERNAL_CONFIG_READ, 4L,
-            AuditCategory.COMPLIANCE_INTERNAL_CONFIG_WRITE, 4L);
-        Map<AuditCategory, Long> actualCategoryCounts = TestAuditlogImpl.messages.stream().collect(Collectors.groupingBy(AuditMessage::getCategory, Collectors.counting()));
+        final Map<AuditMessage.Category, Long> expectedCategoryCounts = ImmutableMap.of(
+            AuditMessage.Category.COMPLIANCE_INTERNAL_CONFIG_READ, 4L,
+            AuditMessage.Category.COMPLIANCE_INTERNAL_CONFIG_WRITE, 4L);
+        Map<AuditMessage.Category, Long> actualCategoryCounts = TestAuditlogImpl.messages.stream().collect(Collectors.groupingBy(AuditMessage::getCategory, Collectors.counting()));
 
         assertThat(actualCategoryCounts, equalTo(expectedCategoryCounts));
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/SSLTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/SSLTest.java
@@ -34,7 +34,7 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.TrustManagerFactory;
 
-
+import com.amazon.opendistroforelasticsearch.security.test.helper.cluster.ClusterConfiguration;
 import org.apache.http.NoHttpResponseException;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.ElasticsearchSecurityException;
@@ -608,7 +608,10 @@ public class SSLTest extends SingleClusterTest {
         
         RestHelper rh = nonSslRestHelper();
 
-        final Settings tcSettings = Settings.builder().put("cluster.name", clusterInfo.clustername).put("path.home", ".")
+        // Add 4th node
+        final String path = "data/" + clusterInfo.clustername;
+        final Settings tcSettings = Settings.builder().put("cluster.name", clusterInfo.clustername).put("path.home", path)
+                .put("node.max_local_storage_nodes", ClusterConfiguration.DEFAULT.getNodeSettings().size() + 1)
                 .put("node.name", "client_node_" + new Random().nextInt())
                 .put("node.data", false)
                 .put("node.master", false)
@@ -828,7 +831,10 @@ public class SSLTest extends SingleClusterTest {
         
         RestHelper rh = nonSslRestHelper();
 
-        final Settings tcSettings = Settings.builder().put("cluster.name", clusterInfo.clustername).put("path.home", ".")
+        // Add 4th node
+        final String path = "data/" + clusterInfo.clustername;
+        final Settings tcSettings = Settings.builder().put("cluster.name", clusterInfo.clustername).put("path.home", path)
+                .put("node.max_local_storage_nodes", ClusterConfiguration.DEFAULT.getNodeSettings().size() + 1)
                 .put("node.name", "client_node_" + new Random().nextInt())
                 .put("discovery.initial_state_timeout","8s")
                 .putList("discovery.zen.ping.unicast.hosts", clusterInfo.nodeHost+":"+clusterInfo.nodePort)

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/AbstractSecurityUnitTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/AbstractSecurityUnitTest.java
@@ -37,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -186,7 +187,8 @@ public abstract class AbstractSecurityUnitTest {
                 //ignore
             }
 
-            for(IndexRequest ir: securityConfig.getDynamicConfig(getResourceFolder())) {
+            List<IndexRequest> indexRequests = securityConfig.getDynamicConfig(getResourceFolder());
+            for(IndexRequest ir: indexRequests) {
                 tc.index(ir).actionGet();
             }
 
@@ -211,6 +213,9 @@ public abstract class AbstractSecurityUnitTest {
             Assert.assertTrue(tc.get(new GetRequest(".opendistro_security", type,"actiongroups")).actionGet().isExists());
             Assert.assertFalse(tc.get(new GetRequest(".opendistro_security", type,"rolesmapping_xcvdnghtu165759i99465")).actionGet().isExists());
             Assert.assertTrue(tc.get(new GetRequest(".opendistro_security", type,"config")).actionGet().isExists());
+            if (indexRequests.stream().anyMatch(i -> CType.NODESDN.toLCString().equals(i.id()))) {
+                Assert.assertTrue(tc.get(new GetRequest(".opendistro_security", type,"nodesdn")).actionGet().isExists());
+            }
         }
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/DynamicSecurityConfig.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/DynamicSecurityConfig.java
@@ -49,6 +49,7 @@ public class DynamicSecurityConfig {
     private String securityRolesMapping = "roles_mapping.yml";
     private String securityInternalUsers = "internal_users.yml";
     private String securityActionGroups = "action_groups.yml";
+    private String securityNodesDn = "nodes_dn.yml";
     private String securityConfigAsYamlString = null;
     private String type = "_doc";
     private String legacyConfigFolder = "";
@@ -88,6 +89,11 @@ public class DynamicSecurityConfig {
 
     public DynamicSecurityConfig setSecurityActionGroups(String securityActionGroups) {
         this.securityActionGroups = securityActionGroups;
+        return this;
+    }
+
+    public DynamicSecurityConfig setSecurityNodesDn(String nodesDn) {
+        this.securityNodesDn = nodesDn;
         return this;
     }
 
@@ -141,6 +147,14 @@ public class DynamicSecurityConfig {
                     .id(CType.TENANTS.toLCString())
                     .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
                     .source(CType.TENANTS.toLCString(), FileHelper.readYamlContent(prefix+securityTenants)));
+        }
+
+        if (null != FileHelper.getAbsoluteFilePathFromClassPath(prefix + securityNodesDn)) {
+            ret.add(new IndexRequest(securityIndexName)
+                .type(type)
+                .id(CType.NODESDN.toLCString())
+                .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source(CType.NODESDN.toLCString(), FileHelper.readYamlContent(prefix+securityNodesDn)));
         }
 
         return Collections.unmodifiableList(ret);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/cluster/ClusterHelper.java
@@ -85,6 +85,10 @@ public final class ClusterHelper {
         this.clustername = clustername;
     }
 
+    public String getClusterName() {
+        return this.clustername;
+    }
+
     /**
      * Start n Elasticsearch nodes with the provided settings
      *

--- a/src/test/resources/legacy/securityconfig_v6/nodes_dn.yml
+++ b/src/test/resources/legacy/securityconfig_v6/nodes_dn.yml
@@ -1,0 +1,4 @@
+---
+cluster1:
+    nodes_dn:
+        - cn=popeye

--- a/src/test/resources/nodes_dn_empty.yml
+++ b/src/test/resources/nodes_dn_empty.yml
@@ -1,0 +1,4 @@
+---
+_meta:
+  type: "nodesdn"
+  config_version: 2

--- a/src/test/resources/restapi/nodes_dn.yml
+++ b/src/test/resources/restapi/nodes_dn.yml
@@ -1,0 +1,7 @@
+---
+_meta:
+  type: "nodesdn"
+  config_version: 2
+cluster1:
+    nodes_dn:
+        - cn=popeye


### PR DESCRIPTION
Implement APIs and datamodel to configure nodes_dn dynamically.

The PR includes following
- Cherrypick [#362] commit
- Cherrypick 4 dependency refactor commits
- Fixed conflicts (https://gist.github.com/krishnaggk/076c1b2ba7681b6a2b590d803b787273)
- Fixed a flaky test.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
