### PR TITLE
Add backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -43,7 +43,7 @@ jobs:
         if: success()
         uses: peter-evans/create-pull-request@v2.7.0
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.BOT_PAT }}
           title: "[Backport][${{ matrix.branch }}] ${{ github.event.pull_request.title }}"
           body: |
             ### Automated changes by Backport workflow
@@ -56,7 +56,7 @@ jobs:
         if: failure()
         uses: maxkomarychev/oction-create-issue@v0.7.1
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.BOT_PAT }}
           title:  "[Backport Failure][${{ matrix.branch }}] ${{ github.event.pull_request.title }}"
           assignees: ${{ github.event.pull_request.user.login }}
           body: |

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,66 @@
+name: Backport
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    outputs:
+      branches: ${{ steps.set-branch-matrix.outputs.matrix }}
+    steps:
+      - name: Find Branches To Backport
+        env:
+          labels: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        id: set-branch-matrix
+        run: |
+          filtered=$(echo $labels | jq -r --arg prefix "backport " '[.[] | select(. | startswith($prefix)) | ltrimstr($prefix)] | tojson')
+          echo "::set-output name=matrix::$filtered"
+
+  backport:
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: ${{ fromJson(needs.discover.outputs.branches) }}
+      fail-fast: false
+    steps:
+      - name: Checkout ${{ matrix.branch }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Cherry-Pick Changes
+        run: |
+          git config --global user.email opendistro-for-elasticsearch-security+github@amazon.com
+          git config --global user.name opendistro-security[bot]
+          git fetch origin
+          git cherry-pick -x ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Create Pull Request
+        if: success()
+        uses: peter-evans/create-pull-request@v2.7.0
+        with:
+          token: ${{ secrets.PAT }}
+          title: "[Backport][${{ matrix.branch }}] ${{ github.event.pull_request.title }}"
+          body: |
+            ### Automated changes by Backport workflow
+            Cherry picking commits from PR ${{ github.event.pull_request.html_url }}
+          labels: automerge
+          reviewers: ${{ github.event.pull_request.user.login }}
+          branch: backport-${{ github.event.number }}-to-${{ matrix.branch }}
+
+      - name: Create Issue for failures
+        if: failure()
+        uses: maxkomarychev/oction-create-issue@v0.7.1
+        with:
+          token: ${{ secrets.PAT }}
+          title:  "[Backport Failure][${{ matrix.branch }}] ${{ github.event.pull_request.title }}"
+          assignees: ${{ github.event.pull_request.user.login }}
+          body: |
+            ### Automated backporting workflow failed
+            - **Pull Request**: ${{ github.event.pull_request.html_url }}
+            - **Branch**: ${{ matrix.branch }}
+            - **Merge Commit**: ${{ github.event.pull_request.merge_commit_sha }}


### PR DESCRIPTION
Creating a new workflow to backport merge commit. 

- On merge commit, the workflow will look for labels prefixed with backport. eg: `backport opendistro-1.6`, `backport opendistro-1.5` ... 
- Checkout repo and cherry pick merge commit 
- Create a new pull request for each of the specified backport branches.
- On failure to cherry-pick commits, it will create a new issue and assign it to the creator of the pull request to track the failures.

Note: Personal Access Token for the bot user https://github.com/opendistroforelasticsearch-security will be used for creating pull requests because of the github limitation that only an user token can trigger workflows.

Sample PR: 
<img width="777" alt="Screen Shot 2020-04-25 at 5 00 05 PM" src="https://user-images.githubusercontent.com/5506137/80293691-45e6b800-8716-11ea-8ad1-164e69201ddf.png">

Sample Issue:
<img width="934" alt="Screen Shot 2020-04-25 at 5 00 18 PM" src="https://user-images.githubusercontent.com/5506137/80293692-4aab6c00-8716-11ea-82cc-b919b76ea843.png">
