### PR TITLE
[Backport] Fix the security plugin so that we use X-Opaque-Id (#349)

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/transport/OpenDistroSecurityInterceptor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/transport/OpenDistroSecurityInterceptor.java
@@ -137,7 +137,6 @@ public class OpenDistroSecurityInterceptor {
                             || (k.equals("_opendistro_security_source_field_context") && ! (request instanceof SearchRequest) && !(request instanceof GetRequest))
                             || k.startsWith("_opendistro_security_trace")
                             || k.startsWith(ConfigConstants.OPENDISTRO_SECURITY_INITIAL_ACTION_CLASS_HEADER)
-                            || k.equals(Task.X_OPAQUE_ID)
             )));
 
             if (OpenDistroSecurityPlugin.GuiceHolder.getRemoteClusterService().isCrossClusterSearchEnabled()

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/TaskTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/TaskTests.java
@@ -42,5 +42,6 @@ public class TaskTests extends SingleClusterTest {
                 , new BasicHeader(Task.X_OPAQUE_ID, "myOpaqueId12"))).getStatusCode());
         System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().split("X-Opaque-Id").length > 2);
+        Assert.assertTrue(!res.getBody().contains("failures"));
     }
 }


### PR DESCRIPTION
Backporting commit c3609481326ced46980d4ce698635d6da6ae62c4 

