### PR TITLE
Update gradle build script to enforce ES 7.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ ospackage {
     fileMode 0644
     dirMode 0755
 
-    requires('elasticsearch-oss', "7.6.1", EQUAL)
+    requires('elasticsearch-oss', "7.7.0", EQUAL)
     packager = 'Amazon'
     vendor = 'Amazon'
     os = 'LINUX'

--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,6 @@ ospackage {
 
     user 'root'
     permissionGroup 'root'
-    fileMode 0644
-    dirMode 0755
 
     requires('elasticsearch-oss', "7.7.0", EQUAL)
     packager = 'Amazon'


### PR DESCRIPTION
*Description of changes:*
- Update gradle build script to enforce ES 7.7.0
- Use file permission from maven assembly for RPM and DEB

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
