### PR TITLE
Use 'elasticsearch' for the group during rpm/deb installation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ ospackage {
     into '/usr/share/elasticsearch/plugins'
     from(zipTree(project.file(archivePath).absolutePath)) {
         into "opendistro_security"
+        permissionGroup 'elasticsearch'
     }
 
     user 'root'
@@ -57,6 +58,7 @@ ospackage {
 
 buildRpm {
     arch = 'NOARCH'
+    addParentDirs = false
     archiveName "${packageName}-${version}.rpm"
 }
 


### PR DESCRIPTION
*Issue #, if available:*

After installation 'elasticsearch' user that is used to run ES does not have read access to the plugin configuration files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
