### PR TITLE
Update compliance config usage

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/AuditLog.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/AuditLog.java
@@ -72,7 +72,7 @@ public interface AuditLog extends Closeable {
     void logDocumentRead(String index, String id, ShardId shardId, Map<String, String> fieldNameValues);
     void logDocumentWritten(ShardId shardId, GetResult originalIndex, Index currentIndex, IndexResult result);
     void logDocumentDeleted(ShardId shardId, Delete delete, DeleteResult result);
-    void logExternalConfig(Settings settings, Environment environment);
+    void logExternalConfig();
     
     // compliance config
     ComplianceConfig getComplianceConfig();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/NullAuditLog.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/NullAuditLog.java
@@ -130,7 +130,7 @@ public class NullAuditLog implements AuditLog {
     }
 
     @Override
-    public void logExternalConfig(Settings settings, Environment environment) {
+    public void logExternalConfig() {
         //noop, intentionally left empty
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/config/AuditConfig.java
@@ -20,6 +20,8 @@ import java.util.Set;
  */
 public class AuditConfig {
 
+    public static final List<String> DEFAULT_IGNORED_USERS = Collections.singletonList("kibanaserver");
+
     private AuditConfig() { }
 
     /**
@@ -27,7 +29,6 @@ public class AuditConfig {
      * Audit logger will use these settings to determine what audit logs are to be generated.
      */
     public static class Filter {
-        private static final List<String> DEFAULT_IGNORED_USERS = Collections.singletonList("kibanaserver");
         private static final List<String> DEFAULT_DISABLED_CATEGORIES =
                 Arrays.asList(AuditCategory.AUTHENTICATED.toString(),
                         AuditCategory.GRANTED_PRIVILEGES.toString());
@@ -39,8 +40,6 @@ public class AuditConfig {
         private final boolean resolveIndices;
         private final boolean excludeSensitiveHeaders;
         private final WildcardMatcher ignoredAuditUsersMatcher;
-        private final WildcardMatcher ignoredComplianceUsersForReadMatcher;
-        private final WildcardMatcher ignoredComplianceUsersForWriteMatcher;
         private final WildcardMatcher ignoredAuditRequestsMatcher;
         private final EnumSet<AuditCategory> disabledRestCategories;
         private final EnumSet<AuditCategory> disabledTransportCategories;
@@ -52,8 +51,6 @@ public class AuditConfig {
                        final boolean resolveIndices,
                        final boolean excludeSensitiveHeaders,
                        final Set<String> ignoredAuditUsers,
-                       final Set<String> ignoredComplianceUsersForRead,
-                       final Set<String> ignoredComplianceUsersForWrite,
                        final Set<String> ignoredAuditRequests,
                        final EnumSet<AuditCategory> disabledRestCategories,
                        final EnumSet<AuditCategory> disabledTransportCategories) {
@@ -64,8 +61,6 @@ public class AuditConfig {
             this.resolveIndices = resolveIndices;
             this.excludeSensitiveHeaders = excludeSensitiveHeaders;
             this.ignoredAuditUsersMatcher = WildcardMatcher.from(ignoredAuditUsers);
-            this.ignoredComplianceUsersForReadMatcher = WildcardMatcher.from(ignoredComplianceUsersForRead);
-            this.ignoredComplianceUsersForWriteMatcher = WildcardMatcher.from(ignoredComplianceUsersForWrite);
             this.ignoredAuditRequestsMatcher = WildcardMatcher.from(ignoredAuditRequests);
             this.disabledRestCategories = disabledRestCategories;
             this.disabledTransportCategories = disabledTransportCategories;
@@ -102,18 +97,6 @@ public class AuditConfig {
                     DEFAULT_IGNORED_USERS,
                     false);
 
-            final Set<String> ignoredComplianceUsersForRead = getSettingAsSet(
-                    settings,
-                    ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_IGNORE_USERS,
-                    DEFAULT_IGNORED_USERS,
-                    false);
-
-            final Set<String> ignoredComplianceUsersForWrite = getSettingAsSet(
-                    settings,
-                    ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_IGNORE_USERS,
-                    DEFAULT_IGNORED_USERS,
-                    false);
-
             final Set<String> ignoreAuditRequests = ImmutableSet.copyOf(settings.getAsList(
                     ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_REQUESTS,
                     Collections.emptyList()));
@@ -125,19 +108,9 @@ public class AuditConfig {
                     resolveIndices,
                     excludeSensitiveHeaders,
                     ignoredAuditUsers,
-                    ignoredComplianceUsersForRead,
-                    ignoredComplianceUsersForWrite,
                     ignoreAuditRequests,
                     disabledRestCategories,
                     disabledTransportCategories);
-        }
-
-        private static Set<String> getSettingAsSet(final Settings settings, final String key, final List<String> defaultList, final boolean ignoreCaseForNone) {
-            final List<String> list = settings.getAsList(key, defaultList);
-            if (list.size() == 1 && "NONE".equals(ignoreCaseForNone? list.get(0).toUpperCase() : list.get(0))) {
-                return Collections.emptySet();
-            }
-            return ImmutableSet.copyOf(list);
         }
 
         /**
@@ -203,34 +176,6 @@ public class AuditConfig {
         }
 
         @VisibleForTesting
-        WildcardMatcher getIgnoredComplianceUsersForReadMatcher() {
-            return ignoredComplianceUsersForReadMatcher;
-        }
-
-        /**
-         * Check if user is excluded from compliance read audit
-         * @param user
-         * @return true if user is excluded from compliance read audit
-         */
-        public boolean isComplianceReadAuditDisabled(String user) {
-            return ignoredComplianceUsersForReadMatcher.test(user);
-        }
-
-        @VisibleForTesting
-        WildcardMatcher getIgnoredComplianceUsersForWriteMatcher() {
-            return ignoredComplianceUsersForWriteMatcher;
-        }
-
-        /**
-         * Check if user is excluded from compliance write audit
-         * @param user
-         * @return true if user is excluded from compliance write audit
-         */
-        public boolean isComplianceWriteAuditDisabled(String user) {
-            return ignoredComplianceUsersForWriteMatcher.test(user);
-        }
-
-        @VisibleForTesting
         WildcardMatcher getIgnoredAuditRequestsMatcher() {
             return ignoredAuditRequestsMatcher;
         }
@@ -270,8 +215,6 @@ public class AuditConfig {
             logger.info("Index resolution is {} during request auditing.", resolveIndices ? "enabled" : "disabled");
             logger.info("Sensitive headers auditing is {}.", excludeSensitiveHeaders ? "enabled" : "disabled");
             logger.info("Auditing requests from {} users is disabled.", ignoredAuditUsersMatcher);
-            logger.info("Compliance read operation requests auditing from {} users is disabled.", ignoredComplianceUsersForReadMatcher);
-            logger.info("Compliance write operation requests auditing from {} users is disabled.", ignoredComplianceUsersForWriteMatcher);
         }
 
         @Override
@@ -286,10 +229,16 @@ public class AuditConfig {
                     ", resolveIndices=" + resolveIndices +
                     ", excludeSensitiveHeaders=" + excludeSensitiveHeaders +
                     ", ignoredAuditUsers=" + ignoredAuditUsersMatcher +
-                    ", ignoredComplianceUsersForRead=" + ignoredComplianceUsersForReadMatcher +
-                    ", ignoredComplianceUsersForWrite=" + ignoredComplianceUsersForWriteMatcher +
                     ", ignoreAuditRequests=" + ignoredAuditRequestsMatcher +
                     '}';
         }
+    }
+
+    public static Set<String> getSettingAsSet(final Settings settings, final String key, final List<String> defaultList, final boolean ignoreCaseForNone) {
+        final List<String> list = settings.getAsList(key, defaultList);
+        if (list.size() == 1 && "NONE".equals(ignoreCaseForNone? list.get(0).toUpperCase() : list.get(0))) {
+            return Collections.emptySet();
+        }
+        return ImmutableSet.copyOf(list);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditLogImpl.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditLogImpl.java
@@ -48,12 +48,12 @@ public final class AuditLogImpl extends AbstractAuditLog {
 
 	AuditLogImpl(final Settings settings, final Path configPath, Client clientProvider, ThreadPool threadPool,
 				 final IndexNameExpressionResolver resolver, final ClusterService clusterService) {
-		this(settings, configPath, clientProvider, threadPool, resolver, clusterService, false);
+		this(settings, configPath, clientProvider, threadPool, resolver, clusterService, null, false);
 	}
 
 	public AuditLogImpl(final Settings settings, final Path configPath, Client clientProvider, ThreadPool threadPool,
-						final IndexNameExpressionResolver resolver, final ClusterService clusterService, final boolean dlsFlsAvailable) {
-		super(settings, threadPool, resolver, clusterService, dlsFlsAvailable);
+						final IndexNameExpressionResolver resolver, final ClusterService clusterService, final Environment environment, final boolean dlsFlsAvailable) {
+		super(settings, threadPool, resolver, clusterService, environment, dlsFlsAvailable);
 
 		this.messageRouter = new AuditMessageRouter(settings, clientProvider, threadPool, configPath);
 		this.enabled = messageRouter.isEnabled();
@@ -212,9 +212,9 @@ public final class AuditLogImpl extends AbstractAuditLog {
 	}
 
 	@Override
-	public void logExternalConfig(Settings settings, Environment environment) {
+	public void logExternalConfig() {
 		if (enabled) {
-			super.logExternalConfig(settings, environment);
+			super.logExternalConfig();
 		}
 	}
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/compliance/FieldReadCallback.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/compliance/FieldReadCallback.java
@@ -87,7 +87,8 @@ public final class FieldReadCallback {
     }
 
     private boolean recordField(final String fieldName, boolean isStringField) {
-        return !(isStringField && maskedFieldsMatcher.test(fieldName)) && auditLog.getComplianceConfig().readHistoryEnabledForField(index.getName(), fieldName);
+        final ComplianceConfig complianceConfig = auditLog.getComplianceConfig();
+        return !(isStringField && maskedFieldsMatcher.test(fieldName)) && complianceConfig != null && complianceConfig.readHistoryEnabledForField(index.getName(), fieldName);
     }
 
     public void binaryFieldRead(final FieldInfo fieldInfo, byte[] fieldValue) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/ConfigurationRepository.java
@@ -45,6 +45,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import com.amazon.opendistroforelasticsearch.security.compliance.ComplianceConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
@@ -348,7 +349,8 @@ public class ConfigurationRepository {
             throw new ElasticsearchException(e);
         }
 
-        if (logComplianceEvent && auditLog.getComplianceConfig().isEnabled()) {
+        final ComplianceConfig complianceConfig = auditLog.getComplianceConfig();
+        if (logComplianceEvent && complianceConfig != null && complianceConfig.isEnabled()) {
             CType configurationType = configTypes.iterator().next();
             Map<String, String> fields = new HashMap<String, String>();
             fields.put(configurationType.toLCString(), Strings.toString(retVal.get(configurationType)));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ReflectionHelper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ReflectionHelper.java
@@ -42,6 +42,7 @@ import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditLogImpl;
+import com.amazon.opendistroforelasticsearch.security.compliance.ComplianceIndexingOperationListenerImpl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
@@ -49,6 +50,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
@@ -172,14 +174,14 @@ public class ReflectionHelper {
     }
 
     public static AuditLog instantiateAuditLog(final Settings settings, final Path configPath, final Client localClient, final ThreadPool threadPool,
-            final IndexNameExpressionResolver resolver, final ClusterService clusterService, final boolean dlsFlsAvailable) {
+                                               final IndexNameExpressionResolver resolver, final ClusterService clusterService, final Environment environment, final boolean dlsFlsAvailable) {
 
         if (advancedModulesDisabled()) {
             return new NullAuditLog();
         }
 
         try {
-            final AuditLog impl = new AuditLogImpl(settings, configPath, localClient, threadPool, resolver, clusterService, dlsFlsAvailable);
+            final AuditLog impl = new AuditLogImpl(settings, configPath, localClient, threadPool, resolver, clusterService, environment, dlsFlsAvailable);
             addLoadedModule(AuditLogImpl.class);
             return impl;
         } catch (final Throwable e) {
@@ -191,26 +193,16 @@ public class ReflectionHelper {
         }
     }
 
-    public static ComplianceIndexingOperationListener instantiateComplianceListener(AuditLog auditlog) {
+    public static ComplianceIndexingOperationListener instantiateComplianceListener(final String indexName, final AuditLog auditlog) {
 
         if (advancedModulesDisabled()) {
             return new ComplianceIndexingOperationListener();
         }
 
         try {
-            final Class<?> clazz = Class.forName("com.amazon.opendistroforelasticsearch.security.compliance.ComplianceIndexingOperationListenerImpl");
-            final ComplianceIndexingOperationListener impl = (ComplianceIndexingOperationListener) clazz
-                    .getConstructor(AuditLog.class)
-                    .newInstance(auditlog);
-            addLoadedModule(clazz);
+            final ComplianceIndexingOperationListener impl = new ComplianceIndexingOperationListenerImpl(indexName, auditlog);
+            addLoadedModule(ComplianceIndexingOperationListenerImpl.class);
             return impl;
-        } catch (final ClassNotFoundException e) {
-            //TODO produce a single warn msg, this here is issued for every index
-           log.debug("Unable to enable Compliance Module due to {}", e.toString());
-           if(log.isDebugEnabled()) {
-               log.debug("Stacktrace: ",e);
-           }
-           return new ComplianceIndexingOperationListener();
         } catch (final Throwable e) {
             log.error("Unable to enable Compliance Module due to {}", e.toString());
             if(log.isDebugEnabled()) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/compliance/ComplianceConfigTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/compliance/ComplianceConfigTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -26,6 +27,8 @@ public class ComplianceConfigTest {
 
     @Test
     public void testDefault() {
+        // arrange
+        final WildcardMatcher defaultIgnoredUserMatcher = WildcardMatcher.from("kibanaserver");
         // act
         final ComplianceConfig complianceConfig = ComplianceConfig.from(Settings.EMPTY);
         // assert
@@ -35,8 +38,9 @@ public class ComplianceConfigTest {
         assertFalse(complianceConfig.shouldLogReadMetadataOnly());
         assertFalse(complianceConfig.shouldLogWriteMetadataOnly());
         assertFalse(complianceConfig.shouldLogDiffsForWrite());
-        assertSame(WildcardMatcher.NONE, complianceConfig.getImmutableIndicesMatcher());
         assertEquals(16, complianceConfig.getSalt16().length);
+        assertEquals(defaultIgnoredUserMatcher, complianceConfig.getIgnoredComplianceUsersForReadMatcher());
+        assertEquals(defaultIgnoredUserMatcher, complianceConfig.getIgnoredComplianceUsersForWriteMatcher());
     }
 
     @Test
@@ -53,6 +57,10 @@ public class ComplianceConfigTest {
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_IMMUTABLE_INDICES, "immutable1", "immutable2", "immutable2")
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_WATCHED_INDICES, "write_index1", "write_index_pattern*")
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_WATCHED_FIELDS, "read_index1,field1,field2", "read_index_pattern*,field1,field_pattern*")
+                .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_IGNORE_USERS,
+                        "test-user-1", "test-user-2")
+                .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_IGNORE_USERS,
+                        "test-user-3", "test-user-4")
                 .build();
 
         // act
@@ -65,9 +73,10 @@ public class ComplianceConfigTest {
         assertTrue(complianceConfig.shouldLogReadMetadataOnly());
         assertTrue(complianceConfig.shouldLogWriteMetadataOnly());
         assertFalse(complianceConfig.shouldLogDiffsForWrite());
-        assertEquals(complianceConfig.getImmutableIndicesMatcher(), WildcardMatcher.from(ImmutableSet.of("immutable1", "immutable2")));
         assertArrayEquals(testSalt.getBytes(StandardCharsets.UTF_8), complianceConfig.getSalt16());
         assertEquals(16, complianceConfig.getSalt16().length);
+        assertEquals(WildcardMatcher.from(ImmutableSet.of("test-user-1", "test-user-2")), complianceConfig.getIgnoredComplianceUsersForReadMatcher());
+        assertEquals(WildcardMatcher.from(ImmutableSet.of("test-user-3", "test-user-4")), complianceConfig.getIgnoredComplianceUsersForWriteMatcher());
 
         // test write history
         assertTrue(complianceConfig.writeHistoryEnabledForIndex(".opendistro_security"));
@@ -91,6 +100,38 @@ public class ComplianceConfigTest {
         assertTrue(complianceConfig.readHistoryEnabledForField("read_index_pattern_2", "field1"));
         assertFalse(complianceConfig.readHistoryEnabledForField("read_index_pattern_2", "field2"));
         assertTrue(complianceConfig.readHistoryEnabledForField("read_index_pattern_2", "field_pattern_1"));
+    }
+
+    @Test
+    public void testNone() {
+        // arrange
+        final Settings settings = Settings.builder()
+                .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_IGNORE_USERS,
+                        "NONE")
+                .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_IGNORE_USERS,
+                        "NONE")
+                .build();
+        // act
+        final ComplianceConfig complianceConfig = ComplianceConfig.from(settings);
+        // assert
+        assertSame(WildcardMatcher.NONE, complianceConfig.getIgnoredComplianceUsersForReadMatcher());
+        assertSame(WildcardMatcher.NONE, complianceConfig.getIgnoredComplianceUsersForWriteMatcher());
+    }
+
+    @Test
+    public void testEmpty() {
+        // arrange
+        final Settings settings = Settings.builder()
+                .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_IGNORE_USERS,
+                        Collections.emptyList())
+                .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_IGNORE_USERS,
+                        Collections.emptyList())
+                .build();
+        // act
+        final ComplianceConfig complianceConfig = ComplianceConfig.from(settings);
+        // assert
+        assertSame(WildcardMatcher.NONE, complianceConfig.getIgnoredComplianceUsersForReadMatcher());
+        assertSame(WildcardMatcher.NONE, complianceConfig.getIgnoredComplianceUsersForWriteMatcher());
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/config/AuditConfigFilterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/config/AuditConfigFilterTest.java
@@ -40,8 +40,6 @@ public class AuditConfigFilterTest {
         assertTrue(auditConfigFilter.shouldExcludeSensitiveHeaders());
         assertSame(WildcardMatcher.NONE, auditConfigFilter.getIgnoredAuditRequestsMatcher());
         assertEquals(defaultIgnoredUserMatcher, auditConfigFilter.getIgnoredAuditUsersMatcher());
-        assertEquals(defaultIgnoredUserMatcher, auditConfigFilter.getIgnoredComplianceUsersForReadMatcher());
-        assertEquals(defaultIgnoredUserMatcher, auditConfigFilter.getIgnoredComplianceUsersForWriteMatcher());
         assertEquals(auditConfigFilter.getDisabledRestCategories(), defaultDisabledCategories);
         assertEquals(auditConfigFilter.getDisabledTransportCategories(), defaultDisabledCategories);
     }
@@ -58,10 +56,6 @@ public class AuditConfigFilterTest {
                 .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_EXCLUDE_SENSITIVE_HEADERS, false)
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_REQUESTS, "test-request")
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_USERS, "test-user")
-                .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_IGNORE_USERS,
-                        "test-user-1", "test-user-2")
-                .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_IGNORE_USERS,
-                        "test-user-3", "test-user-4")
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES,
                         BAD_HEADERS.toString(), SSL_EXCEPTION.toString())
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES,
@@ -78,8 +72,6 @@ public class AuditConfigFilterTest {
         assertFalse(auditConfigFilter.shouldExcludeSensitiveHeaders());
         assertEquals(WildcardMatcher.from(Collections.singleton("test-user")), auditConfigFilter.getIgnoredAuditUsersMatcher());
         assertEquals(WildcardMatcher.from(Collections.singleton("test-request")), auditConfigFilter.getIgnoredAuditRequestsMatcher());
-        assertEquals(WildcardMatcher.from(ImmutableSet.of("test-user-1", "test-user-2")), auditConfigFilter.getIgnoredComplianceUsersForReadMatcher());
-        assertEquals(WildcardMatcher.from(ImmutableSet.of("test-user-3", "test-user-4")), auditConfigFilter.getIgnoredComplianceUsersForWriteMatcher());
         assertEquals(auditConfigFilter.getDisabledRestCategories(), EnumSet.of(BAD_HEADERS, SSL_EXCEPTION));
         assertEquals(auditConfigFilter.getDisabledTransportCategories(), EnumSet.of(FAILED_LOGIN, MISSING_PRIVILEGES));
     }
@@ -102,8 +94,6 @@ public class AuditConfigFilterTest {
         final AuditConfig.Filter auditConfigFilter = AuditConfig.Filter.from(settings);
         // assert
         assertSame(WildcardMatcher.NONE, auditConfigFilter.getIgnoredAuditUsersMatcher());
-        assertSame(WildcardMatcher.NONE, auditConfigFilter.getIgnoredComplianceUsersForReadMatcher());
-        assertSame(WildcardMatcher.NONE, auditConfigFilter.getIgnoredComplianceUsersForWriteMatcher());
         assertTrue(auditConfigFilter.getDisabledRestCategories().isEmpty());
         assertTrue(auditConfigFilter.getDisabledTransportCategories().isEmpty());
     }
@@ -127,8 +117,6 @@ public class AuditConfigFilterTest {
         final AuditConfig.Filter auditConfigFilter = AuditConfig.Filter.from(settings);
         // assert
         assertSame(WildcardMatcher.NONE, auditConfigFilter.getIgnoredAuditUsersMatcher());
-        assertSame(WildcardMatcher.NONE, auditConfigFilter.getIgnoredComplianceUsersForReadMatcher());
-        assertSame(WildcardMatcher.NONE, auditConfigFilter.getIgnoredComplianceUsersForWriteMatcher());
         assertTrue(auditConfigFilter.getDisabledRestCategories().isEmpty());
         assertTrue(auditConfigFilter.getDisabledTransportCategories().isEmpty());
     }


### PR DESCRIPTION

- moved compliance ignore read and write users into compliance config as it belongs there

- moved environment external logging into audit log and store state to check its logged only once per node start. When hot-reloaded, compliance config wont be available in index yet at the time of node start

- use ComplianceIndexingOperationListenerImpl as compliance config can be changed dynamically. This is called by index and at the time of creation setting the object

- use <string, set<string>> type for read enabled fields and move creation to the source generating the config

- add null checks for compliance config as it can be null

- updated reflection helper to construct object by constructor instead of reflection
