### PR TITLE
Remove immutable indices from compliance config

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -790,7 +790,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
         
         cr.setDynamicConfigFactory(dcf);
         
-        odsf = new OpenDistroSecurityFilter(evaluator, adminDns, dlsFlsValve, auditLog, threadPool, cs, compatConfig, irr);
+        odsf = new OpenDistroSecurityFilter(settings, evaluator, adminDns, dlsFlsValve, auditLog, threadPool, cs, compatConfig, irr);
 
 
         final String principalExtractorClass = settings.get(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_PRINCIPAL_EXTRACTOR_CLASS, null);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/compliance/ComplianceConfig.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/compliance/ComplianceConfig.java
@@ -76,7 +76,6 @@ public class ComplianceConfig {
     private final boolean logWriteMetadataOnly;
     private final boolean logDiffsForWrite;
     private final WildcardMatcher watchedWriteIndicesMatcher;
-    private final WildcardMatcher immutableIndicesMatcher;
     private final String opendistrosecurityIndex;
 
     private final Map<WildcardMatcher, Set<String>> readEnabledFields;
@@ -94,7 +93,6 @@ public class ComplianceConfig {
             final boolean logDiffsForWrite,
             final List<String> watchedReadFields,
             final List<String> watchedWriteIndicesPatterns,
-            final Set<String> immutableIndicesPatterns,
             final String saltAsString,
             final String opendistrosecurityIndex,
             final String destinationType,
@@ -105,7 +103,6 @@ public class ComplianceConfig {
         this.logWriteMetadataOnly = logWriteMetadataOnly;
         this.logDiffsForWrite = logDiffsForWrite;
         this.watchedWriteIndicesMatcher = WildcardMatcher.from(watchedWriteIndicesPatterns);
-        this.immutableIndicesMatcher = WildcardMatcher.from(immutableIndicesPatterns);
         this.opendistrosecurityIndex = opendistrosecurityIndex;
 
         this.salt16 = new byte[SALT_SIZE];
@@ -166,7 +163,6 @@ public class ComplianceConfig {
         logger.info("Auditing only metadata information for write request is {}.", logWriteMetadataOnly ? "enabled" : "disabled");
         logger.info("Auditing diffs for write requests is {}.", logDiffsForWrite ? "enabled" : "disabled");
         logger.info("Auditing will watch {} for write requests.", watchedWriteIndicesMatcher);
-        logger.info("{} indices are made immutable.", immutableIndicesMatcher);
         logger.info("{} is used as internal security index.", opendistrosecurityIndex);
         logger.info("Internal index used for posting audit logs is {}", auditLogIndex);
     }
@@ -185,7 +181,6 @@ public class ComplianceConfig {
         final List<String> watchedReadFields = settings.getAsList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_WATCHED_FIELDS,
                 Collections.emptyList(), false);
         final List<String> watchedWriteIndices = settings.getAsList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_WATCHED_INDICES, Collections.emptyList());
-        final Set<String> immutableIndicesPatterns = ImmutableSet.copyOf(settings.getAsList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_IMMUTABLE_INDICES, Collections.emptyList()));
         final String saltAsString = settings.get(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_SALT, ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_SALT_DEFAULT);
         final String opendistrosecurityIndex = settings.get(ConfigConstants.OPENDISTRO_SECURITY_CONFIG_INDEX_NAME, ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX);
         final String type = settings.get(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_TYPE_DEFAULT, null);
@@ -199,7 +194,6 @@ public class ComplianceConfig {
                 logDiffsForWrite,
                 watchedReadFields,
                 watchedWriteIndices,
-                immutableIndicesPatterns,
                 saltAsString,
                 opendistrosecurityIndex,
                 type,
@@ -253,14 +247,6 @@ public class ComplianceConfig {
      */
     public boolean shouldLogReadMetadataOnly() {
         return logReadMetadataOnly;
-    }
-
-    /**
-     * Get set of immutable index pattern
-     * @return set of index patterns
-     */
-    public WildcardMatcher getImmutableIndicesMatcher() {
-        return immutableIndicesMatcher;
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
@@ -102,7 +102,7 @@ import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
-public final class IndexResolverReplacer {
+public class IndexResolverReplacer {
 
     private static final Set<String> NULL_SET = new HashSet<>(Collections.singleton(null));
     private final Logger log = LogManager.getLogger(this.getClass());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/compliance/ComplianceConfigTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/compliance/ComplianceConfigTest.java
@@ -35,7 +35,6 @@ public class ComplianceConfigTest {
         assertFalse(complianceConfig.shouldLogReadMetadataOnly());
         assertFalse(complianceConfig.shouldLogWriteMetadataOnly());
         assertFalse(complianceConfig.shouldLogDiffsForWrite());
-        assertSame(WildcardMatcher.NONE, complianceConfig.getImmutableIndicesMatcher());
         assertEquals(16, complianceConfig.getSalt16().length);
     }
 
@@ -50,7 +49,6 @@ public class ComplianceConfigTest {
                 .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_METADATA_ONLY, true)
                 .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_LOG_DIFFS, true)
                 .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_SALT, testSalt)
-                .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_IMMUTABLE_INDICES, "immutable1", "immutable2", "immutable2")
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_WATCHED_INDICES, "write_index1", "write_index_pattern*")
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_WATCHED_FIELDS, "read_index1,field1,field2", "read_index_pattern*,field1,field_pattern*")
                 .build();
@@ -65,7 +63,6 @@ public class ComplianceConfigTest {
         assertTrue(complianceConfig.shouldLogReadMetadataOnly());
         assertTrue(complianceConfig.shouldLogWriteMetadataOnly());
         assertFalse(complianceConfig.shouldLogDiffsForWrite());
-        assertEquals(complianceConfig.getImmutableIndicesMatcher(), WildcardMatcher.from(ImmutableSet.of("immutable1", "immutable2")));
         assertArrayEquals(testSalt.getBytes(StandardCharsets.UTF_8), complianceConfig.getSalt16());
         assertEquals(16, complianceConfig.getSalt16().length);
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilterTest.java
@@ -2,7 +2,6 @@ package com.amazon.opendistroforelasticsearch.security.filter;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog;
 import com.amazon.opendistroforelasticsearch.security.configuration.AdminDNs;
-import com.amazon.opendistroforelasticsearch.security.configuration.ClusterInfoHolder;
 import com.amazon.opendistroforelasticsearch.security.configuration.CompatConfig;
 import com.amazon.opendistroforelasticsearch.security.configuration.DlsFlsRequestValve;
 import com.amazon.opendistroforelasticsearch.security.privileges.PrivilegesEvaluator;
@@ -10,7 +9,6 @@ import com.amazon.opendistroforelasticsearch.security.resolver.IndexResolverRepl
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 import com.google.common.collect.ImmutableSet;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -52,7 +50,6 @@ public class OpenDistroSecurityFilterTest {
 
     @Test
     public void testImmutableIndicesWildcardMatcher() {
-        // act
         final OpenDistroSecurityFilter filter = new OpenDistroSecurityFilter(
                 settings,
                 mock(PrivilegesEvaluator.class),
@@ -62,14 +59,8 @@ public class OpenDistroSecurityFilterTest {
                 mock(ThreadPool.class),
                 mock(ClusterService.class),
                 mock(CompatConfig.class),
-                new IndexResolverReplacer(
-                        mock(IndexNameExpressionResolver.class),
-                        mock(ClusterService.class),
-                        mock(ClusterInfoHolder.class)
-                )
+                mock(IndexResolverReplacer.class)
         );
-
-        // assert
         assertEquals(expected, filter.getImmutableIndicesMatcher());
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilterTest.java
@@ -1,0 +1,75 @@
+package com.amazon.opendistroforelasticsearch.security.filter;
+
+import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog;
+import com.amazon.opendistroforelasticsearch.security.configuration.AdminDNs;
+import com.amazon.opendistroforelasticsearch.security.configuration.ClusterInfoHolder;
+import com.amazon.opendistroforelasticsearch.security.configuration.CompatConfig;
+import com.amazon.opendistroforelasticsearch.security.configuration.DlsFlsRequestValve;
+import com.amazon.opendistroforelasticsearch.security.privileges.PrivilegesEvaluator;
+import com.amazon.opendistroforelasticsearch.security.resolver.IndexResolverReplacer;
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
+import com.google.common.collect.ImmutableSet;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+@RunWith(Parameterized.class)
+public class OpenDistroSecurityFilterTest {
+
+    private final Settings settings;
+    private final WildcardMatcher expected;
+
+    public OpenDistroSecurityFilterTest(Settings settings, WildcardMatcher expected) {
+        this.settings = settings;
+        this.expected = expected;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {Settings.EMPTY, WildcardMatcher.NONE},
+                {Settings.builder()
+                        .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_IMMUTABLE_INDICES, "immutable1", "immutable2")
+                        .build(),
+                        WildcardMatcher.from(ImmutableSet.of("immutable1", "immutable2"))},
+                {Settings.builder()
+                        .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_IMMUTABLE_INDICES, "immutable1", "immutable2", "immutable2")
+                        .build(),
+                        WildcardMatcher.from(ImmutableSet.of("immutable1", "immutable2"))},
+        });
+    }
+
+    @Test
+    public void testImmutableIndicesWildcardMatcher() {
+        // act
+        final OpenDistroSecurityFilter filter = new OpenDistroSecurityFilter(
+                settings,
+                mock(PrivilegesEvaluator.class),
+                mock(AdminDNs.class),
+                mock(DlsFlsRequestValve.class),
+                mock(AuditLog.class),
+                mock(ThreadPool.class),
+                mock(ClusterService.class),
+                mock(CompatConfig.class),
+                new IndexResolverReplacer(
+                        mock(IndexNameExpressionResolver.class),
+                        mock(ClusterService.class),
+                        mock(ClusterInfoHolder.class)
+                )
+        );
+
+        // assert
+        assertEquals(expected, filter.getImmutableIndicesMatcher());
+    }
+}


### PR DESCRIPTION
- Removing immutable indices from compliance config as immutable indices changes the behavior of request handling and should not be impacted by enabling/disabling compliance config.

- There is testImmutableIndex test which passes. Migrated ComplianceConfigTest to OpenDistroSecurityFilterTest
