### PR TITLE
Move compliance ignore users from audit config to compliance config

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/config/AuditConfig.java
@@ -51,8 +51,6 @@ public class AuditConfig {
                        final boolean resolveIndices,
                        final boolean excludeSensitiveHeaders,
                        final Set<String> ignoredAuditUsers,
-                       final Set<String> ignoredComplianceUsersForRead,
-                       final Set<String> ignoredComplianceUsersForWrite,
                        final Set<String> ignoredAuditRequests,
                        final EnumSet<AuditCategory> disabledRestCategories,
                        final EnumSet<AuditCategory> disabledTransportCategories) {
@@ -99,18 +97,6 @@ public class AuditConfig {
                     DEFAULT_IGNORED_USERS,
                     false);
 
-            final Set<String> ignoredComplianceUsersForRead = getSettingAsSet(
-                    settings,
-                    ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_IGNORE_USERS,
-                    DEFAULT_IGNORED_USERS,
-                    false);
-
-            final Set<String> ignoredComplianceUsersForWrite = getSettingAsSet(
-                    settings,
-                    ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_IGNORE_USERS,
-                    DEFAULT_IGNORED_USERS,
-                    false);
-
             final Set<String> ignoreAuditRequests = ImmutableSet.copyOf(settings.getAsList(
                     ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_REQUESTS,
                     Collections.emptyList()));
@@ -122,8 +108,6 @@ public class AuditConfig {
                     resolveIndices,
                     excludeSensitiveHeaders,
                     ignoredAuditUsers,
-                    ignoredComplianceUsersForRead,
-                    ignoredComplianceUsersForWrite,
                     ignoreAuditRequests,
                     disabledRestCategories,
                     disabledTransportCategories);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AbstractAuditLog.java
@@ -717,7 +717,7 @@ public abstract class AbstractAuditLog implements AuditLog {
 
         if(category == AuditCategory.COMPLIANCE_DOC_READ || category == AuditCategory.COMPLIANCE_INTERNAL_CONFIG_READ) {
 
-            if (effectiveUser != null && auditConfigFilter.isComplianceReadAuditDisabled(effectiveUser)) {
+            if (effectiveUser != null && complianceConfig.isComplianceReadAuditDisabled(effectiveUser)) {
 
                 if(log.isTraceEnabled()) {
                     log.trace("Skipped compliance log message because of user {} is ignored", effectiveUser);
@@ -727,7 +727,7 @@ public abstract class AbstractAuditLog implements AuditLog {
         }
 
         if(category == AuditCategory.COMPLIANCE_DOC_WRITE || category == AuditCategory.COMPLIANCE_INTERNAL_CONFIG_WRITE) {
-            if (effectiveUser != null && auditConfigFilter.isComplianceWriteAuditDisabled(effectiveUser)) {
+            if (effectiveUser != null && complianceConfig.isComplianceWriteAuditDisabled(effectiveUser)) {
 
                 if(log.isTraceEnabled()) {
                     log.trace("Skipped compliance log message because of user {} is ignored", effectiveUser);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/config/AuditConfigFilterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/config/AuditConfigFilterTest.java
@@ -3,7 +3,6 @@ package com.amazon.opendistroforelasticsearch.security.auditlog.config;
 import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditCategory;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
-import com.google.common.collect.ImmutableSet;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
@@ -40,8 +39,6 @@ public class AuditConfigFilterTest {
         assertTrue(auditConfigFilter.shouldExcludeSensitiveHeaders());
         assertSame(WildcardMatcher.NONE, auditConfigFilter.getIgnoredAuditRequestsMatcher());
         assertEquals(defaultIgnoredUserMatcher, auditConfigFilter.getIgnoredAuditUsersMatcher());
-        assertEquals(defaultIgnoredUserMatcher, auditConfigFilter.getIgnoredComplianceUsersForReadMatcher());
-        assertEquals(defaultIgnoredUserMatcher, auditConfigFilter.getIgnoredComplianceUsersForWriteMatcher());
         assertEquals(auditConfigFilter.getDisabledRestCategories(), defaultDisabledCategories);
         assertEquals(auditConfigFilter.getDisabledTransportCategories(), defaultDisabledCategories);
     }
@@ -58,10 +55,6 @@ public class AuditConfigFilterTest {
                 .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_EXCLUDE_SENSITIVE_HEADERS, false)
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_REQUESTS, "test-request")
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_USERS, "test-user")
-                .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_IGNORE_USERS,
-                        "test-user-1", "test-user-2")
-                .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_IGNORE_USERS,
-                        "test-user-3", "test-user-4")
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES,
                         BAD_HEADERS.toString(), SSL_EXCEPTION.toString())
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES,
@@ -78,8 +71,6 @@ public class AuditConfigFilterTest {
         assertFalse(auditConfigFilter.shouldExcludeSensitiveHeaders());
         assertEquals(WildcardMatcher.from(Collections.singleton("test-user")), auditConfigFilter.getIgnoredAuditUsersMatcher());
         assertEquals(WildcardMatcher.from(Collections.singleton("test-request")), auditConfigFilter.getIgnoredAuditRequestsMatcher());
-        assertEquals(WildcardMatcher.from(ImmutableSet.of("test-user-1", "test-user-2")), auditConfigFilter.getIgnoredComplianceUsersForReadMatcher());
-        assertEquals(WildcardMatcher.from(ImmutableSet.of("test-user-3", "test-user-4")), auditConfigFilter.getIgnoredComplianceUsersForWriteMatcher());
         assertEquals(auditConfigFilter.getDisabledRestCategories(), EnumSet.of(BAD_HEADERS, SSL_EXCEPTION));
         assertEquals(auditConfigFilter.getDisabledTransportCategories(), EnumSet.of(FAILED_LOGIN, MISSING_PRIVILEGES));
     }
@@ -89,10 +80,6 @@ public class AuditConfigFilterTest {
         // arrange
         final Settings settings = Settings.builder()
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_USERS, "NONE")
-                .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_IGNORE_USERS,
-                        "NONE")
-                .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_IGNORE_USERS,
-                        "NONE")
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES,
                         "None")
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES,
@@ -102,8 +89,6 @@ public class AuditConfigFilterTest {
         final AuditConfig.Filter auditConfigFilter = AuditConfig.Filter.from(settings);
         // assert
         assertSame(WildcardMatcher.NONE, auditConfigFilter.getIgnoredAuditUsersMatcher());
-        assertSame(WildcardMatcher.NONE, auditConfigFilter.getIgnoredComplianceUsersForReadMatcher());
-        assertSame(WildcardMatcher.NONE, auditConfigFilter.getIgnoredComplianceUsersForWriteMatcher());
         assertTrue(auditConfigFilter.getDisabledRestCategories().isEmpty());
         assertTrue(auditConfigFilter.getDisabledTransportCategories().isEmpty());
     }
@@ -114,10 +99,6 @@ public class AuditConfigFilterTest {
         final Settings settings = Settings.builder()
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_USERS, Collections.emptyList())
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_REQUESTS,  Collections.emptyList())
-                .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_IGNORE_USERS,
-                        Collections.emptyList())
-                .putList(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_IGNORE_USERS,
-                        Collections.emptyList())
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES,
                         Collections.emptyList())
                 .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES,
@@ -127,8 +108,6 @@ public class AuditConfigFilterTest {
         final AuditConfig.Filter auditConfigFilter = AuditConfig.Filter.from(settings);
         // assert
         assertSame(WildcardMatcher.NONE, auditConfigFilter.getIgnoredAuditUsersMatcher());
-        assertSame(WildcardMatcher.NONE, auditConfigFilter.getIgnoredComplianceUsersForReadMatcher());
-        assertSame(WildcardMatcher.NONE, auditConfigFilter.getIgnoredComplianceUsersForWriteMatcher());
         assertTrue(auditConfigFilter.getDisabledRestCategories().isEmpty());
         assertTrue(auditConfigFilter.getDisabledTransportCategories().isEmpty());
     }


### PR DESCRIPTION
- Moving compliance ignore users from audit config to compliance config as thats the correct place for this setting to exist. 
- Migrated all the tests 