### PR TITLE
Preventing users from mapping to hidden/reserved opendistro_security_…

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -115,20 +115,19 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
         final ObjectNode contentAsNode = (ObjectNode) content;
         final SecurityJsonNode securityJsonNode = new SecurityJsonNode(contentAsNode);
 
-
-        // Don't allow user to add reserved or hidden role
-        final SecurityDynamicConfiguration<?> rolesConfiguration = load(CType.ROLES, false);
+        // Don't allow user to add hidden, reserved or non-existent role
         final List<String> opendistroSecurityRoles = securityJsonNode.get("opendistro_security_roles").asList();
         if (opendistroSecurityRoles != null) {
+            final SecurityDynamicConfiguration<?> rolesConfiguration = load(CType.ROLES, false);
             for (final String role: opendistroSecurityRoles) {
 
-                if (isHidden(rolesConfiguration, role)) {
+                if (!rolesConfiguration.exists(role) || isHidden(rolesConfiguration, role)) {
                     notFound(channel, "Role '"+role+"' is not found.");
                     return;
                 }
 
                 if (isReserved(rolesConfiguration, role)) {
-                    forbidden(channel, "Role '" + role + "' is read-only.");
+                    forbidden(channel, "Role '" + role + "' is reserved.");
                     return;
                 }
             }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -99,21 +99,39 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
         // TODO it might be sensible to consolidate this with the overridden method in
         // order to minimize duplicated logic
 
-        final SecurityDynamicConfiguration<?> configuration = load(getConfigName(), false);
+        final SecurityDynamicConfiguration<?> internalUsersConfiguration = load(getConfigName(), false);
 
-        if (isHidden(configuration, username)) {
+        if (isHidden(internalUsersConfiguration, username)) {
             forbidden(channel, "Resource '" + username + "' is not available.");
             return;
         }
 
         // check if resource is writeable
-        if (!isReservedAndAccessible(configuration, username)) {
+        if (!isReservedAndAccessible(internalUsersConfiguration, username)) {
             forbidden(channel, "Resource '" + username + "' is read-only.");
             return;
         }
 
         final ObjectNode contentAsNode = (ObjectNode) content;
         final SecurityJsonNode securityJsonNode = new SecurityJsonNode(contentAsNode);
+
+
+        // Don't allow user to add reserved or hidden role
+        final SecurityDynamicConfiguration<?> rolesConfiguration = load(CType.ROLES, false);
+        final List<String> opendistroSecurityRoles = securityJsonNode.get("opendistro_security_roles").asList();
+        if (opendistroSecurityRoles != null) {
+            for (final String role: opendistroSecurityRoles) {
+                if (isHidden(rolesConfiguration, role)) {
+                    forbidden(channel, "Role '"+role+"' is not available.");
+                    return;
+                }
+
+                if (isReserved(rolesConfiguration, role)) {
+                    forbidden(channel, "Cannot associate user with reserved role '"+role+"'");
+                    return;
+                }
+            }
+        }
 
         // if password is set, it takes precedence over hash
         final String plainTextPassword = securityJsonNode.get("password").asString();
@@ -127,10 +145,7 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
             contentAsNode.remove("password");
         }
 
-        // check if user exists
-        final SecurityDynamicConfiguration<?> internaluser = load(CType.INTERNALUSERS, false);
-
-        final boolean userExisted = internaluser.exists(username);
+        final boolean userExisted = internalUsersConfiguration.exists(username);
 
         // when updating an existing user password hash can be blank, which means no
         // changes
@@ -144,21 +159,21 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
         // for existing users, hash is optional
         if (userExisted && securityJsonNode.get("hash").asString() == null) {
             // sanity check, this should usually not happen
-            final String hash = ((Hashed) internaluser.getCEntry(username)).getHash();
+            final String hash = ((Hashed) internalUsersConfiguration.getCEntry(username)).getHash();
             if (hash == null || hash.length() == 0) {
                 internalErrorResponse(channel,
-                        "Existing user " + username + " has no password, and no new password or hash was specified.");
+                    "Existing user " + username + " has no password, and no new password or hash was specified.");
                 return;
             }
             contentAsNode.put("hash", hash);
         }
 
-        internaluser.remove(username);
+        internalUsersConfiguration.remove(username);
 
         // checks complete, create or update the user
-        internaluser.putCObject(username, DefaultObjectMapper.readTree(contentAsNode, internaluser.getImplementingClass()));
+        internalUsersConfiguration.putCObject(username, DefaultObjectMapper.readTree(contentAsNode,  internalUsersConfiguration.getImplementingClass()));
 
-        saveAnUpdateConfigs(client, request, CType.INTERNALUSERS, internaluser, new OnSucessActionListener<IndexResponse>(channel) {
+        saveAnUpdateConfigs(client, request, CType.INTERNALUSERS, internalUsersConfiguration, new OnSucessActionListener<IndexResponse>(channel) {
 
             @Override
             public void onResponse(IndexResponse response) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -127,7 +127,7 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
                     return;
                 }
 
-                if (!isReservedAndAccessible(rolesConfiguration, role)) {
+                if (isReserved(rolesConfiguration, role)) {
                     forbidden(channel, "Role '" + role + "' is read-only.");
                     return;
                 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -121,13 +121,14 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
         final List<String> opendistroSecurityRoles = securityJsonNode.get("opendistro_security_roles").asList();
         if (opendistroSecurityRoles != null) {
             for (final String role: opendistroSecurityRoles) {
+
                 if (isHidden(rolesConfiguration, role)) {
-                    forbidden(channel, "Role '"+role+"' is not available.");
+                    notFound(channel, "Role '"+role+"' is not found.");
                     return;
                 }
 
-                if (isReserved(rolesConfiguration, role)) {
-                    forbidden(channel, "Cannot associate user with reserved role '"+role+"'");
+                if (!isReservedAndAccessible(rolesConfiguration, role)) {
+                    forbidden(channel, "Role '" + role + "' is read-only.");
                     return;
                 }
             }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigFactory.java
@@ -189,8 +189,8 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
 
                 log.debug("Static tenants loaded ({})", staticTenants.getCEntries().size());
 
-                log.debug("Static configuration loaded (total roles: {}/total action groups: {}/total tenants: {})", roles.getCEntries().size(),
-                    actionGroups.getCEntries().size(), tenants.getCEntries().size());
+                log.debug("Static configuration loaded (total roles: {}/total action groups: {}/total tenants: {})",
+                    roles.getCEntries().size(), actionGroups.getCEntries().size(), tenants.getCEntries().size());
 
             
 
@@ -245,9 +245,9 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
     
     private static class InternalUsersModelV7 extends InternalUsersModel {
         
-        SecurityDynamicConfiguration<InternalUserV7> internalUserV7SecurityDynamicConfiguration;
+        private final SecurityDynamicConfiguration<InternalUserV7> internalUserV7SecurityDynamicConfiguration;
 
-        SecurityDynamicConfiguration<RoleV7> roleV7SecurityDynamicConfiguration;
+        private final SecurityDynamicConfiguration<RoleV7> roleV7SecurityDynamicConfiguration;
         
         public InternalUsersModelV7(SecurityDynamicConfiguration<InternalUserV7> internalUserV7SecurityDynamicConfiguration, SecurityDynamicConfiguration<RoleV7> roleV7SecurityDynamicConfiguration) {
             super();
@@ -288,11 +288,14 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
             InternalUserV7 tmp = internalUserV7SecurityDynamicConfiguration.getCEntry(user);
 
             // Filtering out hidden and reserved roles for existing users
-            return tmp==null? ImmutableList.of():
-                                    tmp.getOpendistro_security_roles()
-                                        .stream()
-                                        .filter(role -> roleV7SecurityDynamicConfiguration.getCEntry(role).isHidden() || roleV7SecurityDynamicConfiguration.getCEntry(role).isReserved())
-                                        .collect(ImmutableList.toImmutableList());
+            return tmp == null ? ImmutableList.of() :
+                tmp.getOpendistro_security_roles().stream().filter(role -> !isHiddenReservedOrNonExistent(role)).collect(ImmutableList.toImmutableList());
+        }
+
+        // We will remove opendistro security mapping for roles that are hidden/reserved or non-existent in the roles configuration
+        private boolean isHiddenReservedOrNonExistent(String rolename) {
+            final RoleV7 role = roleV7SecurityDynamicConfiguration.getCEntry(rolename);
+            return role == null || role.isHidden() || role.isReserved();
         }
     }
     

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigFactory.java
@@ -7,10 +7,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.NodesDn;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
+import com.google.common.collect.ImmutableList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Client;
@@ -189,13 +189,14 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
 
                 log.debug("Static tenants loaded ({})", staticTenants.getCEntries().size());
 
-                log.debug("Static configuration loaded (total roles: {}/total action groups: {}/total tenants: {})", roles.getCEntries().size(), actionGroups.getCEntries().size(), tenants.getCEntries().size());
+                log.debug("Static configuration loaded (total roles: {}/total action groups: {}/total tenants: {})", roles.getCEntries().size(),
+                    actionGroups.getCEntries().size(), tenants.getCEntries().size());
 
             
 
             //rebuild v7 Models
             dcm = new DynamicConfigModelV7(getConfigV7(config), esSettings, configPath, iab);
-            ium = new InternalUsersModelV7((SecurityDynamicConfiguration<InternalUserV7>) internalusers);
+            ium = new InternalUsersModelV7((SecurityDynamicConfiguration<InternalUserV7>) internalusers, (SecurityDynamicConfiguration<RoleV7>) roles);
             cm = new ConfigModelV7((SecurityDynamicConfiguration<RoleV7>) roles,(SecurityDynamicConfiguration<RoleMappingsV7>)rolesmapping, (SecurityDynamicConfiguration<ActionGroupsV7>)actionGroups, (SecurityDynamicConfiguration<TenantV7>) tenants,dcm, esSettings);
 
         } else {
@@ -244,45 +245,54 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
     
     private static class InternalUsersModelV7 extends InternalUsersModel {
         
-        SecurityDynamicConfiguration<InternalUserV7> configuration;
+        SecurityDynamicConfiguration<InternalUserV7> internalUserV7SecurityDynamicConfiguration;
+
+        SecurityDynamicConfiguration<RoleV7> roleV7SecurityDynamicConfiguration;
         
-        public InternalUsersModelV7(SecurityDynamicConfiguration<InternalUserV7> configuration) {
+        public InternalUsersModelV7(SecurityDynamicConfiguration<InternalUserV7> internalUserV7SecurityDynamicConfiguration, SecurityDynamicConfiguration<RoleV7> roleV7SecurityDynamicConfiguration) {
             super();
-            this.configuration = configuration;
+            this.internalUserV7SecurityDynamicConfiguration = internalUserV7SecurityDynamicConfiguration;
+            this.roleV7SecurityDynamicConfiguration = roleV7SecurityDynamicConfiguration;
         }
 
         @Override
         public boolean exists(String user) {
-            return configuration.exists(user);
+            return internalUserV7SecurityDynamicConfiguration.exists(user);
         }
 
         @Override
         public List<String> getBackenRoles(String user) {
-            InternalUserV7 tmp = configuration.getCEntry(user);
+            InternalUserV7 tmp = internalUserV7SecurityDynamicConfiguration.getCEntry(user);
             return tmp==null?null:tmp.getBackend_roles();
         }
 
         @Override
         public Map<String, String> getAttributes(String user) {
-            InternalUserV7 tmp = configuration.getCEntry(user);
+            InternalUserV7 tmp = internalUserV7SecurityDynamicConfiguration.getCEntry(user);
             return tmp==null?null:tmp.getAttributes();
         }
 
         @Override
         public String getDescription(String user) {
-            InternalUserV7 tmp = configuration.getCEntry(user);
+            InternalUserV7 tmp = internalUserV7SecurityDynamicConfiguration.getCEntry(user);
             return tmp==null?null:tmp.getDescription();
         }
 
         @Override
         public String getHash(String user) {
-            InternalUserV7 tmp = configuration.getCEntry(user);
+            InternalUserV7 tmp = internalUserV7SecurityDynamicConfiguration.getCEntry(user);
             return tmp==null?null:tmp.getHash();
         }
         
         public List<String> getOpenDistroSecurityRoles(String user) {
-            InternalUserV7 tmp = configuration.getCEntry(user);
-            return tmp==null?Collections.emptyList():tmp.getOpendistro_security_roles();
+            InternalUserV7 tmp = internalUserV7SecurityDynamicConfiguration.getCEntry(user);
+
+            // Filtering out hidden and reserved roles for existing users
+            return tmp==null? ImmutableList.of():
+                                    tmp.getOpendistro_security_roles()
+                                        .stream()
+                                        .filter(role -> roleV7SecurityDynamicConfiguration.getCEntry(role).isHidden() || roleV7SecurityDynamicConfiguration.getCEntry(role).isReserved())
+                                        .collect(ImmutableList.toImmutableList());
         }
     }
     

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/OpendistroSecurityRolesTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/OpendistroSecurityRolesTests.java
@@ -45,7 +45,7 @@ import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelpe
 public class OpendistroSecurityRolesTests extends SingleClusterTest {
 
 	@Test
-	public void testSecurityRAnon() throws Exception {
+	public void testOpenDistroSecurityRolesAnon() throws Exception {
 
 		setup(Settings.EMPTY, new DynamicSecurityConfig()
 				.setSecurityInternalUsers("internal_users_sr.yml")
@@ -61,12 +61,13 @@ public class OpendistroSecurityRolesTests extends SingleClusterTest {
 		resc = rh.executeGetRequest("_opendistro/_security/authinfo?pretty", encodeBasicHeader("sr_user", "nagilum"));
 		Assert.assertTrue(resc.getBody().contains("sr_user"));
 		Assert.assertTrue(resc.getBody().contains("xyz_sr"));
+		Assert.assertFalse(resc.getBody().contains("opendistro_security_kibana_server"));
 		Assert.assertTrue(resc.getBody().contains("backend_roles=[abc_ber]"));
 		Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
 	}
 
 	@Test
-	public void testSecurityR() throws Exception {
+	public void testOpenDistroSecurityRoles() throws Exception {
 
 		setup(Settings.EMPTY, new DynamicSecurityConfig()
 				.setSecurityInternalUsers("internal_users_sr.yml"), Settings.EMPTY, true);
@@ -76,12 +77,18 @@ public class OpendistroSecurityRolesTests extends SingleClusterTest {
 		HttpResponse resc = rh.executeGetRequest("_opendistro/_security/authinfo?pretty", encodeBasicHeader("sr_user", "nagilum"));
 		Assert.assertTrue(resc.getBody().contains("sr_user"));
 		Assert.assertTrue(resc.getBody().contains("xyz_sr"));
+
+		// Ensure hidden reserved and non-existent roles are not available
+		Assert.assertFalse(resc.getBody().contains("xyz_sr_non_existent"));
+		Assert.assertFalse(resc.getBody().contains("xyz_sr_hidden"));
+		Assert.assertFalse(resc.getBody().contains("xyz_sr_reserved"));
+
 		Assert.assertTrue(resc.getBody().contains("backend_roles=[abc_ber]"));
 		Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
 	}
 
 	@Test
-	public void testSecurityRImpersonation() throws Exception {
+	public void testOpenDistroSecurityRolesImpersonation() throws Exception {
 
 		Settings settings = Settings.builder()
 				.putList(ConfigConstants.OPENDISTRO_SECURITY_AUTHCZ_REST_IMPERSONATION_USERS+".sr_user", "sr_impuser")

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
@@ -184,7 +184,7 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
         final String createInternalUserPayload = "{\n" +
                 "  \"password\": \"" + testPassword + "\",\n" +
                 "  \"backend_roles\": [\"test-backend-role-1\"],\n" +
-                "  \"opendistro_security_roles\": [\"kibana_server\"],\n" +
+                "  \"opendistro_security_roles\": [\"opendistro_security_all_access\"],\n" +
                 "  \"attributes\": {\n" +
                 "    \"attribute1\": \"value1\"\n" +
                 "  }\n" +
@@ -211,7 +211,7 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
                 .build()
                 .getAsSettings(testUsername);
         assertTrue(responseBody.getAsList("backend_roles").contains("test-backend-role-1"));
-        assertTrue(responseBody.getAsList("opendistro_security_roles").contains("kibana_server"));
+        assertTrue(responseBody.getAsList("opendistro_security_roles").contains("opendistro_security_all_access"));
         assertEquals(responseBody.getAsSettings("attributes").get("attribute1"), "value1");
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
@@ -184,7 +184,7 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
         final String createInternalUserPayload = "{\n" +
                 "  \"password\": \"" + testPassword + "\",\n" +
                 "  \"backend_roles\": [\"test-backend-role-1\"],\n" +
-                "  \"opendistro_security_roles\": [\"all_access\"],\n" +
+                "  \"opendistro_security_roles\": [\"kibana_server\"],\n" +
                 "  \"attributes\": {\n" +
                 "    \"attribute1\": \"value1\"\n" +
                 "  }\n" +
@@ -211,7 +211,7 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
                 .build()
                 .getAsSettings(testUsername);
         assertTrue(responseBody.getAsList("backend_roles").contains("test-backend-role-1"));
-        assertTrue(responseBody.getAsList("opendistro_security_roles").contains("all_access"));
+        assertTrue(responseBody.getAsList("opendistro_security_roles").contains("kibana_server"));
         assertEquals(responseBody.getAsSettings("attributes").get("attribute1"), "value1");
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
@@ -72,6 +72,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
         Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
         Assert.assertEquals(35, settings.size());
+
         // --- GET
 
         // GET, user admin, exists
@@ -117,6 +118,13 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         //Assert.assertEquals(settings.get("reason"), AbstractConfigurationValidator.ErrorType.INVALID_CONFIGURATION.getMessage());
         //Assert.assertTrue(settings.get(AbstractConfigurationValidator.INVALID_KEYS_KEY + ".keys").contains("some"));
         //Assert.assertTrue(settings.get(AbstractConfigurationValidator.INVALID_KEYS_KEY + ".keys").contains("other"));
+
+        // Associating with reserved or hidden role is not allowed
+        response = rh.executePutRequest("/_opendistro/_security/api/internalusers/nagilum", "{ \"opendistro_security_roles\": [\"kibana_server\"]}",
+            new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
+        Assert.assertEquals(settings.get("message"), "Cannot associate user with reserved role 'kibana_server'");
 
         // Wrong config keys
         response = rh.executePutRequest("/_opendistro/_security/api/internalusers/nagilum", "{\"some\": \"thing\", \"other\": \"thing\"}",

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
@@ -120,11 +120,11 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         //Assert.assertTrue(settings.get(AbstractConfigurationValidator.INVALID_KEYS_KEY + ".keys").contains("other"));
 
         // Associating with reserved or hidden role is not allowed
-        response = rh.executePutRequest("/_opendistro/_security/api/internalusers/nagilum", "{ \"opendistro_security_roles\": [\"kibana_server\"]}",
+        response = rh.executePutRequest("/_opendistro/_security/api/internalusers/nagilum", "{ \"opendistro_security_roles\": [\"opendistro_security_internal\"]}",
             new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals(settings.get("message"), "Cannot associate user with reserved role 'kibana_server'");
+        Assert.assertEquals(settings.get("message"), "Role 'opendistro_security_internal' is not found.");
 
         // Wrong config keys
         response = rh.executePutRequest("/_opendistro/_security/api/internalusers/nagilum", "{\"some\": \"thing\", \"other\": \"thing\"}",

--- a/src/test/resources/internal_users_sr.yml
+++ b/src/test/resources/internal_users_sr.yml
@@ -10,6 +10,9 @@ sr_user:
     - abc_ber
   opendistro_security_roles:
     - xyz_sr
+    - xyz_sr_hidden
+    - xyz_sr_reserved
+    - xyz_sr_non_existent
 
 sr_impuser:
   #password is: nagilum

--- a/src/test/resources/restapi/roles.yml
+++ b/src/test/resources/restapi/roles.yml
@@ -17,6 +17,37 @@ opendistro_security_unittest_1:
     allowed_actions:
     - "*"
   tenant_permissions: []
+
+opendistro_security_hidden:
+  reserved: false
+  hidden: true
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "OPENDISTRO_SECURITY_CLUSTER_ALL"
+  index_permissions:
+    - index_patterns:
+        - "*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "ALL"
+  tenant_permissions: []
+
+opendistro_security_reserved:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "OPENDISTRO_SECURITY_CLUSTER_ALL"
+  index_permissions:
+    - index_patterns:
+        - "*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "ALL"
 opendistro_security_internal:
   reserved: false
   hidden: true

--- a/src/test/resources/roles.yml
+++ b/src/test/resources/roles.yml
@@ -1031,3 +1031,54 @@ role_foo_all:
         - indices:data/read/*
         - indices:admin/*
         - indices:monitor/*
+
+xyz_sr:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "OPENDISTRO_SECURITY_CLUSTER_COMPOSITE_OPS_RO"
+  index_permissions:
+    - index_patterns:
+        - "twitter"
+        - "analytics"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "*"
+  tenant_permissions: []
+
+xyz_sr_hidden:
+  reserved: false
+  hidden: true
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "OPENDISTRO_SECURITY_CLUSTER_COMPOSITE_OPS_RO"
+  index_permissions:
+    - index_patterns:
+        - "twitter"
+        - "analytics"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "*"
+  tenant_permissions: []
+
+xyz_sr_reserved:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "OPENDISTRO_SECURITY_CLUSTER_COMPOSITE_OPS_RO"
+  index_permissions:
+    - index_patterns:
+        - "twitter"
+        - "analytics"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "*"
+  tenant_permissions: []


### PR DESCRIPTION
…roles

*Issue #, if available:* 


*Description of changes:*
Currently an authorized user can create a new user and attach a reserved role using a PUT request to the /_opendistro/_security/api/user/(new_username_here) endpoint. 

Eg: 
```
PUT _opendistro/_security/api/internalusers/kirkuser
{
  "password": "kirkpass",
  "backend_roles": ["captains", "starfleet"],
  "opendistro_security_roles": ["restricted_role"]
}
```

This change will forbid users from associating user with restricted` opendistro_security_roles`

*Tests:*
Updated unit tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
