### PR TITLE
Create indexing operation listener for every index module call

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -508,20 +508,11 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
         //called for every index!
 
         if (!disabled && !client && !sslOnly) {
-            final ComplianceConfig complianceConfig = auditLog.getComplianceConfig();
-            log.debug("Handle complianceConfig="+complianceConfig+"/dlsFlsAvailable: "+dlsFlsAvailable+"/auditLog="+auditLog.getClass()+" for onIndexModule() of index "+indexModule.getIndex().getName());
+            log.debug("Handle dlsFlsAvailable: "+dlsFlsAvailable+"/auditLog="+auditLog.getClass()+" for onIndexModule() of index "+indexModule.getIndex().getName());
             if (dlsFlsAvailable) {
 
-                final ComplianceIndexingOperationListener ciol;
-
-                assert complianceConfig!=null:"compliance config must not be null here";
-                
-                if(complianceConfig.writeHistoryEnabledForIndex(indexModule.getIndex().getName())) {
-                    ciol = ReflectionHelper.instantiateComplianceListener(Objects.requireNonNull(auditLog));
-                    indexModule.addIndexOperationListener(ciol);
-                } else {
-                    ciol = new ComplianceIndexingOperationListener();
-                }
+                final ComplianceIndexingOperationListener ciol = ReflectionHelper.instantiateComplianceListener(Objects.requireNonNull(auditLog));
+                indexModule.addIndexOperationListener(ciol);
 
                 indexModule.setReaderWrapper(indexService -> loadFlsDlsIndexSearcherWrapper(indexService, ciol));
                 indexModule.forceQueryCacheProvider((indexSettings,nodeCache)->new QueryCache() {
@@ -563,9 +554,6 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
                     }
                 });
             } else {
-                
-                assert complianceConfig==null:"compliance config must be null here";
-                
                 indexModule.setReaderWrapper(
                         indexService -> new OpenDistroSecurityIndexSearcherWrapper(indexService, settings, Objects.requireNonNull(adminDns), Objects.requireNonNull(evaluator)));
             }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/compliance/ComplianceConfig.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/compliance/ComplianceConfig.java
@@ -353,7 +353,7 @@ public class ComplianceConfig {
      * @return true/false
      */
     public boolean writeHistoryEnabledForIndex(String index) {
-        if (index == null) {
+        if (index == null || !isEnabled()) {
             return false;
         }
         // if open distro index (internal index) check if internal config logging is enabled

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/compliance/ComplianceIndexingOperationListenerImpl.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/compliance/ComplianceIndexingOperationListenerImpl.java
@@ -67,7 +67,8 @@ public final class ComplianceIndexingOperationListenerImpl extends ComplianceInd
 
     @Override
     public void postDelete(final ShardId shardId, final Delete delete, final DeleteResult result) {
-        if (auditlog.getComplianceConfig().isEnabled()) {
+        final ComplianceConfig complianceConfig = auditlog.getComplianceConfig();
+        if (complianceConfig != null && complianceConfig.writeHistoryEnabledForIndex(shardId.getIndexName())) {
             Objects.requireNonNull(is);
             if(result.getFailure() == null && result.isFound() && delete.origin() == org.elasticsearch.index.engine.Engine.Operation.Origin.PRIMARY) {
                 auditlog.logDocumentDeleted(shardId, delete, result);
@@ -77,8 +78,7 @@ public final class ComplianceIndexingOperationListenerImpl extends ComplianceInd
 
     @Override
     public Index preIndex(final ShardId shardId, final Index index) {
-        final ComplianceConfig complianceConfig = auditlog.getComplianceConfig();
-        if (complianceConfig.isEnabled() && complianceConfig.shouldLogDiffsForWrite()) {
+        if (isLoggingWriteDiffEnabled(auditlog.getComplianceConfig(), shardId.getIndexName())) {
             Objects.requireNonNull(is);
 
             final IndexShard shard;
@@ -120,8 +120,7 @@ public final class ComplianceIndexingOperationListenerImpl extends ComplianceInd
 
     @Override
     public void postIndex(final ShardId shardId, final Index index, final Exception ex) {
-        final ComplianceConfig complianceConfig = auditlog.getComplianceConfig();
-        if (complianceConfig.isEnabled() && complianceConfig.shouldLogDiffsForWrite()) {
+        if (isLoggingWriteDiffEnabled(auditlog.getComplianceConfig(), shardId.getIndexName())) {
             threadContext.remove();
         }
     }
@@ -129,7 +128,11 @@ public final class ComplianceIndexingOperationListenerImpl extends ComplianceInd
     @Override
     public void postIndex(ShardId shardId, Index index, IndexResult result) {
         final ComplianceConfig complianceConfig = auditlog.getComplianceConfig();
-        if (complianceConfig.isEnabled() && complianceConfig.shouldLogDiffsForWrite()) {
+        if (complianceConfig == null || !complianceConfig.writeHistoryEnabledForIndex(shardId.getIndexName())) {
+            return;
+        }
+
+        if (complianceConfig.shouldLogDiffsForWrite()) {
             final Context context = threadContext.get();
             final GetResult previousContent = context==null?null:context.getGetResult();
             threadContext.remove();
@@ -157,7 +160,7 @@ public final class ComplianceIndexingOperationListenerImpl extends ComplianceInd
             }
 
             auditlog.logDocumentWritten(shardId, previousContent, index, result);
-        } else if (complianceConfig.isEnabled()) {
+        } else {
             //no diffs
             if (result.getFailure() != null || index.origin() != org.elasticsearch.index.engine.Engine.Operation.Origin.PRIMARY) {
                 return;
@@ -167,4 +170,7 @@ public final class ComplianceIndexingOperationListenerImpl extends ComplianceInd
         }
     }
 
+    private static boolean isLoggingWriteDiffEnabled(final ComplianceConfig complianceConfig, final String indexName) {
+        return complianceConfig != null && complianceConfig.shouldLogDiffsForWrite() && complianceConfig.writeHistoryEnabledForIndex(indexName);
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/compliance/ComplianceIndexingOperationListenerImpl.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/compliance/ComplianceIndexingOperationListenerImpl.java
@@ -68,7 +68,7 @@ public final class ComplianceIndexingOperationListenerImpl extends ComplianceInd
     @Override
     public void postDelete(final ShardId shardId, final Delete delete, final DeleteResult result) {
         final ComplianceConfig complianceConfig = auditlog.getComplianceConfig();
-        if (complianceConfig != null && complianceConfig.writeHistoryEnabledForIndex(shardId.getIndexName())) {
+        if (isLoggingWriteEnabled(complianceConfig, shardId.getIndexName())) {
             Objects.requireNonNull(is);
             if(result.getFailure() == null && result.isFound() && delete.origin() == org.elasticsearch.index.engine.Engine.Operation.Origin.PRIMARY) {
                 auditlog.logDocumentDeleted(shardId, delete, result);
@@ -128,7 +128,7 @@ public final class ComplianceIndexingOperationListenerImpl extends ComplianceInd
     @Override
     public void postIndex(ShardId shardId, Index index, IndexResult result) {
         final ComplianceConfig complianceConfig = auditlog.getComplianceConfig();
-        if (complianceConfig == null || !complianceConfig.writeHistoryEnabledForIndex(shardId.getIndexName())) {
+        if (!isLoggingWriteEnabled(complianceConfig, shardId.getIndexName())) {
             return;
         }
 
@@ -170,7 +170,11 @@ public final class ComplianceIndexingOperationListenerImpl extends ComplianceInd
         }
     }
 
+    private static boolean isLoggingWriteEnabled(final ComplianceConfig complianceConfig, final String indexName) {
+        return complianceConfig != null && complianceConfig.writeHistoryEnabledForIndex(indexName);
+    }
+
     private static boolean isLoggingWriteDiffEnabled(final ComplianceConfig complianceConfig, final String indexName) {
-        return complianceConfig != null && complianceConfig.shouldLogDiffsForWrite() && complianceConfig.writeHistoryEnabledForIndex(indexName);
+        return isLoggingWriteEnabled(complianceConfig, indexName) && complianceConfig.shouldLogDiffsForWrite();
     }
 }


### PR DESCRIPTION
- IndexModule is called per index. 

- Current behavior, at the time it is called for index, checks for compliance write is enabled for the index. If not enabled at that time, then it creates an empty listener and will not check for compliance write updates and the index documents will be unaudited. 

- Change is creating index listener for a given index and check with the latest compliance write value at that time. 