### PR TITLE
Grant access to all packages under com.sun.jndi

### DIFF
--- a/plugin-security.policy
+++ b/plugin-security.policy
@@ -71,7 +71,7 @@ grant {
   permission java.lang.RuntimePermission "createClassLoader";
   
   //Java 9+
-  permission java.lang.RuntimePermission "accessClassInPackage.com.sun.jndi.ldap";
+  permission java.lang.RuntimePermission "accessClassInPackage.com.sun.jndi.*";
 
   //Enable this permission to debug unauthorized de-serialization attempt
   //permission java.io.SerializablePermission "enableSubstitution";


### PR DESCRIPTION
…licy

Issue: https://github.com/opendistro-for-elasticsearch/security/issues/489

*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/security/issues/489

*Description of changes:* This permission is needed to enable StartTLS for LDAP. See http://www.docjar.com/docs/api/com/sun/jndi/ldap/ext/package-index.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
