### PR TITLE
Avoid using Basic Authorization header as JWT token

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -137,7 +137,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
 
     protected String getJwtTokenString(RestRequest request) {
         String jwtToken = request.header(jwtHeaderName);
-        if (isDefaultAuthHeader && BASIC.matcher(jwtToken).matches()) {
+        if (isDefaultAuthHeader && jwtToken != null && BASIC.matcher(jwtToken).matches()) {
             jwtToken = null;
         }
 

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -20,9 +20,11 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collection;
 import java.util.Map.Entry;
+import java.util.regex.Pattern;
 
 import org.apache.cxf.rs.security.jose.jwt.JwtClaims;
 import org.apache.cxf.rs.security.jose.jwt.JwtToken;
+import org.apache.http.HttpHeaders;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchSecurityException;
@@ -46,17 +48,20 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
     private final static Logger log = LogManager.getLogger(AbstractHTTPJwtAuthenticator.class);
 
     private static final String BEARER = "bearer ";
+    private static final Pattern BASIC = Pattern.compile("^\\s*Basic\\s.*", Pattern.CASE_INSENSITIVE);
 
     private KeyProvider keyProvider;
     private JwtVerifier jwtVerifier;
     private final String jwtHeaderName;
+    private final boolean isDefaultAuthHeader;
     private final String jwtUrlParameter;
     private final String subjectKey;
     private final String rolesKey;
 
     public AbstractHTTPJwtAuthenticator(Settings settings, Path configPath) {
         jwtUrlParameter = settings.get("jwt_url_parameter");
-        jwtHeaderName = settings.get("jwt_header", "Authorization");
+        jwtHeaderName = settings.get("jwt_header", HttpHeaders.AUTHORIZATION);
+        isDefaultAuthHeader = HttpHeaders.AUTHORIZATION.equalsIgnoreCase(jwtHeaderName);
         rolesKey = settings.get("roles_key");
         subjectKey = settings.get("subject_key");
 
@@ -132,6 +137,9 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
 
     protected String getJwtTokenString(RestRequest request) {
         String jwtToken = request.header(jwtHeaderName);
+        if (isDefaultAuthHeader && BASIC.matcher(jwtToken).matches()) {
+            jwtToken = null;
+        }
 
         if (jwtUrlParameter != null) {
             if (jwtToken == null || jwtToken.isEmpty()) {

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -138,7 +138,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         }
 
         String jwtToken = request.header(jwtHeaderName);
-        if (isDefaultAuthHeader && BASIC.matcher(jwtToken).matches()) {
+        if (isDefaultAuthHeader && jwtToken != null && BASIC.matcher(jwtToken).matches()) {
             jwtToken = null;
         }
 

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -26,7 +26,9 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Collection;
 import java.util.Map.Entry;
+import java.util.regex.Pattern;
 
+import org.apache.http.HttpHeaders;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchSecurityException;
@@ -51,9 +53,12 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
 
+    private static final Pattern BASIC = Pattern.compile("^\\s*Basic\\s.*", Pattern.CASE_INSENSITIVE);
     private static final String BEARER = "bearer ";
+
     private final JwtParser jwtParser;
     private final String jwtHeaderName;
+    private final boolean isDefaultAuthHeader;
     private final String jwtUrlParameter;
     private final String rolesKey;
     private final String subjectKey;
@@ -100,7 +105,8 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         }
 
         jwtUrlParameter = settings.get("jwt_url_parameter");
-        jwtHeaderName = settings.get("jwt_header","Authorization");
+        jwtHeaderName = settings.get("jwt_header", HttpHeaders.AUTHORIZATION);
+        isDefaultAuthHeader = HttpHeaders.AUTHORIZATION.equalsIgnoreCase(jwtHeaderName);
         rolesKey = settings.get("roles_key");
         subjectKey = settings.get("subject_key");
         jwtParser = _jwtParser;
@@ -132,6 +138,9 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         }
 
         String jwtToken = request.header(jwtHeaderName);
+        if (isDefaultAuthHeader && BASIC.matcher(jwtToken).matches()) {
+            jwtToken = null;
+        }
 
         if((jwtToken == null || jwtToken.isEmpty()) && jwtUrlParameter != null) {
             jwtToken = request.param(jwtUrlParameter);


### PR DESCRIPTION
*Issue #, if available:* #376

*Description of changes:*
When Authorization header includes "Basic" it can't be JWT token, so we don't need to try to parse it as JWT.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
