### PR TITLE
Refactor salt from compliance config into Salt class

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -49,6 +49,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.amazon.opendistroforelasticsearch.security.configuration.OpenDistroSecurityFlsDlsIndexSearcherWrapper;
+import com.amazon.opendistroforelasticsearch.security.configuration.Salt;
 import com.amazon.opendistroforelasticsearch.security.ssl.rest.OpenDistroSecuritySSLReloadCertsAction;
 import com.amazon.opendistroforelasticsearch.security.ssl.rest.OpenDistroSecuritySSLCertsInfoAction;
 import org.apache.lucene.search.QueryCachingPolicy;
@@ -188,6 +189,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
     private AtomicBoolean externalConfigLogged = new AtomicBoolean();
     private volatile NamedXContentRegistry namedXContentRegistry = null;
     private volatile DlsFlsRequestValve dlsFlsValve = null;
+    private volatile Salt salt;
 
     @Override
     public void close() throws IOException {
@@ -483,7 +485,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
                 final ComplianceIndexingOperationListener ciol = ReflectionHelper.instantiateComplianceListener(Objects.requireNonNull(auditLog));
                 indexModule.addIndexOperationListener(ciol);
 
-                indexModule.setReaderWrapper(indexService -> new OpenDistroSecurityFlsDlsIndexSearcherWrapper(indexService, settings, adminDns, cs, auditLog, ciol, evaluator));
+                indexModule.setReaderWrapper(indexService -> new OpenDistroSecurityFlsDlsIndexSearcherWrapper(indexService, settings, adminDns, cs, auditLog, ciol, evaluator, salt));
                 indexModule.forceQueryCacheProvider((indexSettings,nodeCache)->new QueryCache() {
 
                     @Override
@@ -701,7 +703,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
         }
         final ClusterInfoHolder cih = new ClusterInfoHolder();
         this.cs.addListener(cih);
-
+        this.salt = Salt.from(settings);
         dlsFlsValve = ReflectionHelper.instantiateDlsFlsValve();
 
         final IndexNameExpressionResolver resolver = new IndexNameExpressionResolver();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/MaskedField.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/MaskedField.java
@@ -36,8 +36,8 @@ public class MaskedField {
     private List<RegexReplacement> regexReplacements;
     private final byte[] defaultSalt;
 
-    public MaskedField(final String value, final byte[] defaultSalt) {
-        this.defaultSalt = defaultSalt;
+    public MaskedField(final String value, final Salt salt) {
+        this.defaultSalt = salt.getSalt16();
         final List<String> tokens = Splitter.on("::").splitToList(Objects.requireNonNull(value));
         final int tokenCount = tokens.size();
         if (tokenCount == 1) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityFlsDlsIndexSearcherWrapper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityFlsDlsIndexSearcherWrapper.java
@@ -48,10 +48,11 @@ public class OpenDistroSecurityFlsDlsIndexSearcherWrapper extends OpenDistroSecu
     private final IndexService indexService;
     private final AuditLog auditlog;
     private final LongSupplier nowInMillis;
+    private final Salt salt;
 
     public OpenDistroSecurityFlsDlsIndexSearcherWrapper(final IndexService indexService, final Settings settings,
             final AdminDNs adminDNs, final ClusterService clusterService, final AuditLog auditlog,
-            final ComplianceIndexingOperationListener ciol, final PrivilegesEvaluator evaluator) {
+            final ComplianceIndexingOperationListener ciol, final PrivilegesEvaluator evaluator, final Salt salt) {
         super(indexService, settings, adminDNs, evaluator);
         ciol.setIs(indexService);
         this.clusterService = clusterService;
@@ -64,6 +65,7 @@ public class OpenDistroSecurityFlsDlsIndexSearcherWrapper extends OpenDistroSecu
             nowInMillis = () -> {throw new IllegalArgumentException("'now' is not allowed in DLS queries");};
         }
         log.debug("FLS/DLS {} enabled for index {}", this, indexService.index().getName());
+        this.salt = salt;
     }
 
     @SuppressWarnings("unchecked")
@@ -112,6 +114,6 @@ public class OpenDistroSecurityFlsDlsIndexSearcherWrapper extends OpenDistroSecu
         }
 
         return new DlsFlsFilterLeafReader.DlsFlsDirectoryReader(reader, flsFields, dlsQuery,
-                indexService, threadContext, clusterService, auditlog, maskedFields, shardId);
+                indexService, threadContext, clusterService, auditlog, maskedFields, shardId, salt);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/Salt.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/Salt.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.configuration;
+
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.settings.Settings;
+
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * Configuration class to store salt used for FLS anonymization
+ */
+public class Salt {
+
+    private static final Logger log = LogManager.getLogger(Salt.class);
+
+    @VisibleForTesting
+    static final int SALT_SIZE = 16;
+
+    private final byte[] salt16;
+
+    public Salt(final byte[] salt) {
+        if (salt.length != SALT_SIZE) {
+            throw new ElasticsearchException("Provided compliance salt must contain 16 bytes");
+        }
+        this.salt16 = salt;
+    }
+
+    private Salt(final String saltAsString) {
+        this.salt16 = new byte[SALT_SIZE];
+        if (saltAsString.equals(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_SALT_DEFAULT)) {
+            log.warn("If you plan to use field masking pls configure compliance salt {} to be a random string of 16 chars length identical on all nodes", saltAsString);
+        }
+        try {
+            ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode(saltAsString);
+            byteBuffer.get(salt16);
+            if (byteBuffer.remaining() > 0) {
+                log.warn("Provided compliance salt {} is greater than 16 bytes. Only the first 16 bytes are used for salting", saltAsString);
+            }
+        } catch (BufferUnderflowException e) {
+            throw new ElasticsearchException("Provided compliance salt " + saltAsString + " must at least contain 16 bytes", e);
+        }
+    }
+
+    /**
+     * Get the salt in bytes for field anonymization.
+     * Returns a new salt array every time it is called.
+     * @return salt in bytes
+     */
+    byte[] getSalt16() {
+        return salt16;
+    }
+
+    /**
+     * Get salt configuration from Elasticsearch settings
+     * @param settings Elasticsearch settings
+     * @return configuration
+     */
+    public static Salt from(final Settings settings) {
+        final String saltAsString = settings.get(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_SALT, ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_SALT_DEFAULT);
+        return new Salt(saltAsString);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/RolesValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/RolesValidator.java
@@ -17,6 +17,7 @@ package com.amazon.opendistroforelasticsearch.security.dlic.rest.validation;
 
 import java.util.List;
 
+import com.amazon.opendistroforelasticsearch.security.configuration.Salt;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestRequest;
@@ -26,6 +27,8 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.ReadContext;
 
 public class RolesValidator extends AbstractConfigurationValidator {
+
+    private static final Salt SALT = new Salt(new byte[] {1,2,3,4,5,1,2,3,4,5,1,2,3,4,5,6});
 
 	public RolesValidator(final RestRequest request, boolean isSuperAdmin, final BytesReference ref, final Settings esSettings, Object... param) {
 		super(request, ref, esSettings, param);
@@ -70,7 +73,7 @@ public class RolesValidator extends AbstractConfigurationValidator {
 
     private boolean validateMaskedFieldSyntax(String mf) {
         try {
-            new MaskedField(mf, new byte[] {1,2,3,4,5,1,2,3,4,5,1,2,3,4,5,6}).isValid();
+            new MaskedField(mf, SALT).isValid();
         } catch (Exception e) {
             wrongDatatypes.put("Masked field not valid: "+mf, e.getMessage());
             return false;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/compliance/ComplianceConfigTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/compliance/ComplianceConfigTest.java
@@ -5,25 +5,17 @@ import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 
 import com.google.common.collect.ImmutableSet;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.settings.Settings;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertArrayEquals;
 
 public class ComplianceConfigTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testDefault() {
@@ -38,7 +30,6 @@ public class ComplianceConfigTest {
         assertFalse(complianceConfig.shouldLogReadMetadataOnly());
         assertFalse(complianceConfig.shouldLogWriteMetadataOnly());
         assertFalse(complianceConfig.shouldLogDiffsForWrite());
-        assertEquals(16, complianceConfig.getSalt16().length);
         assertEquals(defaultIgnoredUserMatcher, complianceConfig.getIgnoredComplianceUsersForReadMatcher());
         assertEquals(defaultIgnoredUserMatcher, complianceConfig.getIgnoredComplianceUsersForWriteMatcher());
     }
@@ -72,8 +63,6 @@ public class ComplianceConfigTest {
         assertTrue(complianceConfig.shouldLogReadMetadataOnly());
         assertTrue(complianceConfig.shouldLogWriteMetadataOnly());
         assertFalse(complianceConfig.shouldLogDiffsForWrite());
-        assertArrayEquals(testSalt.getBytes(StandardCharsets.UTF_8), complianceConfig.getSalt16());
-        assertEquals(16, complianceConfig.getSalt16().length);
         assertEquals(WildcardMatcher.from(ImmutableSet.of("test-user-1", "test-user-2")), complianceConfig.getIgnoredComplianceUsersForReadMatcher());
         assertEquals(WildcardMatcher.from(ImmutableSet.of("test-user-3", "test-user-4")), complianceConfig.getIgnoredComplianceUsersForWriteMatcher());
 
@@ -99,36 +88,6 @@ public class ComplianceConfigTest {
         assertTrue(complianceConfig.readHistoryEnabledForField("read_index_pattern_2", "field1"));
         assertFalse(complianceConfig.readHistoryEnabledForField("read_index_pattern_2", "field2"));
         assertTrue(complianceConfig.readHistoryEnabledForField("read_index_pattern_2", "field_pattern_1"));
-    }
-
-    @Test
-    public void testSaltThrowsExceptionWhenInsufficientBytesProvided() {
-        // assert
-        thrown.expect(ElasticsearchException.class);
-        thrown.expectMessage("Provided compliance salt abcd must at least contain 16 bytes");
-
-        // arrange
-        final String testSalt = "abcd";
-        final Settings settings = Settings.builder()
-                .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_SALT, testSalt)
-                .build();
-        // act
-        ComplianceConfig.from(settings);
-    }
-
-    @Test
-    public void testSaltUsesOnlyFirst16Bytes() {
-        // arrange
-        final String testSalt = "abcdefghijklmnopqrstuvwxyz";
-        final Settings settings = Settings.builder()
-                .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_SALT, testSalt)
-                .build();
-        // act
-        final ComplianceConfig complianceConfig = ComplianceConfig.from(settings);
-
-        // assert
-        assertEquals(16, complianceConfig.getSalt16().length);
-        assertArrayEquals(testSalt.substring(0, 16).getBytes(StandardCharsets.UTF_8), complianceConfig.getSalt16());
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/configuration/SaltTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/configuration/SaltTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.configuration;
+
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.nio.charset.StandardCharsets;
+
+import static com.amazon.opendistroforelasticsearch.security.configuration.Salt.SALT_SIZE;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class SaltTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testDefault() {
+        // act
+        final Salt salt = Salt.from(Settings.EMPTY);
+
+        // assert
+        assertEquals(SALT_SIZE, salt.getSalt16().length);
+        assertArrayEquals(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_SALT_DEFAULT.getBytes(StandardCharsets.UTF_8), salt.getSalt16());
+    }
+
+    @Test
+    public void testConfig() {
+        // arrange
+        final String testSalt = "abcdefghijklmnop";
+        final Settings settings = Settings.builder()
+                .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_SALT, testSalt)
+                .build();
+
+        // act
+        final Salt salt = Salt.from(settings);
+
+        // assert
+        assertArrayEquals(testSalt.getBytes(StandardCharsets.UTF_8), salt.getSalt16());
+        assertEquals(SALT_SIZE, salt.getSalt16().length);
+    }
+
+    @Test
+    public void testSaltUsesOnlyFirst16Bytes() {
+        // arrange
+        final String testSalt = "abcdefghijklmnopqrstuvwxyz";
+        final Settings settings = Settings.builder()
+                .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_SALT, testSalt)
+                .build();
+        // act
+        final Salt salt = Salt.from(settings);
+
+        // assert
+        assertEquals(SALT_SIZE, salt.getSalt16().length);
+        assertArrayEquals(testSalt.substring(0, SALT_SIZE).getBytes(StandardCharsets.UTF_8), salt.getSalt16());
+    }
+
+    @Test
+    public void testSaltThrowsExceptionWhenInsufficientBytesProvided() {
+        // assert
+        thrown.expect(ElasticsearchException.class);
+        thrown.expectMessage("Provided compliance salt abcd must at least contain 16 bytes");
+
+        // arrange
+        final String testSalt = "abcd";
+        final Settings settings = Settings.builder()
+                .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_SALT, testSalt)
+                .build();
+        // act
+        final Salt salt = Salt.from(settings);
+    }
+
+    @Test
+    public void testSaltThrowsExceptionWhenInsufficientBytesArrayProvided() {
+        // assert
+        thrown.expect(ElasticsearchException.class);
+        thrown.expectMessage("Provided compliance salt must contain 16 bytes");
+
+        // act
+        new Salt(new byte[]{1, 2, 3, 4, 5});
+    }
+
+    @Test
+    public void testSaltThrowsExceptionWhenExcessBytesArrayProvided() {
+        // assert
+        thrown.expect(ElasticsearchException.class);
+        thrown.expectMessage("Provided compliance salt must contain 16 bytes");
+
+        // act
+        new Salt(new byte[]{1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5});
+    }
+
+    @Test
+    public void testSaltThrowsNoExceptionWhenCorrectBytesArrayProvided() {
+        // act
+        new Salt(new byte[]{1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1});
+    }
+}


### PR DESCRIPTION
Changes:
- Removing salt from ComplianceConfig as it is not reloaded as part of it. Enabling/Disabling compliance for audit logging should not change the field anonymization behavior. 
- Refactored the salt usage into a separate FLS configuration class (inner class of DlsFlsConfig which could store other DlsFls configurations)
- Moved all the associated tests. 
- OpenDistroSecurityFlsDlsIndexSearcherWrapper was called per index, so the config had to be injected down from top level into DlsFlsFilterLeafReader (where its being used) to avoid being created everytime