### PR TITLE
Allow superadmin to add/update/delete hidden resources. Also added ki…

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -450,7 +450,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
                 handlers.add(new OpenDistroSecurityHealthAction(settings, restController, Objects.requireNonNull(backendRegistry)));
                 handlers.add(new OpenDistroSecuritySSLCertsInfoAction(settings, restController, odsks, Objects.requireNonNull(threadPool), Objects.requireNonNull(adminDns)));
                 handlers.add(new TenantInfoAction(settings, restController, Objects.requireNonNull(evaluator), Objects.requireNonNull(threadPool),
-				Objects.requireNonNull(cs), Objects.requireNonNull(adminDns)));
+				Objects.requireNonNull(cs), Objects.requireNonNull(adminDns), Objects.requireNonNull(cr)));
 
                 if (sslCertReloadEnabled) {
                     handlers.add(new OpenDistroSecuritySSLReloadCertsAction(settings, restController, odsks, Objects.requireNonNull(threadPool), Objects.requireNonNull(adminDns)));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
@@ -148,7 +148,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 
 		final SecurityDynamicConfiguration<?> existingConfiguration = load(getConfigName(), false);
 
-		if (isHidden(existingConfiguration, name)) {
+		if (!isHiddenAndAccessible(existingConfiguration, name)) {
 			notFound(channel, getResourceName() + " " + name + " not found.");
 			return;
 		}
@@ -191,7 +191,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 		    return;
 		}
 
-		if (isHidden(existingConfiguration, name)) {
+		if (!isHiddenAndAccessible(existingConfiguration, name)) {
 			forbidden(channel, "Resource '"+ name +"' is not available.");
 			return;
 		}
@@ -272,7 +272,9 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 	}
 
 	protected void filter(SecurityDynamicConfiguration<?> builder) {
-		builder.removeHidden();
+		if (!isSuperAdmin()){
+			builder.removeHidden();
+		}
 		builder.set_meta(null);
 	}
 
@@ -550,6 +552,14 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 	protected boolean isReservedAndAccessible(final SecurityDynamicConfiguration<?> existingConfiguration,
 											  String name) {
 		if( isReserved(existingConfiguration, name) && !isSuperAdmin()) {
+			return false;
+		}
+		return true;
+	}
+
+	protected boolean isHiddenAndAccessible(final SecurityDynamicConfiguration<?> existingConfiguration,
+											  String name) {
+		if( isHidden(existingConfiguration, name) && !isSuperAdmin()) {
 			return false;
 		}
 		return true;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
@@ -193,7 +193,7 @@ public class AccountApiAction extends AbstractApiAction {
             return;
         }
 
-        if (isHidden(internalUser, username)) {
+        if (!isHiddenAndAccessible(internalUser, username)) {
             forbidden(channel, "Resource '" + username + "' is not available.");
             return;
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -101,7 +101,7 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
 
         final SecurityDynamicConfiguration<?> configuration = load(getConfigName(), false);
 
-        if (isHidden(configuration, username)) {
+        if (!isHiddenAndAccessible(configuration, username)) {
             forbidden(channel, "Resource '" + username + "' is not available.");
             return;
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
@@ -106,7 +106,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
 
     private void handleSinglePatch(RestChannel channel, RestRequest request, Client client, String name,
             SecurityDynamicConfiguration<?> existingConfiguration, ObjectNode existingAsObjectNode, JsonNode jsonPatch) throws IOException {
-        if (isHidden(existingConfiguration, name)) {
+        if (!isHiddenAndAccessible(existingConfiguration, name)) {
             notFound(channel, getResourceName() + " " + name + " not found.");
             return;
         }
@@ -191,7 +191,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
                     return;
                 }
 
-                if (isHidden(existingConfiguration, resourceName)) {
+                if (!isHiddenAndAccessible(existingConfiguration, resourceName)) {
                     badRequestResponse(channel, "Resource name '" + resourceName + "' is reserved");
                     return;
                 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
@@ -462,6 +462,10 @@ public class PrivilegesEvaluator {
         return dcm.getKibanaServerUsername();
     }
 
+    public String kibanaOpendistroRole() {
+        return dcm.getKibanaOpendistroRole();
+    }
+
     private Set<String> evaluateAdditionalIndexPermissions(final ActionRequest request, final String originalAction) {
       //--- check inner bulk requests
         final Set<String> additionalPermissionsRequired = new HashSet<>();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModel.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModel.java
@@ -43,6 +43,7 @@ public abstract class DynamicConfigModel {
     public abstract boolean isInterTransportAuthDisabled();
     public abstract boolean isRespectRequestIndicesEnabled();
     public abstract String getKibanaServerUsername();
+    public abstract String getKibanaOpendistroRole();
     public abstract String getKibanaIndexname();
     public abstract boolean isKibanaMultitenancyEnabled();
     public abstract boolean isDnfofEnabled();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModelV6.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModelV6.java
@@ -114,6 +114,8 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
         return config.dynamic.kibana.server_username;
     }
     @Override
+    public String getKibanaOpendistroRole() { return config.dynamic.kibana.opendistro_role;}
+    @Override
     public String getKibanaIndexname() {
         return config.dynamic.kibana.index;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModelV7.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModelV7.java
@@ -114,6 +114,8 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
         return config.dynamic.kibana.server_username;
     }
     @Override
+    public String getKibanaOpendistroRole() { return config.dynamic.kibana.opendistro_role;}
+    @Override
     public String getKibanaIndexname() {
         return config.dynamic.kibana.index;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/RoleMappings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/RoleMappings.java
@@ -1,0 +1,12 @@
+package com.amazon.opendistroforelasticsearch.security.securityconf.impl;
+
+import java.util.Collections;
+import java.util.List;
+
+public abstract class RoleMappings {
+    protected List<String> hosts= Collections.emptyList();
+    protected java.util.List<String> users= Collections.emptyList();
+
+    public abstract List<String> getUsers();
+    public abstract List<String> getHosts();
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v6/ConfigV6.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v6/ConfigV6.java
@@ -53,12 +53,13 @@ public class ConfigV6 {
 
         public boolean multitenancy_enabled = true;
         public String server_username = "kibanaserver";
+        public String opendistro_role = "kibana_server";
         public String index = ".kibana";
         public boolean do_not_fail_on_forbidden;
         @Override
         public String toString() {
-            return "Kibana [multitenancy_enabled=" + multitenancy_enabled + ", server_username=" + server_username + ", index=" + index
-                    + ", do_not_fail_on_forbidden=" + do_not_fail_on_forbidden + "]";
+            return "Kibana [multitenancy_enabled=" + multitenancy_enabled + ", server_username=" + server_username + ", opendistro_role=" + opendistro_role
+                    + ", index=" + index + ", do_not_fail_on_forbidden=" + do_not_fail_on_forbidden + "]";
         }
         
         

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v6/RoleMappingsV6.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v6/RoleMappingsV6.java
@@ -3,17 +3,16 @@ package com.amazon.opendistroforelasticsearch.security.securityconf.impl.v6;
 import java.util.Collections;
 import java.util.List;
 
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.RoleMappings;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.amazon.opendistroforelasticsearch.security.securityconf.Hideable;
 
-public class RoleMappingsV6 implements Hideable {
+public class RoleMappingsV6 extends RoleMappings implements Hideable {
 
     private boolean readonly;
     private boolean hidden;
     private List<String> backendroles = Collections.emptyList();
-    private List<String> hosts= Collections.emptyList();
-    private List<String> users= Collections.emptyList();
     private List<String> andBackendroles= Collections.emptyList();
 
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v7/ConfigV7.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v7/ConfigV7.java
@@ -105,10 +105,12 @@ public class ConfigV7 {
 
         public boolean multitenancy_enabled = true;
         public String server_username = "kibanaserver";
+        public String opendistro_role = "kibana_server";
         public String index = ".kibana";
         @Override
         public String toString() {
-            return "Kibana [multitenancy_enabled=" + multitenancy_enabled + ", server_username=" + server_username + ", index=" + index + "]";
+            return "Kibana [multitenancy_enabled=" + multitenancy_enabled + ", server_username=" + server_username + ", opendistro_role=" + opendistro_role
+            + ", index=" + index + "]";
         }
         
         

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v7/RoleMappingsV7.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v7/RoleMappingsV7.java
@@ -4,15 +4,14 @@ import java.util.Collections;
 import java.util.List;
 
 import com.amazon.opendistroforelasticsearch.security.securityconf.Hideable;
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.RoleMappings;
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v6.RoleMappingsV6;
 
-public class RoleMappingsV7 implements Hideable {
+public class RoleMappingsV7 extends RoleMappings implements Hideable {
 
     private boolean reserved;
     private boolean hidden;
     private List<String> backend_roles = Collections.emptyList();
-    private List<String> hosts= Collections.emptyList();
-    private List<String> users= Collections.emptyList();
     private List<String> and_backend_roles= Collections.emptyList();
     private String description;
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/GetConfigurationApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/GetConfigurationApiTest.java
@@ -71,10 +71,12 @@ public class GetConfigurationApiTest extends AbstractRestApiUnitTest {
 
 		// action groups
 		response = rh.executeGetRequest("_opendistro/_security/api/actiongroups");
+		System.out.println("Palash_");
+		System.out.println(response);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
 		Assert.assertEquals(settings.getAsList("ALL.allowed_actions").get(0), "indices:*");
-		Assert.assertFalse(settings.hasValue("INTERNAL.allowed_actions"));
+		Assert.assertTrue(settings.hasValue("INTERNAL.allowed_actions"));
 		Assert.assertNull(settings.get("_opendistro_security_meta.type"));
 	}
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiTest.java
@@ -144,7 +144,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
         // hidden role
         response = rh.executeGetRequest("/_opendistro/_security/api/roles/opendistro_security_internal", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         // create index
         setupStarfleetIndex();
@@ -170,9 +170,9 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/opendistro_security_transport_client", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
-        // hidden role
+        // hidden role allowed for superadmin
         response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/opendistro_security_internal", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         // remove complete role mapping for opendistro_security_role_starfleet_captains
         response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/opendistro_security_role_starfleet_captains", new Header[0]);
@@ -232,10 +232,10 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
                 FileHelper.loadFile("restapi/roles_captains.json"), new Header[0]);
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
 
-        // put hidden role, must be forbidden
+        // put hidden role, must be forbidden, but allowed for super admin
         response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_internal",
                 FileHelper.loadFile("restapi/roles_captains.json"), new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
 
         // restore starfleet role
         response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_role_starfleet",
@@ -357,10 +357,10 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         response = rh.executePatchRequest("/_opendistro/_security/api/roles/opendistro_security_transport_client", "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
-        // PATCH hidden resource, must be not found
+        // PATCH hidden resource, must be not found, can be found for superadmin
         rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/roles/opendistro_security_internal", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         // PATCH value of hidden flag, must fail with validation error
         rh.sendAdminCertificate = true;
@@ -407,10 +407,10 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         response = rh.executePatchRequest("/_opendistro/_security/api/roles", "[{ \"op\": \"remove\", \"path\": \"/opendistro_security_transport_client\" }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
-        // PATCH hidden resource, must be bad request
+        // PATCH hidden resource, must be bad request, but allowed for superadmin
         rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/roles", "[{ \"op\": \"remove\", \"path\": \"/opendistro_security_internal\"}]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         // PATCH value of hidden flag, must fail with validation error
         rh.sendAdminCertificate = true;
@@ -460,8 +460,6 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
         HttpResponse response;
 
-        response = rh.executeGetRequest("_opendistro/_security/api/roles");
-
         // Delete read only roles
         response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/opendistro_security_transport_client" , new Header[0]);
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
@@ -477,6 +475,26 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         // Patch multiple read only roles
         response = rh.executePatchRequest("/_opendistro/_security/api/roles/", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_transport_client/description\", \"value\": \"foo\" }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // get hidden role
+        response = rh.executeGetRequest("_opendistro/_security/api/roles/opendistro_security_internal");
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+
+        // delete hidden role
+        response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/opendistro_security_internal" , new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+
+        // put hidden role
+        response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_internal", "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // Patch single hidden roles
+        response = rh.executePatchRequest("/_opendistro/_security/api/roles/opendistro_security_internal", "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+
+        // Patch multiple hidden roles
+        response = rh.executePatchRequest("/_opendistro/_security/api/roles/", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_internal/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/TenantInfoActionTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/TenantInfoActionTest.java
@@ -1,0 +1,55 @@
+package com.amazon.opendistroforelasticsearch.security.dlic.rest.api;
+
+import com.amazon.opendistroforelasticsearch.security.privileges.PrivilegesEvaluator;
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import com.amazon.opendistroforelasticsearch.security.test.helper.file.FileHelper;
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper;
+import org.apache.http.Header;
+import org.apache.http.HttpStatus;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class TenantInfoActionTest extends AbstractRestApiUnitTest {
+    private String payload = "{\"hosts\":[],\"users\":[\"sarek\"]," +
+            "\"backend_roles\":[\"starfleet*\",\"ambassador\"],\"and_backend_roles\":[],\"description\":\"Migrated " +
+            "from v6\"}";
+
+    @Test
+    public void testAllRolesNotContainMetaHeader() throws Exception {
+        Settings settings = Settings.builder().put(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, true).build();
+        setup(settings);
+
+        rh.keystore = "restapi/kirk-keystore.jks";
+        rh.sendAdminCertificate = true;
+        RestHelper.HttpResponse response = rh.executeGetRequest("_opendistro/_security/tenantinfo");
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        rh.sendAdminCertificate = false;
+        response = rh.executeGetRequest("_opendistro/_security/tenantinfo");
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
+
+        rh.sendHTTPClientCredentials = true;
+        response = rh.executeGetRequest("_opendistro/_security/tenantinfo");
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        rh.sendAdminCertificate = true;
+
+        //update security config
+        response = rh.executePatchRequest("/_opendistro/_security/api/securityconfig", "[{\"op\": \"replace\",\"path\": \"/config/dynamic/kibana/opendistro_role\",\"value\": \"opendistro_security_role_internal\"}]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executePutRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_internal", payload, new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeGetRequest("_opendistro/_security/api/rolesmapping/opendistro_security_role_internal");
+
+        rh.sendAdminCertificate = false;
+        response = rh.executeGetRequest("_opendistro/_security/tenantinfo");
+
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+    }
+}


### PR DESCRIPTION
*Description of changes:*
1. Allow superadmin to add/update/delete hidden resources.
2. Super admin can see hidden resource such as roles, rolesmapping, internalusers
3. Added kibana attribute to security config
`"kibana" : {
        "multitenancy_enabled" : true,
        "server_username" : "AmazonESKibanaServerUser",
        "opendistro_role" : "kibana_server",
        "index" : ".kibana"
      },`
4. tenantinfo check based on "opendistro_role"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
