### PR TITLE
Added kibana attribute to security config which will be used by tenan…

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -437,7 +437,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
                 handlers.add(new OpenDistroSecurityHealthAction(settings, restController, Objects.requireNonNull(backendRegistry)));
                 handlers.add(new OpenDistroSecuritySSLCertsInfoAction(settings, restController, odsks, Objects.requireNonNull(threadPool), Objects.requireNonNull(adminDns)));
                 handlers.add(new TenantInfoAction(settings, restController, Objects.requireNonNull(evaluator), Objects.requireNonNull(threadPool),
-				Objects.requireNonNull(cs), Objects.requireNonNull(adminDns)));
+				Objects.requireNonNull(cs), Objects.requireNonNull(adminDns), Objects.requireNonNull(cr)));
 
                 if (sslCertReloadEnabled) {
                     handlers.add(new OpenDistroSecuritySSLReloadCertsAction(settings, restController, odsks, Objects.requireNonNull(threadPool), Objects.requireNonNull(adminDns)));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
@@ -466,6 +466,10 @@ public class PrivilegesEvaluator {
         return dcm.getKibanaServerUsername();
     }
 
+    public String kibanaOpendistroRole() {
+        return dcm.getKibanaOpendistroRole();
+    }
+
     private Set<String> evaluateAdditionalIndexPermissions(final ActionRequest request, final String originalAction) {
       //--- check inner bulk requests
         final Set<String> additionalPermissionsRequired = new HashSet<>();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModel.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModel.java
@@ -43,6 +43,7 @@ public abstract class DynamicConfigModel {
     public abstract boolean isInterTransportAuthDisabled();
     public abstract boolean isRespectRequestIndicesEnabled();
     public abstract String getKibanaServerUsername();
+    public abstract String getKibanaOpendistroRole();
     public abstract String getKibanaIndexname();
     public abstract boolean isKibanaMultitenancyEnabled();
     public abstract boolean isDnfofEnabled();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModelV6.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModelV6.java
@@ -114,6 +114,10 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
         return config.dynamic.kibana.server_username;
     }
     @Override
+    public String getKibanaOpendistroRole() {
+        return config.dynamic.kibana.opendistro_role;
+    }
+    @Override
     public String getKibanaIndexname() {
         return config.dynamic.kibana.index;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModelV7.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModelV7.java
@@ -114,6 +114,10 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
         return config.dynamic.kibana.server_username;
     }
     @Override
+    public String getKibanaOpendistroRole() {
+        return config.dynamic.kibana.opendistro_role;
+    }
+    @Override
     public String getKibanaIndexname() {
         return config.dynamic.kibana.index;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/RoleMappings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/RoleMappings.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.securityconf;
+
+import java.util.Collections;
+import java.util.List;
+
+public class RoleMappings {
+
+    private List<String> hosts= Collections.emptyList();
+    private List<String> users= Collections.emptyList();
+
+    public void setHosts(List<String> hosts) {
+        this.hosts = hosts;
+    }
+
+    public List<String> getHosts() {
+        return hosts;
+    }
+
+    public void setUsers(List<String> users) {
+        this.users = users;
+    }
+
+    public List<String> getUsers() {
+        return users;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v6/ConfigV6.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v6/ConfigV6.java
@@ -53,12 +53,13 @@ public class ConfigV6 {
 
         public boolean multitenancy_enabled = true;
         public String server_username = "kibanaserver";
+        public String opendistro_role = "";
         public String index = ".kibana";
         public boolean do_not_fail_on_forbidden;
         @Override
         public String toString() {
-            return "Kibana [multitenancy_enabled=" + multitenancy_enabled + ", server_username=" + server_username + ", index=" + index
-                    + ", do_not_fail_on_forbidden=" + do_not_fail_on_forbidden + "]";
+            return "Kibana [multitenancy_enabled=" + multitenancy_enabled + ", server_username=" + server_username + ", opendistro_role=" + opendistro_role
+                    + ", index=" + index + ", do_not_fail_on_forbidden=" + do_not_fail_on_forbidden + "]";
         }
         
         

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v6/RoleMappingsV6.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v6/RoleMappingsV6.java
@@ -3,17 +3,16 @@ package com.amazon.opendistroforelasticsearch.security.securityconf.impl.v6;
 import java.util.Collections;
 import java.util.List;
 
+import com.amazon.opendistroforelasticsearch.security.securityconf.RoleMappings;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.amazon.opendistroforelasticsearch.security.securityconf.Hideable;
 
-public class RoleMappingsV6 implements Hideable {
+public class RoleMappingsV6 extends RoleMappings implements Hideable {
 
     private boolean readonly;
     private boolean hidden;
     private List<String> backendroles = Collections.emptyList();
-    private List<String> hosts= Collections.emptyList();
-    private List<String> users= Collections.emptyList();
     private List<String> andBackendroles= Collections.emptyList();
 
 
@@ -41,18 +40,6 @@ public class RoleMappingsV6 implements Hideable {
     public void setBackendroles(List<String> backendroles) {
         this.backendroles = backendroles;
     }
-    public List<String> getHosts() {
-        return hosts;
-    }
-    public void setHosts(List<String> hosts) {
-        this.hosts = hosts;
-    }
-    public List<String> getUsers() {
-        return users;
-    }
-    public void setUsers(List<String> users) {
-        this.users = users;
-    }
 
     @JsonProperty(value="and_backendroles")
     public List<String> getAndBackendroles() {
@@ -64,8 +51,8 @@ public class RoleMappingsV6 implements Hideable {
 
     @Override
     public String toString() {
-        return "RoleMappings [readonly=" + readonly + ", hidden=" + hidden + ", backendroles=" + backendroles + ", hosts=" + hosts + ", users="
-                + users + ", andBackendroles=" + andBackendroles + "]";
+        return "RoleMappings [readonly=" + readonly + ", hidden=" + hidden + ", backendroles=" + backendroles + ", hosts=" + getHosts() + ", users="
+                + getUsers() + ", andBackendroles=" + andBackendroles + "]";
     }
     
     @JsonIgnore

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v7/ConfigV7.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v7/ConfigV7.java
@@ -105,10 +105,12 @@ public class ConfigV7 {
 
         public boolean multitenancy_enabled = true;
         public String server_username = "kibanaserver";
+        public String opendistro_role = "";
         public String index = ".kibana";
         @Override
         public String toString() {
-            return "Kibana [multitenancy_enabled=" + multitenancy_enabled + ", server_username=" + server_username + ", index=" + index + "]";
+            return "Kibana [multitenancy_enabled=" + multitenancy_enabled + ", server_username=" + server_username + ", opendistro_role=" + opendistro_role
+            + ", index=" + index + "]";
         }
         
         

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v7/RoleMappingsV7.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v7/RoleMappingsV7.java
@@ -4,15 +4,14 @@ import java.util.Collections;
 import java.util.List;
 
 import com.amazon.opendistroforelasticsearch.security.securityconf.Hideable;
+import com.amazon.opendistroforelasticsearch.security.securityconf.RoleMappings;
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v6.RoleMappingsV6;
 
-public class RoleMappingsV7 implements Hideable {
+public class RoleMappingsV7 extends RoleMappings implements Hideable {
 
     private boolean reserved;
     private boolean hidden;
     private List<String> backend_roles = Collections.emptyList();
-    private List<String> hosts= Collections.emptyList();
-    private List<String> users= Collections.emptyList();
     private List<String> and_backend_roles= Collections.emptyList();
     private String description;
 
@@ -25,10 +24,10 @@ public class RoleMappingsV7 implements Hideable {
         this.reserved = roleMappingsV6.isReserved();
         this.hidden = roleMappingsV6.isHidden();
         this.backend_roles = roleMappingsV6.getBackendroles();
-        this.hosts = roleMappingsV6.getHosts();
-        this.users = roleMappingsV6.getUsers();
         this.and_backend_roles = roleMappingsV6.getAndBackendroles();
         this.description = "Migrated from v6";
+        setHosts(roleMappingsV6.getHosts());
+        setUsers(roleMappingsV6.getUsers());
     }
 
     public boolean isReserved() {
@@ -67,30 +66,6 @@ public class RoleMappingsV7 implements Hideable {
 
 
 
-    public List<String> getHosts() {
-        return hosts;
-    }
-
-
-
-    public void setHosts(List<String> hosts) {
-        this.hosts = hosts;
-    }
-
-
-
-    public List<String> getUsers() {
-        return users;
-    }
-
-
-
-    public void setUsers(List<String> users) {
-        this.users = users;
-    }
-
-
-
     public List<String> getAnd_backend_roles() {
         return and_backend_roles;
     }
@@ -117,8 +92,8 @@ public class RoleMappingsV7 implements Hideable {
 
     @Override
     public String toString() {
-        return "RoleMappingsV7 [reserved=" + reserved + ", hidden=" + hidden + ", backend_roles=" + backend_roles + ", hosts=" + hosts + ", users="
-                + users + ", and_backend_roles=" + and_backend_roles + ", description=" + description + "]";
+        return "RoleMappingsV7 [reserved=" + reserved + ", hidden=" + hidden + ", backend_roles=" + backend_roles + ", hosts=" + getHosts() + ", users="
+                + getUsers() + ", and_backend_roles=" + and_backend_roles + ", description=" + description + "]";
     }
 
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/TenantInfoActionTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/TenantInfoActionTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.dlic.rest.api;
+
+import com.amazon.opendistroforelasticsearch.security.privileges.PrivilegesEvaluator;
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import com.amazon.opendistroforelasticsearch.security.test.helper.file.FileHelper;
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper;
+import org.apache.http.Header;
+import org.apache.http.HttpStatus;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class TenantInfoActionTest extends AbstractRestApiUnitTest {
+    private String payload = "{\"hosts\":[],\"users\":[\"sarek\"]," +
+            "\"backend_roles\":[\"starfleet*\",\"ambassador\"],\"and_backend_roles\":[],\"description\":\"Migrated " +
+            "from v6\"}";
+
+    @Test
+    public void testTenantInfoAPI() throws Exception {
+        Settings settings = Settings.builder().put(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, true).build();
+        setup(settings);
+
+        rh.keystore = "restapi/kirk-keystore.jks";
+        rh.sendAdminCertificate = true;
+        RestHelper.HttpResponse response = rh.executeGetRequest("_opendistro/_security/tenantinfo");
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        rh.sendAdminCertificate = false;
+        response = rh.executeGetRequest("_opendistro/_security/tenantinfo");
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
+
+        rh.sendHTTPClientCredentials = true;
+        response = rh.executeGetRequest("_opendistro/_security/tenantinfo");
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        rh.sendAdminCertificate = true;
+
+        //update security config
+        response = rh.executePatchRequest("/_opendistro/_security/api/securityconfig", "[{\"op\": \"add\",\"path\": \"/config/dynamic/kibana/opendistro_role\",\"value\": \"opendistro_security_role_internal\"}]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executePutRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_internal", payload, new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        rh.sendAdminCertificate = false;
+
+        response = rh.executeGetRequest("_opendistro/_security/tenantinfo");
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+    }
+}


### PR DESCRIPTION
*Description of changes:*
1. Added attribute in kibana security config, required for external kibana.
2. The failed test depend on - https://github.com/opendistro-for-elasticsearch/security/pull/514

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
