### PR TITLE
Fix index exists API

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/ConfigurationRepository.java
@@ -52,6 +52,8 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -213,13 +215,21 @@ public class ConfigurationRepository {
 
     }
 
+    private boolean indexExists(final String index) {
+        final GetIndexResponse getIndexResponse = client.admin().indices()
+                .prepareGetIndex().setIndices(index)
+                .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+                .execute().actionGet();
+        return getIndexResponse.getIndices().length > 0;
+    }
+
     public void initOnNodeStart() {
 
         LOGGER.info("Check if " + opendistrosecurityIndex + " index exists ...");
 
         try {
 
-            if (clusterService.state().metaData().hasConcreteIndex(opendistrosecurityIndex)) {
+            if (indexExists(opendistrosecurityIndex)) {
                 LOGGER.info("{} index does already exist, so we try to load the config from it", opendistrosecurityIndex);
                 bgThread.start();
             } else {


### PR DESCRIPTION
*Description of changes:*

- Current check `clusterService.state().metaData().hasConcreteIndex` maintains cached copy of cluster state because of which when the plugin boots up, it returns false for an index that exists. 

- To reproduce run the plugin. You will see 
`.opendistro_security index does already exist, so we try to load the config from it` printed every time implying the check is failing

- Using admin client to perform https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-indices-exists.html which queries the cluster. 

- Indices Option is `lenientExpandOpen` . Not considering 
  - closed (as .opendistro_security index cannot be closed)
  - hidden (as this parameter is set during index creation in plugin and is not set)

- There is only other place the same check is used [here](https://github.com/opendistro-for-elasticsearch/security/blob/master/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java#L268) but the cluster state is likely to be updated there and will be faster to query
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
