### PR TITLE
Add new permissions for Kibana 7.8

### DIFF
--- a/src/main/resources/static_config/static_roles.yml
+++ b/src/main/resources/static_config/static_roles.yml
@@ -87,6 +87,14 @@ kibana_server:
   - "indices:data/read/scroll*"
   index_permissions:
   - index_patterns:
+    - ".apm-custom-link"
+    allowed_actions:
+    - "indices_all"
+  - index_patterns:
+    - ".apm-agent-configuration"
+    allowed_actions:
+    - "indices_all"
+  - index_patterns:
     - ".kibana"
     allowed_actions:
     - "indices_all"


### PR DESCRIPTION
*Description of changes:*

New indices introduced in Kibana 7.8 are missing permissions in the default configuration causing exceptions to be logged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
