### PR TITLE
Fix: Make sure Internal users API supports adding reserved opendistrosecurityroles (by superuser). Do not filter out reserved roles in the InternalUsersModelV7

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
@@ -25,14 +25,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext.StoredContext;
@@ -153,7 +151,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 			return;
 		}
 
-		if (!isReservedAndAccessible(existingConfiguration, name)) {
+		if (isReadOnly(existingConfiguration, name)) {
 			forbidden(channel, "Resource '"+ name +"' is read-only.");
 			return;
 		}
@@ -196,7 +194,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 			return;
 		}
 
-		if (!isReservedAndAccessible(existingConfiguration, name)) {
+		if (isReadOnly(existingConfiguration, name)) {
 			forbidden(channel, "Resource '"+ name +"' is read-only.");
 			return;
 		}
@@ -548,12 +546,15 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 		return adminDNs.isAdmin(user);
 	}
 
-	protected boolean isReservedAndAccessible(final SecurityDynamicConfiguration<?> existingConfiguration,
-											  String name) {
-		if( isReserved(existingConfiguration, name) && !isSuperAdmin()) {
-			return false;
-		}
-		return true;
+	/**
+	 * Resource is readonly if it is reserved and user is not super admin.
+	 * @param existingConfiguration Configuration
+	 * @param name
+	 * @return True if resource readonly
+	 */
+	protected boolean isReadOnly(final SecurityDynamicConfiguration<?> existingConfiguration,
+								 String name) {
+		return isSuperAdmin() ? false: isReserved(existingConfiguration, name);
 	}
 
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
@@ -198,7 +198,7 @@ public class AccountApiAction extends AbstractApiAction {
             return;
         }
 
-        if (isReserved(internalUser, username)) {
+        if (isReadOnly(internalUser, username)) {
             forbidden(channel, "Resource '" + username + "' is read-only.");
             return;
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -107,7 +107,7 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
         }
 
         // check if resource is writeable
-        if (!isReservedAndAccessible(internalUsersConfiguration, username)) {
+        if (isReadOnly(internalUsersConfiguration, username)) {
             forbidden(channel, "Resource '" + username + "' is read-only.");
             return;
         }
@@ -126,8 +126,8 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
                     return;
                 }
 
-                if (isReserved(rolesConfiguration, role)) {
-                    forbidden(channel, "Role '" + role + "' is reserved.");
+                if (isReadOnly(rolesConfiguration, role)) {
+                    forbidden(channel, "Role '" + role + "' is read-only.");
                     return;
                 }
             }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/NodesDnApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/NodesDnApiAction.java
@@ -101,11 +101,11 @@ public class NodesDnApiAction extends PatchableResourceApiAction {
     }
 
     @Override
-    protected boolean isReservedAndAccessible(SecurityDynamicConfiguration<?> existingConfiguration, String name) {
+    protected boolean isReadOnly(SecurityDynamicConfiguration<?> existingConfiguration, String name) {
         if (STATIC_ES_YML_NODES_DN.equals(name)) {
             return false;
         }
-        return super.isReservedAndAccessible(existingConfiguration, name);
+        return super.isReadOnly(existingConfiguration, name);
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
@@ -111,7 +111,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
             return;
         }
 
-        if (!isReservedAndAccessible(existingConfiguration, name)) {
+        if (isReadOnly(existingConfiguration, name)) {
             forbidden(channel, "Resource '" + name + "' is read-only.");
             return;
         }
@@ -186,7 +186,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
 
             if (oldResource != null && !oldResource.equals(patchedResource)) {
 
-                if (!isReservedAndAccessible(existingConfiguration, resourceName)) {
+                if (isReadOnly(existingConfiguration, resourceName)) {
                     forbidden(channel, "Resource '" + resourceName + "' is read-only.");
                     return;
                 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigFactory.java
@@ -300,15 +300,15 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
         public List<String> getOpenDistroSecurityRoles(String user) {
             InternalUserV7 tmp = internalUserV7SecurityDynamicConfiguration.getCEntry(user);
 
-            // Filtering out hidden and reserved roles for existing users
+            // Filtering out hidden and non-existent roles for existing users
             return tmp == null ? ImmutableList.of() :
-                tmp.getOpendistro_security_roles().stream().filter(role -> !isHiddenReservedOrNonExistent(role)).collect(ImmutableList.toImmutableList());
+                tmp.getOpendistro_security_roles().stream().filter(role -> !isHiddenOrNonExistent(role)).collect(ImmutableList.toImmutableList());
         }
 
-        // We will remove opendistro security mapping for roles that are hidden/reserved or non-existent in the roles configuration
-        private boolean isHiddenReservedOrNonExistent(String rolename) {
+        // We will remove opendistro security mapping for roles that are hidden or non-existent in the roles configuration
+        private boolean isHiddenOrNonExistent(String rolename) {
             final RoleV7 role = roleV7SecurityDynamicConfiguration.getCEntry(rolename);
-            return role == null || role.isHidden() || role.isReserved();
+            return role == null || role.isHidden();
         }
     }
     

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/OpendistroSecurityRolesTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/OpendistroSecurityRolesTests.java
@@ -73,6 +73,7 @@ public class OpendistroSecurityRolesTests extends SingleClusterTest {
 				.setSecurityInternalUsers("internal_users_sr.yml"), Settings.EMPTY, true);
 
 		RestHelper rh = nonSslRestHelper();
+		rh.sendAdminCertificate = false;
 
 		HttpResponse resc = rh.executeGetRequest("_opendistro/_security/authinfo?pretty", encodeBasicHeader("sr_user", "nagilum"));
 		Assert.assertTrue(resc.getBody().contains("sr_user"));
@@ -81,7 +82,7 @@ public class OpendistroSecurityRolesTests extends SingleClusterTest {
 		// Ensure hidden reserved and non-existent roles are not available
 		Assert.assertFalse(resc.getBody().contains("xyz_sr_non_existent"));
 		Assert.assertFalse(resc.getBody().contains("xyz_sr_hidden"));
-		Assert.assertFalse(resc.getBody().contains("xyz_sr_reserved"));
+		Assert.assertTrue(resc.getBody().contains("xyz_sr_reserved"));
 
 		Assert.assertTrue(resc.getBody().contains("backend_roles=[abc_ber]"));
 		Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());

--- a/src/test/resources/restapi/roles.yml
+++ b/src/test/resources/restapi/roles.yml
@@ -48,6 +48,7 @@ opendistro_security_reserved:
       masked_fields: null
       allowed_actions:
         - "ALL"
+
 opendistro_security_internal:
   reserved: false
   hidden: true


### PR DESCRIPTION
*Issue #, if available:*
Related to issue https://github.com/opendistro-for-elasticsearch/security/issues/555

*Description of changes:*


PR https://github.com/opendistro-for-elasticsearch/security/pull/486 added extra validation in the internal users API for opendistro_security_roles. This validation was to ensure that users cannot add hidden roles to opendistro_security_roles. However, this PR incorrectly forbade users from adding reserved roles and incorrectly filtered out the reserved roles.

This PR **will allow superadmin users to add reserved roles** to opendistro_security_roles via the internal users API. 

This is the same check done by the rolesmapping API while associating a user with a role - (See https://github.com/opendistro-for-elasticsearch/security/blob/6fde7a28e9c0945613b9b91ba84976a4616d1266/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java#L194-L202 (RolesMappingApiAction is a extension of AbstractApiAction)).





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
