### PR TITLE
Removing hidden/reserved roles added via rolesmapping

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -115,18 +115,24 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
         final ObjectNode contentAsNode = (ObjectNode) content;
         final SecurityJsonNode securityJsonNode = new SecurityJsonNode(contentAsNode);
 
-        // Don't allow user to add hidden, reserved or non-existent role
+        // Don't allow user to add hidden, reserved or non-existent rolesmapping
         final List<String> opendistroSecurityRoles = securityJsonNode.get("opendistro_security_roles").asList();
         if (opendistroSecurityRoles != null) {
             final SecurityDynamicConfiguration<?> rolesConfiguration = load(CType.ROLES, false);
+            final SecurityDynamicConfiguration<?> rolesmappingConfiguration = load(CType.ROLESMAPPING, false);
             for (final String role: opendistroSecurityRoles) {
 
-                if (!rolesConfiguration.exists(role) || rolesConfiguration.isHidden(role)) {
-                    notFound(channel, "Role '"+role+"' is not found.");
+                if (rolesConfiguration.getCEntry(role) == null) {
+                    notFound(channel, "Role '"+role+"' is not available.");
                     return;
                 }
 
-                if (isReadOnly(rolesConfiguration, role)) {
+                if (rolesmappingConfiguration.isHidden(role)) {
+                    notFound(channel, "Role '"+role+"' is not available.");
+                    return;
+                }
+
+                if (isReadOnly(rolesmappingConfiguration, role)) {
                     forbidden(channel, "Role '" + role + "' is read-only.");
                     return;
                 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/OpendistroSecurityRolesTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/OpendistroSecurityRolesTests.java
@@ -70,6 +70,7 @@ public class OpendistroSecurityRolesTests extends SingleClusterTest {
 	public void testOpenDistroSecurityRoles() throws Exception {
 
 		setup(Settings.EMPTY, new DynamicSecurityConfig()
+				.setSecurityRolesMapping("roles_mapping.yml")
 				.setSecurityInternalUsers("internal_users_sr.yml"), Settings.EMPTY, true);
 
 		RestHelper rh = nonSslRestHelper();
@@ -79,10 +80,14 @@ public class OpendistroSecurityRolesTests extends SingleClusterTest {
 		Assert.assertTrue(resc.getBody().contains("sr_user"));
 		Assert.assertTrue(resc.getBody().contains("xyz_sr"));
 
-		// Ensure hidden reserved and non-existent roles are not available
+		// Opendistro_security_roles cannot contain roles that don't exist.
 		Assert.assertFalse(resc.getBody().contains("xyz_sr_non_existent"));
-		Assert.assertFalse(resc.getBody().contains("xyz_sr_hidden"));
+
+		// Opendistro_security_roles can contain reserved roles.
 		Assert.assertTrue(resc.getBody().contains("xyz_sr_reserved"));
+
+		// Opendistro_security_roles cannot contain roles that are hidden in rolesmapping.yml.
+		Assert.assertFalse(resc.getBody().contains("xyz_sr_hidden"));
 
 		Assert.assertTrue(resc.getBody().contains("backend_roles=[abc_ber]"));
 		Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
@@ -121,14 +121,14 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         Assert.assertTrue(response.getBody().contains("\"hidden\":true"));
 
-        // Associating with hidden role is not allowed
+        // Associating with hidden rolemapping is not allowed
         response = rh.executePutRequest("/_opendistro/_security/api/internalusers/nagilum", "{ \"opendistro_security_roles\": [\"opendistro_security_hidden\"]}",
             new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals(settings.get("message"), "Role 'opendistro_security_hidden' is not found.");
+        Assert.assertEquals(settings.get("message"), "Role 'opendistro_security_hidden' is not available.");
 
-        // Associating with reserved role is allowed (for superamdin)
+        // Associating with reserved role is allowed (for superadmin)
         response = rh.executePutRequest("/_opendistro/_security/api/internalusers/test", "{ \"opendistro_security_roles\": [\"opendistro_security_reserved\"], " +
                 "\"hash\": \"123\"}",
             new Header[0]);
@@ -139,7 +139,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
             new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals(settings.get("message"), "Role 'non_existent' is not found.");
+        Assert.assertEquals(settings.get("message"), "Role 'non_existent' is not available.");
 
         // Wrong config keys
         response = rh.executePutRequest("/_opendistro/_security/api/internalusers/nagilum", "{\"some\": \"thing\", \"other\": \"thing\"}",

--- a/src/test/resources/restapi/roles_mapping.yml
+++ b/src/test/resources/restapi/roles_mapping.yml
@@ -11,6 +11,27 @@ opendistro_security_unittest_1:
   - "CN=spock,OU=client,O=client,L=Test,C=DE"
   and_backend_roles: []
   description: "Migrated from v6"
+
+opendistro_security_hidden:
+  reserved: false
+  hidden: true
+  backend_roles:
+  - "hidden*"
+  hosts: []
+  users: []
+  and_backend_roles: []
+  description: "Migrated from v6"
+
+opendistro_security_reserved:
+  reserved: true
+  hidden: false
+  backend_roles:
+  - "reserved*"
+  hosts: []
+  users: ["nagilum"]
+  and_backend_roles: []
+  description: "Migrated from v6"
+
 opendistro_security_role_starfleet_library:
   reserved: true
   hidden: false

--- a/src/test/resources/roles.yml
+++ b/src/test/resources/roles.yml
@@ -1049,9 +1049,10 @@ xyz_sr:
         - "*"
   tenant_permissions: []
 
+# This role is hidden in rolesmapping
 xyz_sr_hidden:
   reserved: false
-  hidden: true
+  hidden: false
   description: "Migrated from v6 (all types mapped)"
   cluster_permissions:
     - "OPENDISTRO_SECURITY_CLUSTER_COMPOSITE_OPS_RO"

--- a/src/test/resources/roles_mapping.yml
+++ b/src/test/resources/roles_mapping.yml
@@ -376,4 +376,12 @@ role_foo_index:
 role_foo_all:
   users:
     - foo_all
-
+xyz_sr_hidden:
+  reserved: false
+  hidden: true
+  backend_roles: []
+  hosts: []
+  users:
+    - "test_user"
+  and_backend_roles: []
+  description: "Migrated from v6"


### PR DESCRIPTION
Earlier the InternalUsers API was filtering out all hidden/reserved roles. 
We will just restrict it to hidden/reserved roles associated via rolesmapping. This will ensure behaviour of rolesmapping and internalusers API is the same.

*Issue #, if available:*

*Description of changes:*

Tested via unit tests and manually with opendistro-1.9.0.0 - 


RolesMapping API

* Add a new user
curl -XPUT -H "Content-type: application/json"  --cacert root-ca.pem --key kirk-key.pem --cert kirk.pem -d "{ \"password\": \”XXXX\"}" https://localhost:9200/_opendistro/_security/api/internalusers/testuser

* Associate with reserved rolesmapping - super admin (should pass)
| => curl -XPUT -H "Content-type: application/json"  --cacert root-ca.pem --key kirk-key.pem --cert kirk.pem -d "{ \"users\": [\"kibanaserver\", \"testuser\"], "\reserved\": true}" https://localhost:9200/_opendistro/_security/api/rolesmapping/kibana_server
{"status":"OK","message":"'kibana_server' updated."}

* Associate with reserved rolesmapping - non-super admin (should fail)
| => 
curl -XPUT -H "Content-type: application/json" -k -u admin:admin --cacert root-ca.pem -d "{ \"users\": [\"kibanaserver\", \"testuser\"]}" https://localhost:9200/_opendistro/_security/api/rolesmapping/kibana_server --key esnode-key.pem --cert esnode.pem

{"status":"FORBIDDEN","message":"Resource 'kibana_server' is read-only."}____________________________________________________




InternalUsers API

curl -k -XPUT --cacert root-ca.pem --key esnode-key.pem --cert esnode.pem -u admin:admin https://localhost:9200/_opendistro/_security/api/internalusers/testuser  -d "{ \"password\": \"XXXXX\"}" -H "Content-type: application/json" 

* Associate with reserved rolesmapping - non-super admin (should fail)
curl -k -XPUT --cacert root-ca.pem --key esnode-key.pem --cert esnode.pem -u admin:admin https://localhost:9200/_opendistro/_security/api/internalusers/testuser  -d "{ \"password\": \"XXXXX\", \"opendistro_security_roles\": [\"kibana_server\"]}" -H "Content-type: application/json" 

{"status":"FORBIDDEN","message":"Role 'kibana_server' is read-only."}_______________________________________________________________



* Associate with reserved rolesmapping (superadmin) - pass 

curl -k -XPUT --cacert root-ca.pem --key kirk-key.pem --cert kirk.pem -u admin:admin https://localhost:9200/_opendistro/_security/api/internalusers/testuser  -d "{ \"password\": \"XXXXX\", \"opendistro_security_roles\": [\"kibana_server\"]}" -H "Content-type: application/json" 
{"status":"OK","message":"'kibana_server' updated."}




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
