### PR TITLE
Add default private constructor for Jackson to work with older versions

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/config/AuditConfig.java
@@ -70,6 +70,7 @@ public class AuditConfig {
     public static final List<String> DEFAULT_IGNORED_USERS = Collections.singletonList("kibanaserver");
     private static Set<String> FIELDS = DefaultObjectMapper.getFields(AuditConfig.class);
 
+    // Needed by Jackson
     private AuditConfig() {
         this(true, null, null);
     }
@@ -130,6 +131,11 @@ public class AuditConfig {
         private final WildcardMatcher ignoredAuditRequestsMatcher;
         private final Set<AuditCategory> disabledRestCategories;
         private final Set<AuditCategory> disabledTransportCategories;
+
+        // Needed by Jackson
+        private Filter() {
+            this(true, true, false, true, true, true, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
+        }
 
         @VisibleForTesting
         Filter(final boolean isRestApiAuditEnabled,

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/compliance/ComplianceConfig.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/compliance/ComplianceConfig.java
@@ -106,6 +106,11 @@ public class ComplianceConfig {
     private final String auditLogIndex;
     private final boolean enabled;
 
+    // Needed by Jackson
+    private ComplianceConfig() {
+        this(true, false, false, false, Collections.emptyMap(), Collections.emptySet(), false, false, Collections.emptyList(), Collections.emptySet(), Settings.EMPTY);
+    }
+
     private ComplianceConfig(
             final boolean enabled,
             final boolean logExternalConfig,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Older jackson versions (eg: 2.6.x) need default constructor (even if private) to correctly deserialize object.
- Doesnt matter even if fields are private and final and what default values are. Jackson replaces them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
