### PR TITLE
Log granted privileges on REST layer if has access to opendistro APIs

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/AuditLog.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/AuditLog.java
@@ -58,6 +58,7 @@ public interface AuditLog extends Closeable {
 
     //privs
     void logMissingPrivileges(String privilege, String effectiveUser, RestRequest request);
+    void logGrantedPrivileges(String effectiveUser, RestRequest request);
     void logMissingPrivileges(String privilege, TransportRequest request, Task task);
     void logGrantedPrivileges(String privilege, TransportRequest request, Task task);
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/NullAuditLog.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/NullAuditLog.java
@@ -121,6 +121,11 @@ public class NullAuditLog implements AuditLog {
     }
 
     @Override
+    public void logGrantedPrivileges(String effectiveUser, RestRequest request) {
+        //noop, intentionally left empty
+    }
+
+    @Override
     public void logDocumentRead(String index, String id, ShardId shardId, Map<String, String> fieldNameValues) {
         //noop, intentionally left empty
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AbstractAuditLog.java
@@ -215,6 +215,19 @@ public abstract class AbstractAuditLog implements AuditLog {
     }
 
     @Override
+    public void logGrantedPrivileges(String effectiveUser, RestRequest request) {
+        if(!checkRestFilter(AuditCategory.GRANTED_PRIVILEGES, effectiveUser, request)) {
+            return;
+        }
+
+        AuditMessage msg = new AuditMessage(AuditCategory.GRANTED_PRIVILEGES, clusterService, getOrigin(), Origin.REST);
+        msg.addRemoteAddress(getRemoteAddress());
+        msg.addRestRequestInfo(request, auditConfigFilter);
+        msg.addEffectiveUser(effectiveUser);
+        save(msg);
+    }
+
+    @Override
     public void logMissingPrivileges(String privilege, TransportRequest request, Task task) {
         final String action = null;
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditLogImpl.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditLogImpl.java
@@ -170,6 +170,13 @@ public final class AuditLogImpl extends AbstractAuditLog {
 	}
 
 	@Override
+	public void logGrantedPrivileges(String effectiveUser, RestRequest request) {
+		if (enabled) {
+			super.logGrantedPrivileges(effectiveUser, request);
+		}
+	}
+
+	@Override
 	public void logMissingPrivileges(String privilege, TransportRequest request, Task task) {
 		if (enabled) {
 			super.logMissingPrivileges(privilege, request, task);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Currently on REST layer if user does not have access to Opendistro APIs then MISSING_PRIVILEGES is posted.
- Posting corresponding GRANTED_PRIVILEGES if user has role access to Opendistro APIs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
