### PR TITLE
Remove unnecessary check of remote address for null

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityIndexSearcherWrapper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/OpenDistroSecurityIndexSearcherWrapper.java
@@ -122,11 +122,8 @@ public class OpenDistroSecurityIndexSearcherWrapper implements CheckedFunction<D
     }
 
     protected final boolean isPermittedOnIndex() {
-        final TransportAddress caller = (TransportAddress) this.threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS);
-        final User user = (User) threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
-        if (caller == null || user == null) {
-            return false;
-        }
+        final User user = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
+        final TransportAddress caller = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS);
         final Set<String> securityRoles = evaluator.mapRoles(user, caller);
         if (allowedRolesMatcher.matchAny(securityRoles)) {
             return true;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PermissionsInfoAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PermissionsInfoAction.java
@@ -101,9 +101,8 @@ public class PermissionsInfoAction extends BaseRestHandler {
 
                 try {
 
-            		final User user = (User) threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
-            		final TransportAddress remoteAddress = (TransportAddress) threadPool.getThreadContext()
-            				.getTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS);
+            		final User user = threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
+            		final TransportAddress remoteAddress = threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS);
             		Set<String> userRoles = privilegesEvaluator.mapRoles(user, remoteAddress);
             		Boolean hasApiAccess = restApiPrivilegesEvaluator.currentUserHasRestApiAccess(userRoles);
             		Map<Endpoint, List<Method>> disabledEndpoints = restApiPrivilegesEvaluator.getDisabledEndpointsForCurrentUser(user.getName(), userRoles);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RestApiPrivilegesEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RestApiPrivilegesEvaluator.java
@@ -344,8 +344,8 @@ public class RestApiPrivilegesEvaluator {
 		if (this.roleBasedAccessEnabled) {
 
 			// get current user and roles
-			final User user = (User) threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
-			final TransportAddress remoteAddress = (TransportAddress) threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS);
+			final User user = threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
+			final TransportAddress remoteAddress = threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS);
 
 			// map the users Security roles
 			Set<String> userRoles = privilegesEvaluator.mapRoles(user, remoteAddress);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
@@ -177,7 +177,7 @@ public class PrivilegesEvaluator {
             action0 = "indices:admin/create";
         }
 
-        final TransportAddress caller = Objects.requireNonNull((TransportAddress) this.threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS));
+        final TransportAddress caller = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS);
         final Set<String> mappedRoles = mapRoles(user, caller);
         final SecurityRoles securityRoles = getSecurityRoles(mappedRoles);
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/rest/OpenDistroSecurityInfoAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/rest/OpenDistroSecurityInfoAction.java
@@ -100,8 +100,8 @@ public class OpenDistroSecurityInfoAction extends BaseRestHandler {
                     final boolean verbose = request.paramAsBoolean("verbose", false);
                     
                     final X509Certificate[] certs = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_SSL_PEER_CERTIFICATES);
-                    final User user = (User)threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
-                    final TransportAddress remoteAddress = (TransportAddress) threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS);
+                    final User user = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
+                    final TransportAddress remoteAddress = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS);
 
                     final Set<String> securityRoles = evaluator.mapRoles(user, remoteAddress);
 


### PR DESCRIPTION
*Description of changes:* There is no need to check remote TransportAddress for null before calling `PrivilegesEvaluator.mapRoles(...)`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
