### PR TITLE
Opendistro 1.0

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -447,7 +447,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
                 handlers.add(new OpenDistroSecurityHealthAction(settings, restController, Objects.requireNonNull(backendRegistry)));
                 handlers.add(new OpenDistroSecuritySSLCertsInfoAction(settings, restController, odsks, Objects.requireNonNull(threadPool), Objects.requireNonNull(adminDns)));
                 handlers.add(new TenantInfoAction(settings, restController, Objects.requireNonNull(evaluator), Objects.requireNonNull(threadPool),
-				Objects.requireNonNull(cs), Objects.requireNonNull(adminDns)));
+				Objects.requireNonNull(cs), Objects.requireNonNull(adminDns), Objects.requireNonNull(cr)));
 
                 if (sslCertReloadEnabled) {
                     handlers.add(new OpenDistroSecuritySSLReloadCertsAction(settings, restController, odsks, Objects.requireNonNull(threadPool), Objects.requireNonNull(adminDns)));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
@@ -268,7 +268,9 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 	}
 
 	protected void filter(SecurityDynamicConfiguration<?> builder) {
-		builder.removeHidden();
+		if (!isSuperAdmin()){
+			builder.removeHidden();
+		}
 		builder.set_meta(null);
 	}
 
@@ -509,8 +511,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 	}
 
 	protected final boolean isHidden(SecurityDynamicConfiguration<?> configuration, String resourceName) {
-		final Object o = configuration.getCEntry(resourceName);
-		return o != null && o instanceof Hideable && ((Hideable) o).isHidden();
+		return configuration.isHidden(resourceName) && !isSuperAdmin();
 	}
 
 	protected final boolean isStatic(SecurityDynamicConfiguration<?> configuration, String resourceName) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
@@ -130,7 +130,7 @@ public class AccountApiAction extends AbstractApiAction {
 
                 builder.field("user_name", user.getName())
                         .field("is_reserved", isReserved(configuration, user.getName()))
-                        .field("is_hidden", isHidden(configuration, user.getName()))
+                        .field("is_hidden", configuration.isHidden(user.getName()))
                         .field("is_internal_user", configuration.exists(user.getName()))
                         .field("user_requested_tenant", user.getRequestedTenant())
                         .field("backend_roles", user.getRoles())

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
@@ -455,6 +455,10 @@ public class PrivilegesEvaluator {
         return dcm.getKibanaServerUsername();
     }
 
+    public String kibanaOpendistroRole() {
+        return dcm.getKibanaOpendistroRole();
+    }
+
     private Set<String> evaluateAdditionalIndexPermissions(final ActionRequest request, final String originalAction) {
       //--- check inner bulk requests
         final Set<String> additionalPermissionsRequired = new HashSet<>();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/rest/TenantInfoAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/rest/TenantInfoAction.java
@@ -34,8 +34,17 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 import java.io.IOException;
-import java.util.SortedMap;
+import java.util.Collections;
+import java.util.List;
 
+import java.util.SortedMap;
+import com.google.common.base.Strings;
+
+import com.amazon.opendistroforelasticsearch.security.configuration.ConfigurationRepository;
+import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigFactory;
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.CType;
+import com.amazon.opendistroforelasticsearch.security.securityconf.RoleMappings;
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.node.NodeClient;
@@ -64,9 +73,11 @@ public class TenantInfoAction extends BaseRestHandler {
     private final ThreadContext threadContext;
     private final ClusterService clusterService;
     private final AdminDNs adminDns;
+    private final ConfigurationRepository configurationRepository;
 
     public TenantInfoAction(final Settings settings, final RestController controller, 
-    		final PrivilegesEvaluator evaluator, final ThreadPool threadPool, final ClusterService clusterService, final AdminDNs adminDns) {
+            final PrivilegesEvaluator evaluator, final ThreadPool threadPool, final ClusterService clusterService, final AdminDNs adminDns,
+                            final ConfigurationRepository configurationRepository) {
         super(settings);
         this.threadContext = threadPool.getThreadContext();
         this.evaluator = evaluator;
@@ -74,6 +85,7 @@ public class TenantInfoAction extends BaseRestHandler {
         this.adminDns = adminDns;
         controller.registerHandler(GET, "/_opendistro/_security/tenantinfo", this);
         controller.registerHandler(POST, "/_opendistro/_security/tenantinfo", this);
+        this.configurationRepository = configurationRepository;
     }
 
     @Override
@@ -90,9 +102,7 @@ public class TenantInfoAction extends BaseRestHandler {
                     final User user = (User)threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
                     
                     //only allowed for admins or the kibanaserveruser
-                    if(user == null || 
-                    		(!user.getName().equals(evaluator.kibanaServerUsername()))
-                    		 && !adminDns.isAdmin(user)) {
+                    if(!isAuthorized()) {
                         response = new BytesRestResponse(RestStatus.FORBIDDEN,"");
                     } else {
 
@@ -127,7 +137,40 @@ public class TenantInfoAction extends BaseRestHandler {
             }
         };
     }
-    
+
+    private boolean isAuthorized() {
+        final User user = (User)threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
+
+        if (user == null) {
+            return false;
+        }
+
+        // check if the user is a kibanauser or super admin
+        if (user.getName().equals(evaluator.kibanaServerUsername()) || adminDns.isAdmin(user)) {
+            return true;
+        }
+
+        // If user check failed by name and admin, check if the users belong to kibana opendistro role
+        final SecurityDynamicConfiguration<?> rolesMappingConfiguration = load(CType.ROLESMAPPING, true);
+
+        // check if kibanaOpendistroRole is present in RolesMapping and if yes, check if user is a part of this role
+        if (rolesMappingConfiguration != null) {
+            String kibanaOpendistroRole = evaluator.kibanaOpendistroRole();
+            if (Strings.isNullOrEmpty(kibanaOpendistroRole)) {
+                return false;
+            }
+            RoleMappings roleMapping = (RoleMappings) rolesMappingConfiguration.getCEntries().getOrDefault(kibanaOpendistroRole, null);
+            return roleMapping != null && roleMapping.getUsers().contains(user.getName());
+        }
+
+        return false;
+    }
+
+    private final SecurityDynamicConfiguration<?> load(final CType config, boolean logComplianceEvent) {
+        SecurityDynamicConfiguration<?> loaded = configurationRepository.getConfigurationsFromIndex(Collections.singleton(config), logComplianceEvent).get(config).deepClone();
+        return DynamicConfigFactory.addStatics(loaded);
+    }
+
     private String tenantNameForIndex(String index) {
     	String[] indexParts;
     	if(index == null 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModel.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModel.java
@@ -43,6 +43,7 @@ public abstract class DynamicConfigModel {
     public abstract boolean isInterTransportAuthDisabled();
     public abstract boolean isRespectRequestIndicesEnabled();
     public abstract String getKibanaServerUsername();
+    public abstract String getKibanaOpendistroRole();
     public abstract String getKibanaIndexname();
     public abstract boolean isKibanaMultitenancyEnabled();
     public abstract boolean isDnfofEnabled();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModelV6.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModelV6.java
@@ -114,6 +114,10 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
         return config.dynamic.kibana.server_username;
     }
     @Override
+    public String getKibanaOpendistroRole() {
+        return config.dynamic.kibana.opendistro_role;
+    }
+    @Override
     public String getKibanaIndexname() {
         return config.dynamic.kibana.index;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModelV7.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModelV7.java
@@ -114,6 +114,10 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
         return config.dynamic.kibana.server_username;
     }
     @Override
+    public String getKibanaOpendistroRole() {
+        return config.dynamic.kibana.opendistro_role;
+    }
+    @Override
     public String getKibanaIndexname() {
         return config.dynamic.kibana.index;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/RoleMappings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/RoleMappings.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.securityconf;
+
+import java.util.Collections;
+import java.util.List;
+
+public class RoleMappings {
+
+    private List<String> hosts= Collections.emptyList();
+    private List<String> users= Collections.emptyList();
+
+    public void setHosts(List<String> hosts) {
+        this.hosts = hosts;
+    }
+
+    public List<String> getHosts() {
+        return hosts;
+    }
+
+    public void setUsers(List<String> users) {
+        this.users = users;
+    }
+
+    public List<String> getUsers() {
+        return users;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/SecurityDynamicConfiguration.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/SecurityDynamicConfiguration.java
@@ -258,5 +258,9 @@ public class SecurityDynamicConfiguration<T> implements ToXContent {
         return !Collections.disjoint(this.centries.keySet(), other.centries.keySet());
     }
 
-    
+    public boolean isHidden(String resourceName){
+        final Object o = centries.get(resourceName);
+        return o != null && o instanceof Hideable && ((Hideable) o).isHidden();
+    }
+
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v6/ConfigV6.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v6/ConfigV6.java
@@ -53,12 +53,13 @@ public class ConfigV6 {
 
         public boolean multitenancy_enabled = true;
         public String server_username = "kibanaserver";
+        public String opendistro_role = "";
         public String index = ".kibana";
         public boolean do_not_fail_on_forbidden;
         @Override
         public String toString() {
-            return "Kibana [multitenancy_enabled=" + multitenancy_enabled + ", server_username=" + server_username + ", index=" + index
-                    + ", do_not_fail_on_forbidden=" + do_not_fail_on_forbidden + "]";
+            return "Kibana [multitenancy_enabled=" + multitenancy_enabled + ", server_username=" + server_username + ", opendistro_role=" + opendistro_role
+                    + ", index=" + index + ", do_not_fail_on_forbidden=" + do_not_fail_on_forbidden + "]";
         }
         
         

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v6/RoleMappingsV6.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v6/RoleMappingsV6.java
@@ -3,17 +3,16 @@ package com.amazon.opendistroforelasticsearch.security.securityconf.impl.v6;
 import java.util.Collections;
 import java.util.List;
 
+import com.amazon.opendistroforelasticsearch.security.securityconf.RoleMappings;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.amazon.opendistroforelasticsearch.security.securityconf.Hideable;
 
-public class RoleMappingsV6 implements Hideable {
+public class RoleMappingsV6 extends RoleMappings implements Hideable {
 
     private boolean readonly;
     private boolean hidden;
     private List<String> backendroles = Collections.emptyList();
-    private List<String> hosts= Collections.emptyList();
-    private List<String> users= Collections.emptyList();
     private List<String> andBackendroles= Collections.emptyList();
 
 
@@ -41,18 +40,6 @@ public class RoleMappingsV6 implements Hideable {
     public void setBackendroles(List<String> backendroles) {
         this.backendroles = backendroles;
     }
-    public List<String> getHosts() {
-        return hosts;
-    }
-    public void setHosts(List<String> hosts) {
-        this.hosts = hosts;
-    }
-    public List<String> getUsers() {
-        return users;
-    }
-    public void setUsers(List<String> users) {
-        this.users = users;
-    }
 
     @JsonProperty(value="and_backendroles")
     public List<String> getAndBackendroles() {
@@ -64,8 +51,8 @@ public class RoleMappingsV6 implements Hideable {
 
     @Override
     public String toString() {
-        return "RoleMappings [readonly=" + readonly + ", hidden=" + hidden + ", backendroles=" + backendroles + ", hosts=" + hosts + ", users="
-                + users + ", andBackendroles=" + andBackendroles + "]";
+        return "RoleMappings [readonly=" + readonly + ", hidden=" + hidden + ", backendroles=" + backendroles + ", hosts=" + getHosts() + ", users="
+                + getUsers() + ", andBackendroles=" + andBackendroles + "]";
     }
     
     @JsonIgnore

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v7/ConfigV7.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v7/ConfigV7.java
@@ -105,10 +105,12 @@ public class ConfigV7 {
 
         public boolean multitenancy_enabled = true;
         public String server_username = "kibanaserver";
+        public String opendistro_role = "";
         public String index = ".kibana";
         @Override
         public String toString() {
-            return "Kibana [multitenancy_enabled=" + multitenancy_enabled + ", server_username=" + server_username + ", index=" + index + "]";
+            return "Kibana [multitenancy_enabled=" + multitenancy_enabled + ", server_username=" + server_username + ", opendistro_role=" + opendistro_role
+            + ", index=" + index + "]";
         }
         
         

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v7/RoleMappingsV7.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v7/RoleMappingsV7.java
@@ -4,15 +4,14 @@ import java.util.Collections;
 import java.util.List;
 
 import com.amazon.opendistroforelasticsearch.security.securityconf.Hideable;
+import com.amazon.opendistroforelasticsearch.security.securityconf.RoleMappings;
 import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v6.RoleMappingsV6;
 
-public class RoleMappingsV7 implements Hideable {
+public class RoleMappingsV7 extends RoleMappings implements Hideable {
 
     private boolean reserved;
     private boolean hidden;
     private List<String> backend_roles = Collections.emptyList();
-    private List<String> hosts= Collections.emptyList();
-    private List<String> users= Collections.emptyList();
     private List<String> and_backend_roles= Collections.emptyList();
     private String description;
 
@@ -25,10 +24,10 @@ public class RoleMappingsV7 implements Hideable {
         this.reserved = roleMappingsV6.isReserved();
         this.hidden = roleMappingsV6.isHidden();
         this.backend_roles = roleMappingsV6.getBackendroles();
-        this.hosts = roleMappingsV6.getHosts();
-        this.users = roleMappingsV6.getUsers();
         this.and_backend_roles = roleMappingsV6.getAndBackendroles();
         this.description = "Migrated from v6";
+        setHosts(roleMappingsV6.getHosts());
+        setUsers(roleMappingsV6.getUsers());
     }
 
     public boolean isReserved() {
@@ -67,30 +66,6 @@ public class RoleMappingsV7 implements Hideable {
 
 
 
-    public List<String> getHosts() {
-        return hosts;
-    }
-
-
-
-    public void setHosts(List<String> hosts) {
-        this.hosts = hosts;
-    }
-
-
-
-    public List<String> getUsers() {
-        return users;
-    }
-
-
-
-    public void setUsers(List<String> users) {
-        this.users = users;
-    }
-
-
-
     public List<String> getAnd_backend_roles() {
         return and_backend_roles;
     }
@@ -117,8 +92,8 @@ public class RoleMappingsV7 implements Hideable {
 
     @Override
     public String toString() {
-        return "RoleMappingsV7 [reserved=" + reserved + ", hidden=" + hidden + ", backend_roles=" + backend_roles + ", hosts=" + hosts + ", users="
-                + users + ", and_backend_roles=" + and_backend_roles + ", description=" + description + "]";
+        return "RoleMappingsV7 [reserved=" + reserved + ", hidden=" + hidden + ", backend_roles=" + backend_roles + ", hosts=" + getHosts() + ", users="
+                + getUsers() + ", and_backend_roles=" + and_backend_roles + ", description=" + description + "]";
     }
 
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/GetConfigurationApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/GetConfigurationApiTest.java
@@ -74,7 +74,7 @@ public class GetConfigurationApiTest extends AbstractRestApiUnitTest {
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
 		Assert.assertEquals(settings.getAsList("ALL.allowed_actions").get(0), "indices:*");
-		Assert.assertFalse(settings.hasValue("INTERNAL.allowed_actions"));
+		Assert.assertTrue(settings.hasValue("INTERNAL.allowed_actions"));
 		Assert.assertNull(settings.get("_opendistro_security_meta.type"));
 	}
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiTest.java
@@ -108,7 +108,8 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
         // hidden role
         response = rh.executeGetRequest("/_opendistro/_security/api/roles/opendistro_security_internal", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"hidden\":true"));
 
         // create index
         setupStarfleetIndex();
@@ -134,9 +135,10 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/opendistro_security_transport_client", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
-        // hidden role
+        // hidden role allowed for superadmin
         response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/opendistro_security_internal", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("'opendistro_security_internal' deleted."));
 
         // remove complete role mapping for opendistro_security_role_starfleet_captains
         response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/opendistro_security_role_starfleet_captains", new Header[0]);
@@ -196,10 +198,10 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
                 FileHelper.loadFile("restapi/roles_captains.json"), new Header[0]);
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
 
-        // put hidden role, must be forbidden
+        // put hidden role, must be forbidden, but allowed for super admin
         response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_internal",
                 FileHelper.loadFile("restapi/roles_captains.json"), new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
 
         // restore starfleet role
         response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_role_starfleet",
@@ -321,10 +323,10 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         response = rh.executePatchRequest("/_opendistro/_security/api/roles/opendistro_security_transport_client", "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
-        // PATCH hidden resource, must be not found
+        // PATCH hidden resource, must be not found, can be found for superadmin, but will fail with no path present exception
         rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/roles/opendistro_security_internal", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         // PATCH value of hidden flag, must fail with validation error
         rh.sendAdminCertificate = true;
@@ -371,10 +373,11 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         response = rh.executePatchRequest("/_opendistro/_security/api/roles", "[{ \"op\": \"remove\", \"path\": \"/opendistro_security_transport_client\" }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
-        // PATCH hidden resource, must be bad request
+        // PATCH hidden resource, must be bad request, but allowed for superadmin
         rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/roles", "[{ \"op\": \"remove\", \"path\": \"/opendistro_security_internal\"}]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"message\":\"Resource updated."));
 
         // PATCH value of hidden flag, must fail with validation error
         rh.sendAdminCertificate = true;
@@ -424,8 +427,6 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
         HttpResponse response;
 
-        response = rh.executeGetRequest("_opendistro/_security/api/roles");
-
         // Delete read only roles
         response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/opendistro_security_transport_client" , new Header[0]);
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
@@ -441,6 +442,26 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         // Patch multiple read only roles
         response = rh.executePatchRequest("/_opendistro/_security/api/roles/", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_transport_client/description\", \"value\": \"foo\" }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // get hidden role
+        response = rh.executeGetRequest("_opendistro/_security/api/roles/opendistro_security_internal");
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+
+        // delete hidden role
+        response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/opendistro_security_internal" , new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+
+        // put hidden role
+        response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_internal", "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // Patch single hidden roles
+        response = rh.executePatchRequest("/_opendistro/_security/api/roles/opendistro_security_internal", "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+
+        // Patch multiple hidden roles
+        response = rh.executePatchRequest("/_opendistro/_security/api/roles/", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_internal/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesMappingApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesMappingApiTest.java
@@ -73,9 +73,10 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		Assert.assertTrue(response.getContentType(), response.isJsonContentType());
 
-	    // GET, rolesmapping is hidden
-        response = rh.executeGetRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_internal", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+	        // GET, rolesmapping is hidden, allowed for super admin
+        	response = rh.executeGetRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_internal", new Header[0]);
+        	Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+		Assert.assertTrue(response.getBody().contains("\"hidden\":true"));
 
 		// create index
 		setupStarfleetIndex();
@@ -101,9 +102,10 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 		response = rh.executeDeleteRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_library", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
-        // hidden role
-        response = rh.executeDeleteRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_internal", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+        	// hidden role
+        	response = rh.executeDeleteRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_internal", new Header[0]);
+        	Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+		Assert.assertTrue(response.getBody().contains("'opendistro_security_role_internal' deleted."));
 
 		// remove complete role mapping for opendistro_security_role_starfleet_captains
 		response = rh.executeDeleteRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_captains", new Header[0]);
@@ -187,10 +189,10 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 				FileHelper.loadFile("restapi/rolesmapping_all_access.json"), new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
 
-        // hidden role
+        // hidden role, allowed for super admin
         response = rh.executePutRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_internal",
                 FileHelper.loadFile("restapi/rolesmapping_all_access.json"), new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
 
 		response = rh.executePutRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_captains",
 				FileHelper.loadFile("restapi/rolesmapping_all_access.json"), new Header[0]);
@@ -208,10 +210,10 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
         response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_library", "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"foo\"] }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
-        // PATCH hidden resource, must be not found
+        // PATCH hidden resource, must be not found, can be found by super admin
         rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_internal", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         // PATCH value of hidden flag, must fail with validation error
         rh.sendAdminCertificate = true;
@@ -344,8 +346,6 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 
 		HttpResponse response;
 
-		response = rh.executeGetRequest("/_opendistro/_security/api/rolesmapping" , new Header[0]);
-
 		// Delete read only roles mapping
 		response = rh.executeDeleteRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_library" , new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
@@ -363,6 +363,26 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 		response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_role_starfleet_library/description\", \"value\": \"foo\" }]", new Header[0]);
 		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
 
+		// GET, rolesmapping is hidden, allowed for super admin
+		response = rh.executeGetRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_internal", new Header[0]);
+		Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+
+		// Delete hidden roles mapping
+		response = rh.executeDeleteRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_internal" , new Header[0]);
+		Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+
+		// Put hidden roles mapping
+		response = rh.executePutRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_internal",
+				FileHelper.loadFile("restapi/rolesmapping_all_access.json"), new Header[0]);
+		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+		// Patch hidden roles mapping
+		response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_internal", "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
+		Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+
+		// Patch multiple hidden roles mapping
+		response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_role_internal/description\", \"value\": \"foo\" }]", new Header[0]);
+		Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
 	}
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/TenantInfoActionTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/TenantInfoActionTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.dlic.rest.api;
+
+import com.amazon.opendistroforelasticsearch.security.privileges.PrivilegesEvaluator;
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import com.amazon.opendistroforelasticsearch.security.test.helper.file.FileHelper;
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper;
+import org.apache.http.Header;
+import org.apache.http.HttpStatus;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class TenantInfoActionTest extends AbstractRestApiUnitTest {
+    private String payload = "{\"hosts\":[],\"users\":[\"sarek\"]," +
+            "\"backend_roles\":[\"starfleet*\",\"ambassador\"],\"and_backend_roles\":[],\"description\":\"Migrated " +
+            "from v6\"}";
+
+    @Test
+    public void testTenantInfoAPI() throws Exception {
+        Settings settings = Settings.builder().put(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, true).build();
+        setup(settings);
+
+        rh.keystore = "restapi/kirk-keystore.jks";
+        rh.sendAdminCertificate = true;
+        RestHelper.HttpResponse response = rh.executeGetRequest("_opendistro/_security/tenantinfo");
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        rh.sendAdminCertificate = false;
+        response = rh.executeGetRequest("_opendistro/_security/tenantinfo");
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
+
+        rh.sendHTTPClientCredentials = true;
+        response = rh.executeGetRequest("_opendistro/_security/tenantinfo");
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        rh.sendAdminCertificate = true;
+
+        //update security config
+        response = rh.executePatchRequest("/_opendistro/_security/api/securityconfig", "[{\"op\": \"add\",\"path\": \"/config/dynamic/kibana/opendistro_role\",\"value\": \"opendistro_security_role_internal\"}]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executePutRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_internal", payload, new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        rh.sendAdminCertificate = false;
+
+        response = rh.executeGetRequest("_opendistro/_security/tenantinfo");
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
@@ -47,7 +47,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 				.executeGetRequest("_opendistro/_security/api/" + CType.INTERNALUSERS.toLCString());
 		Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
 		Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertEquals(30, settings.size());
+		Assert.assertEquals(42, settings.size());
 		// --- GET
 
 		// GET, user admin, exists
@@ -352,7 +352,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		System.out.println(response.getBody());
 		Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertEquals(49, settings.size());
+		Assert.assertEquals(42, settings.size());
 
 		addUserWithPassword("tooshoort", "", HttpStatus.SC_BAD_REQUEST);
 		addUserWithPassword("tooshoort", "123", HttpStatus.SC_BAD_REQUEST);
@@ -426,7 +426,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 				.executeGetRequest("_opendistro/_security/api/" + CType.INTERNALUSERS.toLCString());
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertEquals(49, settings.size());
+		Assert.assertEquals(42, settings.size());
 
 		addUserWithPassword(".my.dotuser0", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m",
 				HttpStatus.SC_CREATED);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
@@ -33,7 +33,7 @@ import com.amazon.opendistroforelasticsearch.security.test.helper.file.FileHelpe
 import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 public class UserApiTest extends AbstractRestApiUnitTest {
-
+	
 	@Test
 	public void testUserApi() throws Exception {
 
@@ -115,10 +115,10 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/sarek", "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
-        // PATCH hidden resource, must be not found
+        // PATCH hidden resource, must be not found, can be found for super admin
         rh.sendAdminCertificate = true;
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/q", "[{ \"op\": \"add\", \"path\": \"/a/b/c\", \"value\": [ \"foo\", \"bar\" ] }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         // PATCH value of hidden flag, must fail with validation error
         rh.sendAdminCertificate = true;
@@ -187,10 +187,10 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         addUserWithHash("sarek", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m",
                 HttpStatus.SC_OK);
 
-        // add/update user, user is hidden, forbidden
+        // add/update user, user is hidden, forbidden, allowed for super admin
         rh.sendAdminCertificate = true;
         addUserWithHash("q", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m",
-                HttpStatus.SC_FORBIDDEN);
+                HttpStatus.SC_OK);
 
         // add users
         rh.sendAdminCertificate = true;
@@ -213,9 +213,9 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         response = rh.executeDeleteRequest("/_opendistro/_security/api/internalusers/sarek", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
-        // try remove hidden user
+        // try remove hidden user, allowed for super admin
         response = rh.executeDeleteRequest("/_opendistro/_security/api/internalusers/q", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
 		// now really remove user
 		deleteUser("nagilum");
@@ -352,7 +352,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		System.out.println(response.getBody());
 		Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertEquals(30, settings.size());
+		Assert.assertEquals(49, settings.size());
 
 		addUserWithPassword("tooshoort", "", HttpStatus.SC_BAD_REQUEST);
 		addUserWithPassword("tooshoort", "123", HttpStatus.SC_BAD_REQUEST);
@@ -426,7 +426,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 				.executeGetRequest("_opendistro/_security/api/" + CType.INTERNALUSERS.toLCString());
 		Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 		Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-		Assert.assertEquals(30, settings.size());
+		Assert.assertEquals(49, settings.size());
 
 		addUserWithPassword(".my.dotuser0", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m",
 				HttpStatus.SC_CREATED);
@@ -483,8 +483,6 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 
         HttpResponse response;
 
-        response = rh.executeGetRequest("/_opendistro/_security/api/internalusers" , new Header[0]);
-
         // Delete read only user
         response = rh.executeDeleteRequest("/_opendistro/_security/api/internalusers/sarek" , new Header[0]);
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
@@ -500,6 +498,26 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         // Patch multiple read only users
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/sarek/description\", \"value\": \"foo\" }]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // Get hidden role
+        response = rh.executeGetRequest("/_opendistro/_security/api/internalusers/hide" , new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+
+        // Delete hidden user
+        response = rh.executeDeleteRequest("/_opendistro/_security/api/internalusers/hide" , new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+
+        // Put hidden users
+        response = rh.executePutRequest("/_opendistro/_security/api/internalusers/hide", "[{ \"op\": \"add\", \"path\": \"/sarek/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        // Patch single hidden user
+        response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/hide", "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+
+        // Patch multiple hidden users
+        response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/hide/description\", \"value\": \"foo\" }]", new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
     }
 


### PR DESCRIPTION
Backport changes

Allowing SuperAdmin to delete hidden resources, so that tenantinfo api can have additional check for usertype with hidden resource

Tenantinfo api will check role of the user from security config, and if matched will allow to work with this api

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
