### PR TITLE
TenantInfo API should also check backend roles apart from just users …

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/rest/TenantInfoAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/rest/TenantInfoAction.java
@@ -37,6 +37,9 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.SortedMap;
+
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v6.RoleMappingsV6;
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.v7.RoleMappingsV7;
 import com.google.common.base.Strings;
 
 import com.amazon.opendistroforelasticsearch.security.configuration.ConfigurationRepository;
@@ -168,7 +171,18 @@ public class TenantInfoAction extends BaseRestHandler {
                 return false;
             }
             RoleMappings roleMapping = (RoleMappings) rolesMappingConfiguration.getCEntries().getOrDefault(kibanaOpendistroRole, null);
-            return roleMapping != null && roleMapping.getUsers().contains(user.getName());
+            if (roleMapping != null) {
+                if(roleMapping.getUsers().contains(user.getName())) {
+                    return true;
+                }
+                List<String> backendRoles = null;
+                if (roleMapping instanceof  RoleMappingsV6) {
+                    backendRoles = ((RoleMappingsV6) roleMapping).getBackendroles();
+                } else if (roleMapping instanceof RoleMappingsV7) {
+                    backendRoles = ((RoleMappingsV7) roleMapping).getBackend_roles();
+                }
+                return backendRoles.contains(user.getName());
+            }
         }
 
         return false;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/TenantInfoActionTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/TenantInfoActionTest.java
@@ -29,10 +29,12 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 public class TenantInfoActionTest extends AbstractRestApiUnitTest {
-    private String payload = "{\"hosts\":[],\"users\":[\"sarek\"]," +
+    private String userPayload = "{\"hosts\":[],\"users\":[\"sarek\"]," +
             "\"backend_roles\":[\"starfleet*\",\"ambassador\"],\"and_backend_roles\":[],\"description\":\"Migrated " +
             "from v6\"}";
-
+    private String backendRolePayload = "{\"hosts\":[],\"users\":[]," +
+            "\"backend_roles\":[\"sarek\"],\"and_backend_roles\":[],\"description\":\"Migrated " +
+            "from v6\"}";
     @Test
     public void testTenantInfoAPI() throws Exception {
         Settings settings = Settings.builder().put(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, true).build();
@@ -52,16 +54,24 @@ public class TenantInfoActionTest extends AbstractRestApiUnitTest {
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
 
         rh.sendAdminCertificate = true;
-
         //update security config
         response = rh.executePatchRequest("/_opendistro/_security/api/securityconfig", "[{\"op\": \"add\",\"path\": \"/config/dynamic/kibana/opendistro_role\",\"value\": \"opendistro_security_internal\"}]", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
-        response = rh.executePutRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_internal", payload, new Header[0]);
+        response = rh.executePutRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_internal", userPayload, new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         rh.sendAdminCertificate = false;
         response = rh.executeGetRequest("_opendistro/_security/tenantinfo");
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        rh.sendAdminCertificate = true;
+        response = rh.executePutRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_internal", backendRolePayload, new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        rh.sendAdminCertificate = false;
+        response = rh.executeGetRequest("_opendistro/_security/tenantinfo");
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
     }
 }


### PR DESCRIPTION
TenantInfo API should also check backend roles apart from just users in rolesmapping

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
