### PR TITLE
Clean up rest and transport header filtering

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditMessage.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditMessage.java
@@ -26,9 +26,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.config.AuditConfig;
+import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.elasticsearch.ExceptionsHelper;
@@ -54,7 +54,7 @@ import com.amazon.opendistroforelasticsearch.security.dlic.rest.support.Utils;
 public final class AuditMessage {
 
     //clustername and cluster uuid
-    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final WildcardMatcher AUTHORIZATION_HEADER = WildcardMatcher.from("Authorization", false);
     public static final String FORMAT_VERSION = "audit_format_version";
     public static final String CATEGORY = "audit_category";
     public static final String REQUEST_EFFECTIVE_USER = "audit_request_effective_user";
@@ -307,15 +307,11 @@ public final class AuditMessage {
 
     public void addRestHeaders(Map<String,List<String>> headers, boolean excludeSensitiveHeaders) {
         if(headers != null && !headers.isEmpty()) {
-            if(excludeSensitiveHeaders) {
-                final Map<String, List<String>> headersClone = new HashMap<String, List<String>>(headers)
-                        .entrySet().stream()
-                        .filter(map -> !map.getKey().equalsIgnoreCase(AUTHORIZATION_HEADER))
-                        .collect(Collectors.toMap(p -> p.getKey(), p -> p.getValue()));
-                auditInfo.put(REST_REQUEST_HEADERS, headersClone);
-            } else {
-                auditInfo.put(REST_REQUEST_HEADERS, new HashMap<String, List<String>>(headers));
+            final Map<String, List<String>> headersClone = new HashMap<>(headers);
+            if (excludeSensitiveHeaders) {
+                headersClone.keySet().removeIf(AUTHORIZATION_HEADER);
             }
+            auditInfo.put(REST_REQUEST_HEADERS, headersClone);
         }
     }
 
@@ -339,15 +335,11 @@ public final class AuditMessage {
 
     public void addTransportHeaders(Map<String,String> headers, boolean excludeSensitiveHeaders) {
         if(headers != null && !headers.isEmpty()) {
-            if(excludeSensitiveHeaders) {
-                final Map<String,String> headersClone = new HashMap<String,String>(headers)
-                        .entrySet().stream()
-                        .filter(map -> !map.getKey().equalsIgnoreCase(AUTHORIZATION_HEADER))
-                        .collect(Collectors.toMap(p -> p.getKey(), p -> p.getValue()));
-                auditInfo.put(TRANSPORT_REQUEST_HEADERS, headersClone);
-            } else {
-                auditInfo.put(TRANSPORT_REQUEST_HEADERS, new HashMap<String,String>(headers));
+            final Map<String, String> headersClone = new HashMap<>(headers);
+            if (excludeSensitiveHeaders) {
+                headersClone.keySet().removeIf(AUTHORIZATION_HEADER);
             }
+            auditInfo.put(TRANSPORT_REQUEST_HEADERS, headersClone);
         }
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditMessageTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditMessageTest.java
@@ -1,0 +1,89 @@
+package com.amazon.opendistroforelasticsearch.security.auditlog.impl;
+
+import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AuditMessageTest {
+
+    private static final Map<String, List<String>> TEST_REST_HEADERS = ImmutableMap.of(
+            "authorization", ImmutableList.of("test-1"),
+            "Authorization", ImmutableList.of("test-2"),
+            "AuThOrIzAtIoN", ImmutableList.of("test-3"),
+            "test-header", ImmutableList.of("test-4")
+    );
+
+    private static final Map<String, String> TEST_TRANSPORT_HEADERS = ImmutableMap.of(
+            "authorization", "test-1",
+            "Authorization", "test-2",
+            "AuThOrIzAtIoN","test-3",
+            "test-header", "test-4"
+    );
+
+    private AuditMessage message;
+
+    @Before
+    public void setUp() {
+        final ClusterService clusterServiceMock = mock(ClusterService.class);
+        when(clusterServiceMock.localNode()).thenReturn(mock(DiscoveryNode.class));
+        when(clusterServiceMock.getClusterName()).thenReturn(mock(ClusterName.class));
+        message = new AuditMessage(AuditCategory.AUTHENTICATED,
+                clusterServiceMock,
+                AuditLog.Origin.REST,
+                AuditLog.Origin.REST);
+    }
+
+    @Test
+    public void testRestHeadersAreFiltered() {
+        message.addRestHeaders(TEST_REST_HEADERS, true);
+        assertEquals(message.getAsMap().get(AuditMessage.REST_REQUEST_HEADERS), ImmutableMap.of("test-header", ImmutableList.of("test-4")));
+    }
+
+    @Test
+    public void testRestHeadersNull() {
+        message.addRestHeaders(null, true);
+        assertNull(message.getAsMap().get(AuditMessage.REST_REQUEST_HEADERS));
+        message.addRestHeaders(Collections.emptyMap(), true);
+        assertNull(message.getAsMap().get(AuditMessage.REST_REQUEST_HEADERS));
+    }
+
+    @Test
+    public void testRestHeadersAreNotFiltered() {
+        message.addRestHeaders(TEST_REST_HEADERS, false);
+        assertEquals(message.getAsMap().get(AuditMessage.REST_REQUEST_HEADERS), TEST_REST_HEADERS);
+    }
+
+    @Test
+    public void testTransportHeadersNull() {
+        message.addTransportHeaders(null, true);
+        assertNull(message.getAsMap().get(AuditMessage.TRANSPORT_REQUEST_HEADERS));
+        message.addTransportHeaders(Collections.emptyMap(), true);
+        assertNull(message.getAsMap().get(AuditMessage.TRANSPORT_REQUEST_HEADERS));
+    }
+
+    @Test
+    public void testTransportHeadersAreFiltered() {
+        message.addTransportHeaders(TEST_TRANSPORT_HEADERS, true);
+        assertEquals(message.getAsMap().get(AuditMessage.TRANSPORT_REQUEST_HEADERS), ImmutableMap.of("test-header", "test-4"));
+    }
+
+    @Test
+    public void testTransportHeadersAreNotFiltered() {
+        message.addTransportHeaders(TEST_TRANSPORT_HEADERS, false);
+        assertEquals(message.getAsMap().get(AuditMessage.TRANSPORT_REQUEST_HEADERS), TEST_TRANSPORT_HEADERS);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Cleanup header filtering logic. Creating two maps in one flow. 
- Input can be immutable map hence making a map clone (retaining behavior)
- Using wildcard pattern
- Added tests 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
