### PR TITLE
Fail on invalid rest and transport categories

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/AuditValidator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/validation/AuditValidator.java
@@ -2,11 +2,35 @@ package com.amazon.opendistroforelasticsearch.security.dlic.rest.validation;
 
 import com.amazon.opendistroforelasticsearch.security.DefaultObjectMapper;
 import com.amazon.opendistroforelasticsearch.security.auditlog.config.AuditConfig;
+import com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditCategory;
+import com.google.common.collect.ImmutableSet;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestRequest;
 
+import java.util.Set;
+
 public class AuditValidator extends AbstractConfigurationValidator {
+
+    private static final Set<AuditCategory> DISABLED_REST_CATEGORIES = ImmutableSet.of(
+            AuditCategory.BAD_HEADERS,
+            AuditCategory.SSL_EXCEPTION,
+            AuditCategory.AUTHENTICATED,
+            AuditCategory.FAILED_LOGIN,
+            AuditCategory.GRANTED_PRIVILEGES,
+            AuditCategory.MISSING_PRIVILEGES
+    );
+
+    private static final Set<AuditCategory> DISABLED_TRANSPORT_CATEGORIES = ImmutableSet.of(
+            AuditCategory.BAD_HEADERS,
+            AuditCategory.SSL_EXCEPTION,
+            AuditCategory.AUTHENTICATED,
+            AuditCategory.FAILED_LOGIN,
+            AuditCategory.GRANTED_PRIVILEGES,
+            AuditCategory.MISSING_PRIVILEGES,
+            AuditCategory.INDEX_EVENT,
+            AuditCategory.OPENDISTRO_SECURITY_INDEX_ATTEMPT
+    );
 
     public AuditValidator(final RestRequest request,
                           final BytesReference ref,
@@ -30,7 +54,14 @@ public class AuditValidator extends AbstractConfigurationValidator {
                 && this.content.length() > 0) {
             try {
                 // try parsing to target type
-                DefaultObjectMapper.readTree(getContentAsNode(), AuditConfig.class);
+                final AuditConfig auditConfig = DefaultObjectMapper.readTree(getContentAsNode(), AuditConfig.class);
+                final AuditConfig.Filter filter = auditConfig.getFilter();
+                if (!DISABLED_REST_CATEGORIES.containsAll(filter.getDisabledRestCategories())) {
+                    throw new IllegalArgumentException("Invalid REST categories passed in the request");
+                }
+                if (!DISABLED_TRANSPORT_CATEGORIES.containsAll(filter.getDisabledTransportCategories())) {
+                    throw new IllegalArgumentException("Invalid transport categories passed in the request");
+                }
             } catch (Exception e) {
                 // this.content is not valid json
                 this.errorType = ErrorType.BODY_NOT_PARSEABLE;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Addresses #324 to fail on invalid categories in the request.
- Not all the audit categories are valid for REST transport layer
- Fails with 400 bad request if invalid categories are passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
