### PR TITLE
Add non-null to store even non-default values in serialization

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/config/AuditConfig.java
@@ -23,6 +23,7 @@ import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
@@ -80,6 +81,7 @@ import static com.amazon.opendistroforelasticsearch.security.DefaultObjectMapper
  *   }
  * }
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AuditConfig {
 
     public static final List<String> DEFAULT_IGNORED_USERS = Collections.singletonList("kibanaserver");
@@ -126,6 +128,7 @@ public class AuditConfig {
      * Filter represents set of filtering configuration settings for audit logging.
      * Audit logger will use these settings to determine what audit logs are to be generated.
      */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class Filter {
         @VisibleForTesting
         public static final Filter DEFAULT = Filter.from(Settings.EMPTY);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/compliance/ComplianceConfig.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/compliance/ComplianceConfig.java
@@ -42,6 +42,7 @@ import com.amazon.opendistroforelasticsearch.security.auditlog.config.AuditConfi
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
@@ -72,6 +73,7 @@ import static com.amazon.opendistroforelasticsearch.security.DefaultObjectMapper
  * Audit Logger uses this configuration to post compliance audit logs.
  */
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ComplianceConfig {
 
     private static final Logger log = LogManager.getLogger(ComplianceConfig.class);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Currently non-default values are ignored in serialization based on Java defaults because of which during deserialization the defaults are reset causing different values to be used. 
- For eg: if /config/audit/log_request_body is false, then it is not stored during serialization and during the deserialization, since the value is not stored, the default is reset to false.
- `JsonInclude.Include.NON_NULL` will store all non-null & non-default values also
- Added test 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
