### PR TITLE
Remove cluster monitor check from audit transport check

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AbstractAuditLog.java
@@ -646,19 +646,7 @@ public abstract class AbstractAuditLog implements AuditLog {
         }
 
         //skip internals
-        if(action != null
-                &&
-                ( action.startsWith("internal:")
-                        || action.startsWith("cluster:monitor")
-                        || action.startsWith("indices:monitor")
-                )
-        ) {
-
-
-            //if(log.isTraceEnabled()) {
-            //    log.trace("Skipped audit log message due to category ({}) or action ({}) does not match", category, action);
-            //}
-
+        if (action != null && action.startsWith("internal:")) {
             return false;
         }
 
@@ -690,7 +678,7 @@ public abstract class AbstractAuditLog implements AuditLog {
         }
 
 
-        //skip cluster:monitor, index:monitor, internal:*
+        //skip internal:*
         //check transport audit enabled
         //check category enabled
         //check action

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditlogTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditlogTest.java
@@ -155,4 +155,19 @@ public class AuditlogTest {
             Assert.assertFalse(al.checkTransportFilter(category, "action", "user", mock(TransportRequest.class)));
         }
     }
+
+    @Test
+    public void testTransportFilterMonitorActionsCheck() {
+        final Settings settings = Settings.builder()
+                .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_TRANSPORT, true)
+                .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES, "NONE")
+                .build();
+        final AbstractAuditLog al = AuditTestUtils.createAuditLog(settings, null,  null, AbstractSecurityUnitTest.MOCK_POOL, null, cs);
+        for (AuditCategory category: AuditCategory.values()) {
+            Assert.assertTrue(al.checkTransportFilter(category, "cluster:monitor/any", "user", mock(TransportRequest.class)));
+            Assert.assertTrue(al.checkTransportFilter(category, "indices:data/any", "user", mock(TransportRequest.class)));
+            Assert.assertFalse(al.checkTransportFilter(category, "internal:any", "user", mock(TransportRequest.class)));
+
+        }
+    }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/integration/BasicAuditlogTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/integration/BasicAuditlogTest.java
@@ -213,7 +213,7 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("\"audit_request_effective_user\" : \"admin\""));
         Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("REST"));
         Assert.assertFalse(TestAuditlogImpl.sb.toString().toLowerCase().contains("authorization"));
-        Assert.assertEquals(TestAuditlogImpl.messages.get(0).getAsMap().get(AuditMessage.TASK_ID),
+        Assert.assertEquals(TestAuditlogImpl.messages.get(1).getAsMap().get(AuditMessage.TASK_ID),
         TestAuditlogImpl.messages.get(1).getAsMap().get(AuditMessage.TASK_ID));
         Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Removing hard coded check for transport cluster & index monitor actions
- Retaining internal actions to be ignored
- Updated tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
