### PR TITLE
Using onelogin util helper instead of DocumentBuilderFactory

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
@@ -90,7 +90,6 @@ public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
     private AuthTokenProcessorHandler authTokenProcessorHandler;
     private HTTPJwtAuthenticator httpJwtAuthenticator;
     private Settings jwtSettings;
-    private static final DocumentBuilderFactory documentBuilderFactory = getDocumentBuildFactory();
 
     private static int resolverIdCounter = 0;
 
@@ -426,17 +425,9 @@ public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
         }
     }
 
-    private static DocumentBuilderFactory getDocumentBuildFactory() {
-        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-        documentBuilderFactory.setNamespaceAware(true);
-        return documentBuilderFactory;
-    }
-
     private static Element getMetadataDOM(final String xmlString) throws IOException, SAXException, ParserConfigurationException {
-        DocumentBuilder builder = null;
         try {
-            builder = documentBuilderFactory.newDocumentBuilder();
-            Document doc = builder.parse(new InputSource(new StringReader(xmlString)));
+            Document doc = Util.loadXML(xmlString);
             return doc.getDocumentElement();
         } catch (Exception e) {
             log.error("Error while parsing SAML Metadata Body {}", xmlString, e);


### PR DESCRIPTION
… convertToString util helper

*Issue #, if available:*

*Description of changes:* Replaced DocumentBuilderFactory with onelogin util to prevent XXE attacks. Onelogin util has checks for XXE attacks. See - https://github.com/onelogin/java-saml/blob/master/core/src/main/java/com/onelogin/saml2/util/Util.java#L335-L409

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
