### PR TITLE
Close AuditLog while closing OpenDistroSecurityPlugin and unregister shutdown hook when closing AuditLogImpl.

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -208,8 +208,10 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
 
     @Override
     public void close() throws IOException {
-        //TODO implement close
         super.close();
+        if (auditLog != null) {
+            auditLog.close();
+        }
     }
 
     private final SslExceptionHandler evaluateSslExceptionHandler() {


### PR DESCRIPTION
*Description of changes:* In unit tests relying on shutdown hook leads to the memory leak as more and more hooks are added every time `AuditLogImpl` is constructed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
