### PR TITLE
Redact request body for APIs that may contain plaintext password

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/integration/BasicAuditlogTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/integration/BasicAuditlogTest.java
@@ -884,4 +884,41 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("BAD_HEADERS"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("\"audit_rest_request_method\" : \"GET\""));
     }
+
+    @Test
+    public void testSensitiveMethodRedaction() throws Exception {
+        final Settings settings = Settings.builder()
+                .put("opendistro_security.audit.type", TestAuditlogImpl.class.getName())
+                .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_REST, true)
+                .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES, "AUTHENTICATED")
+                .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_TRANSPORT, false)
+                .build();
+        setup(settings);
+        rh.sendAdminCertificate = true;
+        final String expectedRequestBody = "\"audit_request_body\" : \"__SENSITIVE__\"";
+
+        // test PUT accounts API
+        TestAuditlogImpl.clear();
+        rh.executePutRequest("/_opendistro/_security/api/account", "{\"password\":\"new-pass\", \"current_password\":\"curr-passs\"}");
+        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains(expectedRequestBody));
+
+        // test PUT internal users API
+        TestAuditlogImpl.clear();
+        rh.executePutRequest("/_opendistro/_security/api/internalusers/test1", "{\"password\":\"new-pass\", \"backend_roles\":[], \"attributes\": {}}");
+        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains(expectedRequestBody));
+
+        // test PATCH internal users API
+        TestAuditlogImpl.clear();
+        rh.executePatchRequest("/_opendistro/_security/api/internalusers/test1", "[{\"op\":\"add\", \"path\":\"/password\", \"value\": \"test-pass\"}]");
+        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains(expectedRequestBody));
+
+        // test PUT users API
+        TestAuditlogImpl.clear();
+        rh.executePutRequest("/_opendistro/_security/api/user/test2", "{\"password\":\"new-pass\", \"backend_roles\":[], \"attributes\": {}}");
+        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains(expectedRequestBody));
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Currently 3 APIs may contain plaintext passwords which may be audit logged
  - /_opendistro/_security/api/account
  - /_opendistro/_security/api/internalusers
  - /_opendistro/_security/api/user 
- Redact if any of the above requests contain request body (primarily PUT/PATCH) but want to consider possibility of customer accidentally supplying the plain text password for GET requests
- Replace with `__SENSITIVE__` so that customer knows some content is redacted 
- Added tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
