### PR TITLE
Add support for nested roles in OIDC config (e.g. keycloak roles (realm_access.roles))

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -231,14 +231,13 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
 
     @SuppressWarnings("unchecked")
     protected String[] extractRoles(final Claims claims) {
-    	// no roles key specified
+        String[] roles = new String[0];
+        // no roles key specified
     	if(rolesKey == null) {
-    		return new String[0];
+    		return roles;
     	}
 
-        String[] roles = new String[0];
     	Object rolesObject;
-
     	if (rolesKey.contains(".")){
     	    // try to get nested roles e.g. keycloak roles
             rolesObject = getNestedRoles(claims);
@@ -247,6 +246,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     	    rolesObject = claims.get(rolesKey, Object.class);
             if(rolesObject == null) {
                 log.warn("Failed to get roles from JWT claims with roles_key '{}'. Check if this key is correct and available in the JWT payload.", rolesKey);
+                return roles;
             } else {
                 roles = String.valueOf(rolesObject).split(",");
             }

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -230,7 +230,7 @@ public class HTTPJwtAuthenticatorTest {
 
     @Test
     public void testNestedRoles() throws Exception {
-        class NextedRoles implements Serializable {
+        class NestedRoles implements Serializable {
             private String[] roles = {"role1", "role2"};
 
             public String[] getRoles() {
@@ -250,7 +250,7 @@ public class HTTPJwtAuthenticatorTest {
         String jwsToken = Jwts.builder()
                 .setSubject("Leonard McCoy")
 
-                .claim("realm_access", new NextedRoles())
+                .claim("realm_access", new NestedRoles())
                 .signWith(SignatureAlgorithm.HS512, secretKey).compact();
 
         HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/security/issues/476
https://github.com/opendistro-for-elasticsearch/security/issues/551

*Description of changes:*

This should fix the problem of loading keycloak roles with OIDC.

After this PR the following setting is supported for nested JWT (`roles_key: realm_access.roles`):

```yaml
authc:
    openid_auth_domain:
        http_enabled: true
        transport_enabled: true
        order: 0
        http_authenticator:
        type: openid
        challenge: false
        config:
            subject_key: preferred_username
            roles_key: realm_access.roles
            openid_connect_url: https://my-keycloak-server.com:8443/auth/realms/demo/.well-known/openid-configuration
        authentication_backend:
        type: noop
```

This is a draft PR to get your opinion because I am new to opendistro I just wrote the code and the tests.
I still need to figure out how to run and how to debug the project. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
