### PR TITLE
Fix download and doc link in the package description

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,10 +46,10 @@ ospackage {
 
     license 'ASL-2.0'
     maintainer 'OpenDistro for Elasticsearch Team <opendistro@amazon.com>'
-    url 'https://opendistro.github.io/elasticsearch/downloads'
+    url 'https://opendistro.github.io/for-elasticsearch/downloads.html'
     summary '''
      Security plugin for OpenDistro for Elasticsearch. 
-     Reference documentation can be found at https://opendistro.github.io/elasticsearch/docs.
+     Reference documentation can be found at https://opendistro.github.io/for-elasticsearch-docs/.
      '''.stripIndent().replace('\n', ' ').trim()
 
     //TODO: Would be better if the install_demo_configuration.sh script is marked executable in the upstream plugin instead of running bash manually here


### PR DESCRIPTION
*Issue #, if available:*
A community user found a bug in the links stated in package descriptions. check the post [here](https://discuss.opendistrocommunity.dev/t/unable-to-setup-apt-repo-for-opendistro-in-our-org/3124)

*Description of changes:*
Fix the download and document link in package description. Not sure if it needs to be changed anywhere else in this repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
