### PR TITLE
Bump elasticsearch version to 7.9.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ ospackage {
     user 'root'
     permissionGroup 'root'
 
-    requires('elasticsearch-oss', "7.9.0", EQUAL)
+    requires('elasticsearch-oss', "7.9.1", EQUAL)
     packager = 'Amazon'
     vendor = 'Amazon'
     os = 'LINUX'

--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -22,4 +22,4 @@ java.version=1.8
 # elasticsearch release. This version is checked when the plugin
 # is loaded so Elasticsearch will refuse to start in the presence of
 # plugins with the incorrect elasticsearch.version.
-elasticsearch.version=7.9.0
+elasticsearch.version=7.9.1

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.release>8</maven.compiler.release>
 
-        <elasticsearch.version>7.9.0</elasticsearch.version>
+        <elasticsearch.version>7.9.1</elasticsearch.version>
 
         <!-- deps -->
         <netty-native.version>2.0.25.Final</netty-native.version>


### PR DESCRIPTION
*Description of changes:*
Update elasticsearch dependency to 7.9.1.

*Testing:*
Ran `OPENDISTRO_SECURITY_TEST_OPENSSL_OPT=true mvn -B test` (same as what the ci workflow does).

Test results: `Tests run: 926, Failures: 0, Errors: 0, Skipped: 28`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
