### PR TITLE
Bump to 1.10.1.0 and add release notes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 buildDir = 'gradle-build'
 
 ext {
-    opendistroVersion = '1.10.0'
+    opendistroVersion = '1.10.1'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 

--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -3,7 +3,7 @@
 description=Provide access control related features for Elasticsearch 7
 #
 # 'version': plugin's version
-version=1.10.0.0
+version=1.10.1.0
 #
 # 'name': the plugin name
 name=opendistro_security

--- a/release-notes/opendistro-for-elasticsearch-security.release-notes-1.10.1.0.md
+++ b/release-notes/opendistro-for-elasticsearch-security.release-notes-1.10.1.0.md
@@ -1,6 +1,6 @@
-## 2020-08-28 Version 1.10.0.0
+## 2020-09-09 Version 1.10.1.0
 
-Supported Elasticsearch version 7.9.0
+Support Elasticsearch version 7.9.1
 
 ### Enhancements
 
@@ -23,6 +23,7 @@ Supported Elasticsearch version 7.9.0
 
 ### Maintenance
 
+* Support ES 7.9.1 ([#706](https://github.com/opendistro-for-elasticsearch/security/pull/706))
 * Support ES 7.9.0 ([#661](https://github.com/opendistro-for-elasticsearch/security/pull/661))
 * Close AuditLog while closing OpenDistroSecurityPlugin and unregister shutdown hook when closing AuditLogImpl. ([#663](https://github.com/opendistro-for-elasticsearch/security/pull/663))
 * Fix unit tests failures in HTTPSamlAuthenticatorTest ([#664](https://github.com/opendistro-for-elasticsearch/security/pull/664))


### PR DESCRIPTION
*Description of changes:*
Update plugin version to 1.10.1.0 and add release notes.

*Testing:*
Ran OPENDISTRO_SECURITY_TEST_OPENSSL_OPT=true mvn -B test (same as what the ci workflow does).

Test results: Tests run: 926, Failures: 0, Errors: 0, Skipped: 28

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
