### PR TITLE
Validate resource names for config resources

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext.StoredContext;
@@ -177,8 +178,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 
 		final String name = request.param("name");
 
-		if (name == null || name.length() == 0) {
-			badRequestResponse(channel, "No " + getResourceName() + " specified.");
+		if (isResourceNameInvalid(channel, name)) {
 			return;
 		}
 
@@ -612,4 +612,16 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 		return true;
 	}
 
+	boolean isResourceNameInvalid(final RestChannel channel, final String resourceName) {
+		if (Strings.isNullOrEmpty(resourceName)) {
+			badRequestResponse(channel, "No " + getResourceName() + " specified.");
+			return true;
+		}
+
+		if (!ConfigConstants.OPENDISTRO_SECURITY_RESTAPI_RESOURCE_NAME_REGEX.matcher(resourceName).matches()) {
+			badRequestResponse(channel, "Resource name must contain only alphanumeric characters, underscores or hyphens.");
+			return true;
+		}
+		return false;
+	}
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -91,8 +91,7 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
 
         final String username = request.param("name");
 
-        if (username == null || username.length() == 0) {
-            badRequestResponse(channel, "No " + getResourceName() + " specified.");
+        if (isResourceNameInvalid(channel, username)) {
             return;
         }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
@@ -106,6 +106,10 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
 
     private void handleSinglePatch(RestChannel channel, RestRequest request, Client client, String name,
             SecurityDynamicConfiguration<?> existingConfiguration, ObjectNode existingAsObjectNode, JsonNode jsonPatch) throws IOException {
+        if (isResourceNameInvalid(channel, name)) {
+            return;
+        }
+
         if (isHidden(existingConfiguration, name)) {
             notFound(channel, getResourceName() + " " + name + " not found.");
             return;
@@ -190,6 +194,10 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
             JsonNode patchedResource = patchedAsJsonNode.get(resourceName);
 
             if (oldResource != null && !oldResource.equals(patchedResource)) {
+
+                if (isResourceNameInvalid(channel, resourceName)) {
+                    return;
+                }
 
                 if (isReadOnly(existingConfiguration, resourceName)) {
                     forbidden(channel, "Resource '" + resourceName + "' is read-only.");

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesMappingApiAction.java
@@ -65,8 +65,7 @@ public class RolesMappingApiAction extends PatchableResourceApiAction {
 	protected void handlePut(RestChannel channel, final RestRequest request, final Client client, final JsonNode content) throws IOException {
 		final String name = request.param("name");
 
-		if (name == null || name.length() == 0) {
-			badRequestResponse(channel, "No " + getResourceName() + " specified.");
+		if (isResourceNameInvalid(channel, name)) {
 			return;
 		}
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -236,6 +237,7 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_RESTAPI_ENDPOINTS_DISABLED = "opendistro_security.restapi.endpoints_disabled";
     public static final String OPENDISTRO_SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX = "opendistro_security.restapi.password_validation_regex";
     public static final String OPENDISTRO_SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE = "opendistro_security.restapi.password_validation_error_message";
+    public static final Pattern OPENDISTRO_SECURITY_RESTAPI_RESOURCE_NAME_REGEX = Pattern.compile("^[a-zA-Z0-9_-]+$"); // alphanumeric characters, underscores and hyphens
 
     // Illegal Opcodes from here on
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_DISABLE_REST_AUTH_INITIALLY = "opendistro_security.unsupported.disable_rest_auth_initially";

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/OpenDistroSecurityApiAccessTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/OpenDistroSecurityApiAccessTest.java
@@ -15,11 +15,20 @@
 
 package com.amazon.opendistroforelasticsearch.security.dlic.rest.api;
 
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper;
+import com.google.common.collect.ImmutableList;
 import org.apache.http.HttpStatus;
-import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class OpenDistroSecurityApiAccessTest extends AbstractRestApiUnitTest {
+
+	private static final List<String> BAD_RESOURCE_NAMES = ImmutableList.of("a&b", "test.html", "%3chtml%3e%3cscript%3etest123%3c%2fscript%3e%3c%2fhtml%3e");
+	private static final List<String> GOOD_RESOURCE_NAMES = ImmutableList.of("_", "-", "T", "t", "test", "TEST", "123", "T-e-S-t_1_2_3");
 
 	@Test
 	public void testRestApi() throws Exception {
@@ -27,9 +36,9 @@ public class OpenDistroSecurityApiAccessTest extends AbstractRestApiUnitTest {
 		setup();
 
 		// test with no cert, must fail
-		Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED,
+		assertEquals(HttpStatus.SC_UNAUTHORIZED,
 				rh.executeGetRequest("_opendistro/_security/api/internalusers").getStatusCode());
-		Assert.assertEquals(HttpStatus.SC_FORBIDDEN,
+		assertEquals(HttpStatus.SC_FORBIDDEN,
 				rh.executeGetRequest("_opendistro/_security/api/internalusers",
 						encodeBasicHeader("admin", "admin"))
 						.getStatusCode());
@@ -37,13 +46,75 @@ public class OpenDistroSecurityApiAccessTest extends AbstractRestApiUnitTest {
 		// test with non-admin cert, must fail
 		rh.keystore = "restapi/node-0-keystore.jks";
 		rh.sendAdminCertificate = true;
-		Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED,
+		assertEquals(HttpStatus.SC_UNAUTHORIZED,
 				rh.executeGetRequest("_opendistro/_security/api/internalusers").getStatusCode());
-		Assert.assertEquals(HttpStatus.SC_FORBIDDEN,
+		assertEquals(HttpStatus.SC_FORBIDDEN,
 				rh.executeGetRequest("_opendistro/_security/api/internalusers",
 						encodeBasicHeader("admin", "admin"))
 						.getStatusCode());
 
 	}
 
+	@Test
+	public void testResourceName() throws Exception {
+		setup();
+		rh.keystore = "restapi/kirk-keystore.jks";
+		rh.sendAdminCertificate = true;
+
+		for (String resourceName: BAD_RESOURCE_NAMES) {
+			// internal user api
+			validateBadResourceNameResponse(rh.executePutRequest("_opendistro/_security/api/internalusers/" + resourceName, "{\"password\": \"test\"}"));
+			validateBadResourceNameResponse(rh.executePutRequest("_opendistro/_security/api/user/" + resourceName, "{\"password\": \"test\"}"));
+			validateBadResourceNameResponse(rh.executePatchRequest("_opendistro/_security/api/internalusers/" + resourceName, "[{ \"op\": \"add\", \"path\": \"/password\", \"value\": \"test\" }]"));
+
+			// action group api
+			validateBadResourceNameResponse(rh.executePutRequest("_opendistro/_security/api/actiongroups/" + resourceName, "{\"allowed_actions\": []}"));
+			validateBadResourceNameResponse(rh.executePatchRequest("_opendistro/_security/api/actiongroups/" + resourceName, "[{ \"op\": \"add\", \"path\": \"/allowed_actions\", \"value\": [\"test\"] }]"));
+
+			// roles api
+			validateBadResourceNameResponse(rh.executePutRequest("_opendistro/_security/api/roles/" + resourceName, "{ \"cluster_permissions\": [\"*\"] }"));
+			validateBadResourceNameResponse(rh.executePatchRequest("_opendistro/_security/api/roles/" + resourceName, "[{ \"op\": \"add\", \"path\": \"/cluster_permissions\", \"value\": [\"*\"] }]"));
+
+			// roles mapping api
+			validateBadResourceNameResponse(rh.executePutRequest("_opendistro/_security/api/rolesmapping/" + resourceName, "{ \"backend_roles\": [\"test\"] }"));
+			validateBadResourceNameResponse(rh.executePatchRequest("_opendistro/_security/api/rolesmapping/" + resourceName, "[{ \"op\": \"add\", \"path\": \"/backend_roles\", \"value\": [\"test\"] }]"));
+
+			// tenants api
+			validateBadResourceNameResponse(rh.executePutRequest("_opendistro/_security/api/tenants/" + resourceName, "{\"description\": \"test\"}"));
+			validateBadResourceNameResponse(rh.executePatchRequest("_opendistro/_security/api/tenants/" + resourceName, "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"test\" }]"));
+		}
+
+		for (String resourceName: GOOD_RESOURCE_NAMES) {
+			// internal user api
+			validateSuccessResponse(rh.executePutRequest("_opendistro/_security/api/internalusers/" + resourceName, "{\"password\": \"test\"}"));
+			validateSuccessResponse(rh.executePutRequest("_opendistro/_security/api/user/" + resourceName, "{\"password\": \"test\"}"));
+			validateSuccessResponse(rh.executePatchRequest("_opendistro/_security/api/internalusers/" + resourceName, "[{ \"op\": \"add\", \"path\": \"/password\", \"value\": \"test\" }]"));
+
+			// action group api
+			validateSuccessResponse(rh.executePutRequest("_opendistro/_security/api/actiongroups/" + resourceName, "{\"allowed_actions\": []}"));
+			validateSuccessResponse(rh.executePatchRequest("_opendistro/_security/api/actiongroups/" + resourceName, "[{ \"op\": \"add\", \"path\": \"/allowed_actions\", \"value\": [\"test\"] }]"));
+
+			// roles api
+			validateSuccessResponse(rh.executePutRequest("_opendistro/_security/api/roles/" + resourceName, "{ \"cluster_permissions\": [\"*\"] }"));
+			validateSuccessResponse(rh.executePatchRequest("_opendistro/_security/api/roles/" + resourceName, "[{ \"op\": \"add\", \"path\": \"/cluster_permissions\", \"value\": [\"*\"] }]"));
+
+			// roles mapping api
+			validateSuccessResponse(rh.executePutRequest("_opendistro/_security/api/rolesmapping/" + resourceName, "{ \"backend_roles\": [\"test\"] }"));
+			validateSuccessResponse(rh.executePatchRequest("_opendistro/_security/api/rolesmapping/" + resourceName, "[{ \"op\": \"add\", \"path\": \"/backend_roles\", \"value\": [\"test\"] }]"));
+
+			// tenants api
+			validateSuccessResponse(rh.executePutRequest("_opendistro/_security/api/tenants/" + resourceName, "{\"description\": \"test\"}"));
+			validateSuccessResponse(rh.executePatchRequest("_opendistro/_security/api/tenants/" + resourceName, "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"test\" }]"));
+		}
+	}
+
+	private void validateBadResourceNameResponse(RestHelper.HttpResponse response) {
+		assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+		assertEquals("{\"status\":\"BAD_REQUEST\",\"message\":\"Resource name must contain only alphanumeric characters, underscores or hyphens.\"}", response.getBody());
+	}
+
+	private void validateSuccessResponse(RestHelper.HttpResponse response) {
+		int status = response.getStatusCode();
+		assertTrue(status == HttpStatus.SC_OK || status == HttpStatus.SC_CREATED);
+	}
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
@@ -367,7 +367,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         Assert.assertTrue(roles.contains("starfleet"));
         Assert.assertTrue(roles.contains("captains"));
 
-        addUserWithPassword("$1aAAAAAAAAC", "$1aAAAAAAAAC", HttpStatus.SC_CREATED);
+        addUserWithPassword("$1aAAAAAAAAC", "$1aAAAAAAAAC", HttpStatus.SC_BAD_REQUEST);
         addUserWithPassword("abc", "abc", HttpStatus.SC_CREATED);
 
 
@@ -431,7 +431,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         addUserWithPassword("$1aAAAAAAAac", "$1aAAAAAAAAC", HttpStatus.SC_BAD_REQUEST);
         addUserWithPassword(URLEncoder.encode("$1aAAAAAAAac%", "UTF-8"), "$1aAAAAAAAAC%", HttpStatus.SC_BAD_REQUEST);
         addUserWithPassword(URLEncoder.encode("$1aAAAAAAAac%!=\"/\\;:test&~@^", "UTF-8").replace("+", "%2B"), "$1aAAAAAAAac%!=\\\"/\\\\;:test&~@^", HttpStatus.SC_BAD_REQUEST);
-        addUserWithPassword(URLEncoder.encode("$1aAAAAAAAac%!=\"/\\;: test&", "UTF-8"), "$1aAAAAAAAac%!=\\\"/\\\\;: test&123", HttpStatus.SC_CREATED);
+        addUserWithPassword(URLEncoder.encode("$1aAAAAAAAac%!=\"/\\;: test&", "UTF-8"), "$1aAAAAAAAac%!=\\\"/\\\\;: test&123", HttpStatus.SC_BAD_REQUEST);
 
         response = rh.executeGetRequest("/_opendistro/_security/api/internalusers/nothinghthere?pretty", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
@@ -474,16 +474,16 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         Assert.assertEquals(56, settings.size());
 
         addUserWithPassword(".my.dotuser0", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m",
-                HttpStatus.SC_CREATED);
+                HttpStatus.SC_BAD_REQUEST);
 
         addUserWithPassword(".my.dot.user0", "12345678",
-                HttpStatus.SC_CREATED);
+                HttpStatus.SC_BAD_REQUEST);
 
         addUserWithHash(".my.dotuser1", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m",
-                HttpStatus.SC_CREATED);
+                HttpStatus.SC_BAD_REQUEST);
 
         addUserWithPassword(".my.dot.user2", "12345678",
-                HttpStatus.SC_CREATED);
+                HttpStatus.SC_BAD_REQUEST);
 
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Currently it is possible to create faulty resource names that may be used in API paths. For eg: `%3chtml%3e%3cscript%3etest123%3c%2fscript%3e%3c%2fhtml%3e`. This causes the UI also to render as HTML and API path cannot be recognized correctly (some actions like DELETE  won't work)
- Limit resource name creation to only alphanumeric characters, underscores or hyphens. 
- Avoid characters that may have special meaning in API paths or HTML

<img width="1609" alt="Screen Shot 2020-09-11 at 3 00 41 AM" src="https://user-images.githubusercontent.com/5506137/92908347-ff4edd00-f3da-11ea-909a-8c351a6780d0.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
