### PR TITLE
Change status code for hidden resources to NOT_FOUND and read-only sources to METHOD_NOT_ALLOWED

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
@@ -146,7 +146,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 
 		final SecurityDynamicConfiguration<?> existingConfiguration = load(getConfigName(), false);
 
-		if (isWriteable(channel, existingConfiguration, name)) {
+		if (!isWriteable(channel, existingConfiguration, name)) {
 			return;
 		}
 
@@ -183,7 +183,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 		    return;
 		}
 
-		if (isWriteable(channel, existingConfiguration, name)) {
+		if (!isWriteable(channel, existingConfiguration, name)) {
 			return;
 		}
 
@@ -607,14 +607,14 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 	boolean isWriteable(final RestChannel channel, final SecurityDynamicConfiguration<?> configuration, final String name) {
 		if (isHidden(configuration, name)) {
 			notFound(channel, "Resource '"+ name +"' is not available.");
-			return true;
+			return false;
 		}
 
 		if (isReadOnly(configuration, name)) {
             methodNotAllowed(channel, "Resource '"+ name +"' is read-only.");
-			return true;
+			return false;
 		}
 
-		return false;
+		return true;
 	}
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
@@ -15,7 +15,6 @@
 
 package com.amazon.opendistroforelasticsearch.security.dlic.rest.api;
 
-import com.amazon.opendistroforelasticsearch.security.DefaultObjectMapper;
 import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog;
 import com.amazon.opendistroforelasticsearch.security.configuration.AdminDNs;
 import com.amazon.opendistroforelasticsearch.security.configuration.ConfigurationRepository;
@@ -30,7 +29,6 @@ import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.SecurityJsonNode;
 import com.amazon.opendistroforelasticsearch.security.user.User;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.Client;
@@ -193,13 +191,7 @@ public class AccountApiAction extends AbstractApiAction {
             return;
         }
 
-        if (isHidden(internalUser, username)) {
-            forbidden(channel, "Resource '" + username + "' is not available.");
-            return;
-        }
-
-        if (isReadOnly(internalUser, username)) {
-            forbidden(channel, "Resource '" + username + "' is read-only.");
+        if (isWriteable(channel, internalUser, username)) {
             return;
         }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
@@ -191,7 +191,7 @@ public class AccountApiAction extends AbstractApiAction {
             return;
         }
 
-        if (isWriteable(channel, internalUser, username)) {
+        if (!isWriteable(channel, internalUser, username)) {
             return;
         }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -101,14 +101,7 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
 
         final SecurityDynamicConfiguration<?> internalUsersConfiguration = load(getConfigName(), false);
 
-        if (isHidden(internalUsersConfiguration, username)) {
-            forbidden(channel, "Resource '" + username + "' is not available.");
-            return;
-        }
-
-        // check if resource is writeable
-        if (isReadOnly(internalUsersConfiguration, username)) {
-            forbidden(channel, "Resource '" + username + "' is read-only.");
+        if (isWriteable(channel, internalUsersConfiguration, username)) {
             return;
         }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -101,7 +101,7 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
 
         final SecurityDynamicConfiguration<?> internalUsersConfiguration = load(getConfigName(), false);
 
-        if (isWriteable(channel, internalUsersConfiguration, username)) {
+        if (!isWriteable(channel, internalUsersConfiguration, username)) {
             return;
         }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
@@ -106,13 +106,8 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
 
     private void handleSinglePatch(RestChannel channel, RestRequest request, Client client, String name,
             SecurityDynamicConfiguration<?> existingConfiguration, ObjectNode existingAsObjectNode, JsonNode jsonPatch) throws IOException {
-        if (isHidden(existingConfiguration, name)) {
-            notFound(channel, getResourceName() + " " + name + " not found.");
-            return;
-        }
 
-        if (isReadOnly(existingConfiguration, name)) {
-            forbidden(channel, "Resource '" + name + "' is read-only.");
+        if (isWriteable(channel, existingConfiguration, name)) {
             return;
         }
 
@@ -189,17 +184,8 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
             JsonNode oldResource = existingAsObjectNode.get(resourceName);
             JsonNode patchedResource = patchedAsJsonNode.get(resourceName);
 
-            if (oldResource != null && !oldResource.equals(patchedResource)) {
-
-                if (isReadOnly(existingConfiguration, resourceName)) {
-                    forbidden(channel, "Resource '" + resourceName + "' is read-only.");
-                    return;
-                }
-
-                if (isHidden(existingConfiguration, resourceName)) {
-                    badRequestResponse(channel, "Resource name '" + resourceName + "' is reserved");
-                    return;
-                }
+            if (oldResource != null && !oldResource.equals(patchedResource) && isWriteable(channel, existingConfiguration, resourceName)) {
+                return;
             }
         }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
@@ -107,7 +107,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
     private void handleSinglePatch(RestChannel channel, RestRequest request, Client client, String name,
             SecurityDynamicConfiguration<?> existingConfiguration, ObjectNode existingAsObjectNode, JsonNode jsonPatch) throws IOException {
 
-        if (isWriteable(channel, existingConfiguration, name)) {
+        if (!isWriteable(channel, existingConfiguration, name)) {
             return;
         }
 
@@ -184,7 +184,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
             JsonNode oldResource = existingAsObjectNode.get(resourceName);
             JsonNode patchedResource = patchedAsJsonNode.get(resourceName);
 
-            if (oldResource != null && !oldResource.equals(patchedResource) && isWriteable(channel, existingConfiguration, resourceName)) {
+            if (oldResource != null && !oldResource.equals(patchedResource) && !isWriteable(channel, existingConfiguration, resourceName)) {
                 return;
             }
         }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
@@ -150,7 +150,7 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
         assertTrue(body.getAsBoolean("is_reserved", false));
         payload = "{\"password\":\"" + testPass + "\", \"current_password\":\"" + "sarek" + "\"}";
         response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader("sarek", "sarek"));
-        assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
         // test - hidden user - hide
         response = rh.executeGetRequest(ENDPOINT, encodeBasicHeader("hide", "hide"));
@@ -159,7 +159,7 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
         assertTrue(body.getAsBoolean("is_hidden", false));
         payload = "{\"password\":\"" + testPass + "\", \"current_password\":\"" + "hide" + "\"}";
         response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader("hide", "hide"));
-        assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // test - admin with admin cert - internal user does not exist
         rh.keystore = "restapi/kirk-keystore.jks";

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/ActionGroupsApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/ActionGroupsApiTest.java
@@ -324,19 +324,19 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
 
         // Delete read only actiongroups
         response = rh.executeDeleteRequest("/_opendistro/_security/api/actiongroups/create_index" , new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
         // Put read only actiongroups
         response = rh.executePutRequest("/_opendistro/_security/api/actiongroups/create_index", FileHelper.loadFile("restapi/actiongroup_crud.json"), new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
         // Patch single read only actiongroups
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups/create_index", "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
         // Patch multiple read only actiongroups
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups", "[{ \"op\": \"replace\", \"path\": \"/create_index/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
         response = rh.executeGetRequest("/_opendistro/_security/api/actiongroups/INTERNAL" , new Header[0]);
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
@@ -347,7 +347,7 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
 
         // Put hidden actiongroups
         response = rh.executePutRequest("/_opendistro/_security/api/actiongroups/INTERNAL", FileHelper.loadFile("restapi/actiongroup_crud.json"), new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // Patch hidden actiongroups
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups/INTERNAL", "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
@@ -355,7 +355,7 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
 
         // Patch multiple hidden actiongroups
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups", "[{ \"op\": \"replace\", \"path\": \"/INTERNAL/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/NodesDnApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/NodesDnApiTest.java
@@ -143,7 +143,7 @@ public class NodesDnApiTest extends AbstractRestApiUnitTest {
             rh.keystore = "restapi/kirk-keystore.jks";
             rh.sendAdminCertificate = true;
 
-            final int expectedStatus = HttpStatus.SC_FORBIDDEN;
+            final int expectedStatus = HttpStatus.SC_METHOD_NOT_ALLOWED;
 
             response = rh.executePutRequest("_opendistro/_security/api/nodesdn/" + NodesDnApiAction.STATIC_ES_YML_NODES_DN, "{\"nodes_dn\": [\"cn=popeye\"]}", nonAdminCredsHeader);
             assertThat(response.getBody(), response.getStatusCode(), equalTo(expectedStatus));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiTest.java
@@ -466,19 +466,19 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
         // Delete read only roles
         response = rh.executeDeleteRequest("/_opendistro/_security/api/roles/opendistro_security_transport_client" , new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
         // Put read only roles
         response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_transport_client", "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
         // Patch single read only roles
         response = rh.executePatchRequest("/_opendistro/_security/api/roles/opendistro_security_transport_client", "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
         // Patch multiple read only roles
         response = rh.executePatchRequest("/_opendistro/_security/api/roles/", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_transport_client/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
         // get hidden role
         response = rh.executeGetRequest("_opendistro/_security/api/roles/opendistro_security_internal");
@@ -490,7 +490,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
         // put hidden role
         response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_internal", "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // Patch single hidden roles
         response = rh.executePatchRequest("/_opendistro/_security/api/roles/opendistro_security_internal", "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
@@ -498,7 +498,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
         // Patch multiple hidden roles
         response = rh.executePatchRequest("/_opendistro/_security/api/roles/", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_internal/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesMappingApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesMappingApiTest.java
@@ -355,20 +355,20 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 
 		// Delete read only roles mapping
 		response = rh.executeDeleteRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_library" , new Header[0]);
-		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+		Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
 		// Put read only roles mapping
 		response = rh.executePutRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_library",
 				FileHelper.loadFile("restapi/rolesmapping_all_access.json"), new Header[0]);
-		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+		Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
 		// Patch single read only roles mapping
 		response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_role_starfleet_library", "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
-		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+		Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
 		// Patch multiple read only roles mapping
 		response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_role_starfleet_library/description\", \"value\": \"foo\" }]", new Header[0]);
-		Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+		Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
 		// GET, rolesmapping is hidden, allowed for super admin
 		response = rh.executeGetRequest("/_opendistro/_security/api/rolesmapping/opendistro_security_internal", new Header[0]);
@@ -389,7 +389,7 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 
 		// Patch multiple hidden roles mapping
 		response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_internal/description\", \"value\": \"foo\" }]", new Header[0]);
-		Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+		Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
 	}
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
@@ -530,19 +530,19 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 
         // Delete read only user
         response = rh.executeDeleteRequest("/_opendistro/_security/api/internalusers/sarek" , new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
         // Put read only users
         response = rh.executePutRequest("/_opendistro/_security/api/internalusers/sarek", "[{ \"op\": \"add\", \"path\": \"/sarek/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
         // Patch single read only user
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/sarek", "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
         // Patch multiple read only users
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/sarek/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
 
         // Get hidden role
         response = rh.executeGetRequest("/_opendistro/_security/api/internalusers/hide" , new Header[0]);
@@ -554,12 +554,12 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 
         // Put hidden users
         response = rh.executePutRequest("/_opendistro/_security/api/internalusers/hide", "[{ \"op\": \"add\", \"path\": \"/sarek/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // Put reserved role is forbidden for non-superadmin
         response = rh.executePutRequest("/_opendistro/_security/api/internalusers/nagilum", "{ \"opendistro_security_roles\": [\"opendistro_security_reserved\"]}",
             new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
         Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
         Assert.assertEquals(settings.get("message"), "Role 'opendistro_security_reserved' has read-only role-mapping.");
 
@@ -569,7 +569,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 
         // Patch multiple hidden users
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/hide/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Some places return NOT_FOUND (404) for hidden resource and other places return FORBIDDEN (403). Consolidate them to return NOT_FOUND for resources that not available as user may have authorization to perform the request and FORBIDDEN is not appropriate.

- Return METHOD_NOT_ALLOWED(405) when read-only resources are updated as user may have authorization to perform the request and FORBIDDEN is not appropriate

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
