### PR TITLE
Removing newline whitespace from metadata content

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
@@ -61,13 +61,9 @@ import org.opensaml.saml.metadata.resolver.impl.AbstractMetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.DOMMetadataResolver;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
-import java.io.StringReader;
 
 
 public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
@@ -427,7 +423,7 @@ public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
 
     private static Element getMetadataDOM(final String xmlString) throws IOException, SAXException, ParserConfigurationException {
         try {
-            Document doc = Util.loadXML(xmlString);
+            Document doc = Util.loadXML(xmlString.trim());
             return doc.getDocumentElement();
         } catch (Exception e) {
             log.error("Error while parsing SAML Metadata Body {}", xmlString, e);

--- a/src/test/resources/saml/metadata.xml
+++ b/src/test/resources/saml/metadata.xml
@@ -1,3 +1,4 @@
+
 <?xml version="1.0" encoding="UTF-8"?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://test.entity">
     <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
@@ -32,3 +33,4 @@
         <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://localhost:33667/saml/sso" />
     </md:IDPSSODescriptor>
 </md:EntityDescriptor>
+


### PR DESCRIPTION
*Issue #, if available:*
Currently if you set metadata xml content with a new line at the beginning of the file the security plugin is not able to read the XML content .

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.



Did the following test on master branch. Add lines to start and end of saml/metadata.xml, also lines in between tags.
Run 
```
mvn -Dtest=HTTPSamlAuthenticatorTest#testMetadataBody test
- Without trim (FAIL)
[ERROR] Errors: 
[ERROR] com.amazon.dlic.auth.http.saml.HTTPSamlAuthenticatorTest.testMetadataBody(com.amazon.dlic.auth.http.saml.HTTPSamlAuthenticatorTest)
[ERROR]   Run 1: HTTPSamlAuthenticatorTest.testMetadataBody:212 » Runtime java.lang.NullPointer...
[ERROR]   Run 2: HTTPSamlAuthenticatorTest.testMetadataBody:212 » Runtime java.lang.NullPointer...
[ERROR]   Run 3: HTTPSamlAuthenticatorTest.testMetadataBody:212 » Runtime java.lang.NullPointer...
[ERROR]   Run 4: HTTPSamlAuthenticatorTest.testMetadataBody:212 » Runtime java.lang.NullPointer...
[INFO] 

- With trim
[INFO] -------------------------------------------------------
[INFO] Running com.amazon.dlic.auth.http.saml.HTTPSamlAuthenticatorTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.928 s - in com.amazon.dlic.auth.http.saml.HTTPSamlAuthenticatorTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```