### PR TITLE
Consolidate writeable resource validation check

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractApiAction.java
@@ -146,13 +146,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 
 		final SecurityDynamicConfiguration<?> existingConfiguration = load(getConfigName(), false);
 
-		if (isHidden(existingConfiguration, name)) {
-			notFound(channel, getResourceName() + " " + name + " not found.");
-			return;
-		}
-
-		if (isReadOnly(existingConfiguration, name)) {
-			forbidden(channel, "Resource '"+ name +"' is read-only.");
+		if (!isWriteable(channel, existingConfiguration, name)) {
 			return;
 		}
 
@@ -189,13 +183,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 		    return;
 		}
 
-		if (isHidden(existingConfiguration, name)) {
-			forbidden(channel, "Resource '"+ name +"' is not available.");
-			return;
-		}
-
-		if (isReadOnly(existingConfiguration, name)) {
-			forbidden(channel, "Resource '"+ name +"' is read-only.");
+		if (!isWriteable(channel, existingConfiguration, name)) {
 			return;
 		}
 
@@ -600,16 +588,24 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 			return false;
 		}
 
-		if (isHidden(rolesConfiguration, role) || isHidden(rolesMappingConfiguration, role)) {
-			notFound(channel, "Role '"+role+"' is not available for role-mapping.");
+		if (isHidden(rolesConfiguration, role)) {
+			notFound(channel, "Role '" + role + "' is not available for role-mapping.");
 			return false;
 		}
 
-		if (isReadOnly(rolesMappingConfiguration, role)) {
-			forbidden(channel, "Role '" + role + "' has read-only role-mapping.");
+		return isWriteable(channel, rolesMappingConfiguration, role);
+	}
+
+	boolean isWriteable(final RestChannel channel, final SecurityDynamicConfiguration<?> configuration, final String resourceName) {
+		if (isHidden(configuration, resourceName)) {
+			notFound(channel, "Resource '" + resourceName + "' is not available.");
+			return false;
+		}
+
+		if (isReadOnly(configuration, resourceName)) {
+			forbidden(channel, "Resource '" + resourceName + "' is read-only.");
 			return false;
 		}
 		return true;
 	}
-
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiAction.java
@@ -193,13 +193,7 @@ public class AccountApiAction extends AbstractApiAction {
             return;
         }
 
-        if (isHidden(internalUser, username)) {
-            forbidden(channel, "Resource '" + username + "' is not available.");
-            return;
-        }
-
-        if (isReadOnly(internalUser, username)) {
-            forbidden(channel, "Resource '" + username + "' is read-only.");
+        if (!isWriteable(channel, internalUser, username)) {
             return;
         }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -101,14 +101,7 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
 
         final SecurityDynamicConfiguration<?> internalUsersConfiguration = load(getConfigName(), false);
 
-        if (isHidden(internalUsersConfiguration, username)) {
-            forbidden(channel, "Resource '" + username + "' is not available.");
-            return;
-        }
-
-        // check if resource is writeable
-        if (isReadOnly(internalUsersConfiguration, username)) {
-            forbidden(channel, "Resource '" + username + "' is read-only.");
+        if (!isWriteable(channel, internalUsersConfiguration, username)) {
             return;
         }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/PatchableResourceApiAction.java
@@ -106,13 +106,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
 
     private void handleSinglePatch(RestChannel channel, RestRequest request, Client client, String name,
             SecurityDynamicConfiguration<?> existingConfiguration, ObjectNode existingAsObjectNode, JsonNode jsonPatch) throws IOException {
-        if (isHidden(existingConfiguration, name)) {
-            notFound(channel, getResourceName() + " " + name + " not found.");
-            return;
-        }
-
-        if (isReadOnly(existingConfiguration, name)) {
-            forbidden(channel, "Resource '" + name + "' is read-only.");
+        if (!isWriteable(channel, existingConfiguration, name)) {
             return;
         }
 
@@ -189,17 +183,8 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
             JsonNode oldResource = existingAsObjectNode.get(resourceName);
             JsonNode patchedResource = patchedAsJsonNode.get(resourceName);
 
-            if (oldResource != null && !oldResource.equals(patchedResource)) {
-
-                if (isReadOnly(existingConfiguration, resourceName)) {
-                    forbidden(channel, "Resource '" + resourceName + "' is read-only.");
-                    return;
-                }
-
-                if (isHidden(existingConfiguration, resourceName)) {
-                    badRequestResponse(channel, "Resource name '" + resourceName + "' is reserved");
-                    return;
-                }
+            if (oldResource != null && !oldResource.equals(patchedResource) && !isWriteable(channel, existingConfiguration, resourceName)) {
+                return;
             }
         }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AccountApiTest.java
@@ -159,7 +159,7 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
         assertTrue(body.getAsBoolean("is_hidden", false));
         payload = "{\"password\":\"" + testPass + "\", \"current_password\":\"" + "hide" + "\"}";
         response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader("hide", "hide"));
-        assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // test - admin with admin cert - internal user does not exist
         rh.keystore = "restapi/kirk-keystore.jks";

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/ActionGroupsApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/ActionGroupsApiTest.java
@@ -347,7 +347,7 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
 
         // Put hidden actiongroups
         response = rh.executePutRequest("/_opendistro/_security/api/actiongroups/INTERNAL", FileHelper.loadFile("restapi/actiongroup_crud.json"), new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // Patch hidden actiongroups
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups/INTERNAL", "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
@@ -355,7 +355,7 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
 
         // Patch multiple hidden actiongroups
         response = rh.executePatchRequest("/_opendistro/_security/api/actiongroups", "[{ \"op\": \"replace\", \"path\": \"/INTERNAL/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesApiTest.java
@@ -490,7 +490,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
         // put hidden role
         response = rh.executePutRequest("/_opendistro/_security/api/roles/opendistro_security_internal", "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // Patch single hidden roles
         response = rh.executePatchRequest("/_opendistro/_security/api/roles/opendistro_security_internal", "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
@@ -498,7 +498,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
         // Patch multiple hidden roles
         response = rh.executePatchRequest("/_opendistro/_security/api/roles/", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_internal/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesMappingApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/RolesMappingApiTest.java
@@ -389,7 +389,7 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 
 		// Patch multiple hidden roles mapping
 		response = rh.executePatchRequest("/_opendistro/_security/api/rolesmapping", "[{ \"op\": \"add\", \"path\": \"/opendistro_security_internal/description\", \"value\": \"foo\" }]", new Header[0]);
-		Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+		Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
 	}
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/UserApiTest.java
@@ -554,14 +554,14 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 
         // Put hidden users
         response = rh.executePutRequest("/_opendistro/_security/api/internalusers/hide", "[{ \"op\": \"add\", \"path\": \"/sarek/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
         // Put reserved role is forbidden for non-superadmin
         response = rh.executePutRequest("/_opendistro/_security/api/internalusers/nagilum", "{ \"opendistro_security_roles\": [\"opendistro_security_reserved\"]}",
             new Header[0]);
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
         Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals(settings.get("message"), "Role 'opendistro_security_reserved' has read-only role-mapping.");
+        Assert.assertEquals(settings.get("message"), "Resource 'opendistro_security_reserved' is read-only.");
 
         // Patch single hidden user
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers/hide", "[{ \"op\": \"add\", \"path\": \"/description\", \"value\": \"foo\" }]", new Header[0]);
@@ -569,7 +569,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 
         // Patch multiple hidden users
         response = rh.executePatchRequest("/_opendistro/_security/api/internalusers", "[{ \"op\": \"add\", \"path\": \"/hide/description\", \"value\": \"foo\" }]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
 
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Change status of hidden resources to NOT_FOUND
- Currently some places return NOT_FOUND, FORBIDDEN and also BAD_REQUEST for hidden resources.
- Consolidate all resource writeable validation checks
- Update tests

Using components from previous PR https://github.com/opendistro-for-elasticsearch/security/pull/716 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
