### PR TITLE
Redact BCrypt security config internal hashes from audit logs

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditMessage.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/impl/AuditMessage.java
@@ -29,7 +29,9 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.config.AuditConfig;
+import com.amazon.opendistroforelasticsearch.security.securityconf.impl.CType;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.elasticsearch.ExceptionsHelper;
@@ -59,6 +61,11 @@ public final class AuditMessage {
     private static final String SENSITIVE_KEY = "password";
     private static final String SENSITIVE_REPLACEMENT_VALUE = "__SENSITIVE__";
     private static final Pattern SENSITIVE_PATHS = Pattern.compile("/_opendistro/_security/api/(account.*|internalusers.*|user.*)");
+    @VisibleForTesting
+    public static final Pattern BCRYPT_HASH = Pattern.compile("\\$2[ayb]\\$.{56}");
+    private static final String BCRYPT_HASH_REPLACEMENT_VALUE = "__HASH__";
+    private static final String INTERNALUSERS_DOC_ID = CType.INTERNALUSERS.toLCString();
+
     public static final String FORMAT_VERSION = "audit_format_version";
     public static final String CATEGORY = "audit_category";
     public static final String REQUEST_EFFECTIVE_USER = "audit_request_effective_user";
@@ -185,6 +192,10 @@ public final class AuditMessage {
         }
     }
 
+    void addSecurityConfigWriteDiffSource(final String diff, final String id) {
+        addComplianceWriteDiffSource(redactSecurityConfigContent(diff, id));
+    }
+
 //    public void addComplianceWriteStoredFields0(String diff) {
 //        if (diff != null && !diff.isEmpty()) {
 //            auditInfo.put(COMPLIANCE_STORED_FIELDS_CONTENT, diff);
@@ -202,7 +213,7 @@ public final class AuditMessage {
         }
     }
 
-    public void addMapToRequestBody(Map<String, Object> map) {
+    public void addMapToRequestBody(Map<String, ?> map) {
         if(map != null) {
             auditInfo.put(REQUEST_BODY, Utils.convertStructuredMapToJson(map));
         }
@@ -211,6 +222,36 @@ public final class AuditMessage {
     public void addUnescapedJsonToRequestBody(String source) {
         if (source != null) {
             auditInfo.put(REQUEST_BODY, source);
+        }
+    }
+
+    private String redactSecurityConfigContent(String content, String id) {
+        if (content != null && INTERNALUSERS_DOC_ID.equals(id)) {
+            content = BCRYPT_HASH.matcher(content).replaceAll(BCRYPT_HASH_REPLACEMENT_VALUE);
+        }
+        return content;
+    }
+
+    void addSecurityConfigContentToRequestBody(final String source, final String id) {
+        if (source != null) {
+            final String redactedContent = redactSecurityConfigContent(source, id);
+            auditInfo.put(REQUEST_BODY, redactedContent);
+        }
+    }
+
+    void addSecurityConfigTupleToRequestBody(final Tuple<XContentType, BytesReference> xContentTuple, final String id) {
+        if (xContentTuple != null) {
+            try {
+                addSecurityConfigContentToRequestBody(XContentHelper.convertToJson(xContentTuple.v2(), false, xContentTuple.v1()), id);
+            } catch (Exception e) {
+                auditInfo.put(REQUEST_BODY, "ERROR: Unable to convert to json");
+            }
+        }
+    }
+
+    void addSecurityConfigMapToRequestBody(final Map<String, ?> map, final String id) {
+        if (map != null) {
+            addSecurityConfigContentToRequestBody(Utils.convertStructuredMapToJson(map), id);
         }
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/support/Utils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/support/Utils.java
@@ -71,7 +71,7 @@ public class Utils {
         }
     }
 
-    public static BytesReference convertStructuredMapToBytes(Map<String, Object> structuredMap) {
+    private static BytesReference convertStructuredMapToBytes(Map<String, ?> structuredMap) {
         try {
             return BytesReference.bytes(JsonXContent.contentBuilder().map(structuredMap));
         } catch (IOException e) {
@@ -79,7 +79,7 @@ public class Utils {
         }
     }
 
-    public static String convertStructuredMapToJson(Map<String, Object> structuredMap) {
+    public static String convertStructuredMapToJson(Map<String, ?> structuredMap) {
         try {
             return XContentHelper.convertToJson(convertStructuredMapToBytes(structuredMap), false, XContentType.JSON);
         } catch (IOException e) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- BCrypt hashes of internal users may be considered sensitive
- If auditing security index and doc is internalusers then redact all BCrypt hashes with `__HASH__` 
- Added separate methods for adding request body for security index configs as check is already done and not penalizing non security config logs 
- Changed type of convertStructuredMapToBytes to `Map<String, ?>` as used by Elasticsearch
- Updated tests 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
