### PR TITLE
Fix IllegalStateException that is raised when AuditLogImpl.close() is called from ES Bootstrap shutdown hook.

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/routing/AuditMessageRouter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auditlog/routing/AuditMessageRouter.java
@@ -91,6 +91,7 @@ public class AuditMessageRouter {
     }
 
     public final void close() {
+        log.info("Closing {}", getClass().getSimpleName());
         // shutdown storage pool
         storagePool.close();
         // close default


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
