### PR TITLE
When replacing .kibana index with multi-tenant index, create index with alias if one already does not exist

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -767,7 +767,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
         evaluator = new PrivilegesEvaluator(clusterService, threadPool, cr, resolver, auditLog,
                 settings, privilegesInterceptor, cih, irr, advancedModulesEnabled);
 
-        odsf = new OpenDistroSecurityFilter(settings, evaluator, adminDns, dlsFlsValve, auditLog, threadPool, cs, compatConfig, irr);
+        odsf = new OpenDistroSecurityFilter(localClient, settings, evaluator, adminDns, dlsFlsValve, auditLog, threadPool, cs, compatConfig, irr);
 
         final String principalExtractorClass = settings.get(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_PRINCIPAL_EXTRACTOR_CLASS, null);
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/PrivilegesInterceptorImpl.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/PrivilegesInterceptorImpl.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.security.configuration;
 
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -23,6 +24,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.IndicesRequest.Replaceable;
+import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsIndexRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRequest;
@@ -40,6 +42,8 @@ import org.elasticsearch.action.termvectors.MultiTermVectorsRequest;
 import org.elasticsearch.action.termvectors.TermVectorsRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexAbstraction;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -49,10 +53,15 @@ import com.amazon.opendistroforelasticsearch.security.resolver.IndexResolverRepl
 import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfigModel;
 import com.amazon.opendistroforelasticsearch.security.user.User;
 
+import com.google.common.collect.ImmutableMap;
+
 public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
 
     private static final String USER_TENANT = "__user__";
     private static final String EMPTY_STRING = "";
+    private static final Map<String, Object> KIBANA_INDEX_SETTINGS = ImmutableMap.of(
+            IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1
+    );
 
     protected final Logger log = LogManager.getLogger(this.getClass());
 
@@ -88,13 +97,13 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
      *
      */
     @Override
-    public Boolean replaceKibanaIndex(final ActionRequest request, final String action, final User user, final DynamicConfigModel config,
+    public ReplaceResult replaceKibanaIndex(final ActionRequest request, final String action, final User user, final DynamicConfigModel config,
                                       final Resolved requestedResolved, final Map<String, Boolean> tenants) {
 
         final boolean enabled = config.isKibanaMultitenancyEnabled();//config.dynamic.kibana.multitenancy_enabled;
 
         if (!enabled) {
-            return null;
+            return CONTINUE_EVALUATION_REPLACE_RESULT;
         }
 
         //next two lines needs to be retrieved from configuration
@@ -116,10 +125,10 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
             }
 
             if (kibanaIndexOnly && !isTenantAllowed(request, action, user, tenants, "global_tenant")) {
-                return Boolean.TRUE;
+                return ACCESS_DENIED_REPLACE_RESULT;
             }
 
-            return null;
+            return CONTINUE_EVALUATION_REPLACE_RESULT;
         }
 
         if (USER_TENANT.equals(requestedTenant)) {
@@ -132,13 +141,13 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
         }
 
         //request not made by the kibana server and user index is the only index/alias involved
-        if (!user.getName().equals(kibanaserverUsername) && requestedResolved.getAllIndices().size() == 1
-                && requestedResolved.getAllIndices().contains(toUserIndexName(kibanaIndexName, requestedTenant))) {
-
-            if (isTenantAllowed(request, action, user, tenants, requestedTenant)) {
-                return Boolean.FALSE;
+        if (!user.getName().equals(kibanaserverUsername)) {
+            final Set<String> indices = requestedResolved.getAllIndices();
+            final String tenantIndexName = toUserIndexName(kibanaIndexName, requestedTenant);
+            if (indices.size() == 1 && indices.iterator().next().startsWith(tenantIndexName) &&
+                    isTenantAllowed(request, action, user, tenants, requestedTenant)) {
+                    return ACCESS_GRANTED_REPLACE_RESULT;
             }
-
         }
 
         //intercept when requests are not made by the kibana server and if the kibana index/alias (.kibana) is the only index/alias involved
@@ -150,15 +159,15 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
             }
 
             if (!isTenantAllowed(request, action, user, tenants, requestedTenant)) {
-                return Boolean.TRUE;
+                return ACCESS_DENIED_REPLACE_RESULT;
             }
 
             // TODO handle user tenant in that way that this tenant cannot be specified as
             // regular tenant
             // to avoid security issue
 
-            replaceIndex(request, kibanaIndexName, toUserIndexName(kibanaIndexName, requestedTenant), action);
-            return Boolean.FALSE;
+            final String tenantIndexName = toUserIndexName(kibanaIndexName, requestedTenant);
+            return newAccessGrantedReplaceResult(replaceIndex(request, kibanaIndexName, tenantIndexName, action));
 
         } else if (!user.getName().equals(kibanaserverUsername)) {
 
@@ -170,18 +179,30 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
 
         }
 
+        return CONTINUE_EVALUATION_REPLACE_RESULT;
+    }
+
+    private CreateIndexRequest checkAndCreateRequestIfAbsent(final String name) {
+        final IndexAbstraction indexAbstraction = clusterService.state().getMetadata().getIndicesLookup().get(name);
+        if (indexAbstraction == null) {
+            return new CreateIndexRequest(name + "_1")
+                    .settings(KIBANA_INDEX_SETTINGS)
+                    .alias(new Alias(name));
+        }
+        log.debug("{} {} already exists", indexAbstraction.getType(), indexAbstraction.getName());
         return null;
     }
 
-    private void replaceIndex(final ActionRequest request, final String oldIndexName, final String newIndexName, final String action) {
+    private CreateIndexRequest replaceIndex(final ActionRequest request, final String oldIndexName, final String newIndexName, final String action) {
         boolean kibOk = false;
+        CreateIndexRequest createIndexRequest = null;
 
         if (log.isDebugEnabled()) {
             log.debug("{} index will be replaced with {} in this {} request", oldIndexName, newIndexName, request.getClass().getName());
         }
 
         if (request instanceof GetFieldMappingsIndexRequest || request instanceof GetFieldMappingsRequest) {
-            return;
+            return createIndexRequest;
         }
 
         //handle msearch and mget
@@ -192,7 +213,7 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
 
         // CreateIndexRequest
         if (request instanceof CreateIndexRequest) {
-            ((CreateIndexRequest) request).index(newIndexName);
+            ((CreateIndexRequest) request).index(newIndexName + "_1").alias(new Alias(newIndexName));
             kibOk = true;
         } else if (request instanceof BulkRequest) {
 
@@ -203,6 +224,7 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
                 }
 
                 if (ar instanceof IndexRequest) {
+                    createIndexRequest = checkAndCreateRequestIfAbsent(newIndexName);
                     ((IndexRequest) ar).index(newIndexName);
                 }
 
@@ -240,6 +262,7 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
             ((UpdateRequest) request).index(newIndexName);
             kibOk = true;
         } else if (request instanceof IndexRequest) {
+            createIndexRequest = checkAndCreateRequestIfAbsent(newIndexName);
             ((IndexRequest) request).index(newIndexName);
             kibOk = true;
         } else if (request instanceof DeleteRequest) {
@@ -265,6 +288,7 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
         if (!kibOk) {
             log.warn("Dont know what to do (2) with {}", request.getClass());
         }
+        return createIndexRequest;
     }
 
     private String toUserIndexName(final String originalKibanaIndex, final String tenant) {
@@ -276,8 +300,12 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
         return originalKibanaIndex + "_" + tenant.hashCode() + "_" + tenant.toLowerCase().replaceAll("[^a-z0-9]+", EMPTY_STRING);
     }
 
-    private boolean resolveToKibanaIndexOrAlias(final Resolved requestedResolved, final String kibanaIndexName) {
-        return (requestedResolved.getAllIndices().size() == 1 && requestedResolved.getAllIndices().contains(kibanaIndexName))
-                || (requestedResolved.getAliases().size() == 1 && requestedResolved.getAliases().contains(kibanaIndexName));
+    private static boolean resolveToKibanaIndexOrAlias(final Resolved requestedResolved, final String kibanaIndexName) {
+        final Set<String> allIndices = requestedResolved.getAllIndices();
+        if (allIndices.size() == 1 && allIndices.iterator().next().equals(kibanaIndexName)) {
+            return true;
+        }
+        final Set<String> aliases = requestedResolved.getAliases();
+        return (aliases.size() == 1 && aliases.iterator().next().equals(kibanaIndexName));
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/PrivilegesInterceptorImpl.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/PrivilegesInterceptorImpl.java
@@ -61,7 +61,7 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
 
     private static final String USER_TENANT = "__user__";
     private static final String EMPTY_STRING = "";
-    private static final String SUFFIX = "_1";
+    private static final String KIBANA_INDEX_SUFFIX = "_1";
     private static final Map<String, Object> KIBANA_INDEX_SETTINGS = ImmutableMap.of(
             IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1,
             IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1"
@@ -188,7 +188,7 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
 
     private CreateIndexRequest newCreateIndexRequestIfAbsent(final String name) {
         final Map<String, IndexAbstraction> indicesLookup = clusterService.state().getMetadata().getIndicesLookup();
-        final String concreteName = name.concat(SUFFIX);
+        final String concreteName = name.concat(KIBANA_INDEX_SUFFIX);
         if (Arrays.stream(new String[]{name, concreteName})
                 .map(s -> indicesLookup.get(s))
                 .filter(Objects::nonNull)
@@ -220,7 +220,7 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
         // CreateIndexRequest
         if (request instanceof CreateIndexRequest) {
             // use new name for alias and suffixed index name
-            ((CreateIndexRequest) request).index(newIndexName.concat(SUFFIX)).alias(new Alias(newIndexName));
+            ((CreateIndexRequest) request).index(newIndexName.concat(KIBANA_INDEX_SUFFIX)).alias(new Alias(newIndexName));
             kibOk = true;
         } else if (request instanceof BulkRequest) {
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
@@ -36,7 +36,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
@@ -255,20 +254,20 @@ public class PrivilegesEvaluator {
 
                     if(privilegesInterceptor.getClass() != PrivilegesInterceptor.class) {
 
-                        final Boolean replaceResult = privilegesInterceptor.replaceKibanaIndex(request, action0, user, dcm, requestedResolved,
+                        final PrivilegesInterceptor.ReplaceResult replaceResult = privilegesInterceptor.replaceKibanaIndex(request, action0, user, dcm, requestedResolved,
                                 mapTenants(user, mappedRoles));
 
                         if(log.isDebugEnabled()) {
                             log.debug("Result from privileges interceptor for cluster perm: {}", replaceResult);
                         }
 
-                        if (replaceResult == Boolean.TRUE) {
-                            auditLog.logMissingPrivileges(action0, request, task);
-                            return presponse;
-                        }
-
-                        if (replaceResult == Boolean.FALSE) {
-                            presponse.allowed = true;
+                        if (!replaceResult.continueEvaluation) {
+                            if (replaceResult.accessDenied) {
+                                auditLog.logMissingPrivileges(action0, request, task);
+                            } else {
+                                presponse.allowed = true;
+                                presponse.request = replaceResult.createIndexRequest;
+                            }
                             return presponse;
                         }
                     }
@@ -338,19 +337,19 @@ public class PrivilegesEvaluator {
 
         if(privilegesInterceptor.getClass() != PrivilegesInterceptor.class) {
 
-            final Boolean replaceResult = privilegesInterceptor.replaceKibanaIndex(request, action0, user, dcm, requestedResolved, mapTenants(user, mappedRoles));
+            final PrivilegesInterceptor.ReplaceResult replaceResult = privilegesInterceptor.replaceKibanaIndex(request, action0, user, dcm, requestedResolved, mapTenants(user, mappedRoles));
 
             if(log.isDebugEnabled()) {
                 log.debug("Result from privileges interceptor: {}", replaceResult);
             }
 
-            if (replaceResult == Boolean.TRUE) {
-                auditLog.logMissingPrivileges(action0, request, task);
-                return presponse;
-            }
-
-            if (replaceResult == Boolean.FALSE) {
-                presponse.allowed = true;
+            if (!replaceResult.continueEvaluation) {
+                if (replaceResult.accessDenied) {
+                    auditLog.logMissingPrivileges(action0, request, task);
+                } else {
+                    presponse.allowed = true;
+                    presponse.request = replaceResult.createIndexRequest;
+                }
                 return presponse;
             }
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluatorResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluatorResponse.java
@@ -30,6 +30,8 @@
 
 package com.amazon.opendistroforelasticsearch.security.privileges;
 
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -41,6 +43,7 @@ public class PrivilegesEvaluatorResponse {
     Map<String,Set<String>> maskedFields;
     Map<String,Set<String>> queries;
     PrivilegesEvaluatorResponseState state = PrivilegesEvaluatorResponseState.PENDING;
+    CreateIndexRequest request;
     
     public boolean isAllowed() {
         return allowed;
@@ -59,6 +62,10 @@ public class PrivilegesEvaluatorResponse {
 
     public Map<String,Set<String>> getQueries() {
         return queries;
+    }
+
+    public CreateIndexRequest getRequest() {
+        return request;
     }
     
     public PrivilegesEvaluatorResponse markComplete() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesInterceptor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesInterceptor.java
@@ -33,6 +33,7 @@ package com.amazon.opendistroforelasticsearch.security.privileges;
 import java.util.Map;
 
 import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -44,6 +45,25 @@ import com.amazon.opendistroforelasticsearch.security.securityconf.DynamicConfig
 import com.amazon.opendistroforelasticsearch.security.user.User;
 
 public class PrivilegesInterceptor {
+
+    public static class ReplaceResult {
+        final boolean continueEvaluation;
+        final boolean accessDenied;
+        final CreateIndexRequest createIndexRequest;
+
+        private ReplaceResult(boolean continueEvaluation, boolean accessDenied, CreateIndexRequest createIndexRequest) {
+            this.continueEvaluation = continueEvaluation;
+            this.accessDenied = accessDenied;
+            this.createIndexRequest = createIndexRequest;
+        }
+    }
+
+    public static final ReplaceResult CONTINUE_EVALUATION_REPLACE_RESULT = new ReplaceResult(true, false, null);
+    public static final ReplaceResult ACCESS_DENIED_REPLACE_RESULT = new ReplaceResult(false, true, null);
+    public static final ReplaceResult ACCESS_GRANTED_REPLACE_RESULT = new ReplaceResult(false, false, null);
+    protected static ReplaceResult newAccessGrantedReplaceResult(CreateIndexRequest createIndexRequest) {
+        return new ReplaceResult(false, false, createIndexRequest);
+    }
 
     protected final IndexNameExpressionResolver resolver;
     protected final ClusterService clusterService;
@@ -58,7 +78,7 @@ public class PrivilegesInterceptor {
         this.threadPool = threadPool;
     }
 
-    public Boolean replaceKibanaIndex(final ActionRequest request, final String action, final User user, final DynamicConfigModel config,
+    public ReplaceResult replaceKibanaIndex(final ActionRequest request, final String action, final User user, final DynamicConfigModel config,
                                       final Resolved requestedResolved, final Map<String, Boolean> tenants) {
         throw new RuntimeException("not implemented");
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilterTest.java
@@ -24,6 +24,8 @@ import com.amazon.opendistroforelasticsearch.security.resolver.IndexResolverRepl
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 import com.google.common.collect.ImmutableSet;
+
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -66,6 +68,7 @@ public class OpenDistroSecurityFilterTest {
     @Test
     public void testImmutableIndicesWildcardMatcher() {
         final OpenDistroSecurityFilter filter = new OpenDistroSecurityFilter(
+                mock(Client.class),
                 settings,
                 mock(PrivilegesEvaluator.class),
                 mock(AdminDNs.class),


### PR DESCRIPTION
*Description of changes:* Create explicit `CreateIndexRequest` if index or alias does not exist instead of relying on auto index create ES functionality.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
