### PR TITLE
Fix missing trim when parsing roles in proxy authenticator

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/http/HTTPProxyAuthenticator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/http/HTTPProxyAuthenticator.java
@@ -45,6 +45,7 @@ import org.elasticsearch.rest.RestRequest;
 import com.amazon.opendistroforelasticsearch.security.auth.HTTPAuthenticator;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.user.AuthCredentials;
+import com.google.common.base.Predicates;
 
 public class HTTPProxyAuthenticator implements HTTPAuthenticator {
 
@@ -79,9 +80,8 @@ public class HTTPProxyAuthenticator implements HTTPAuthenticator {
             String[] backendRoles = null;
 
             if (!Strings.isNullOrEmpty(rolesHeader) && !Strings.isNullOrEmpty((String) request.header(rolesHeader))) {
-                String roles = (String) request.header(rolesHeader);
                 backendRoles = rolesSeparator
-                        .splitAsStream(roles)
+                        .splitAsStream((String) request.header(rolesHeader))
                         .map(String::trim)
                         .filter(Predicates.not(String::isEmpty))
                         .toArray(String[]::new);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/http/HTTPProxyAuthenticator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/http/HTTPProxyAuthenticator.java
@@ -31,7 +31,7 @@
 package com.amazon.opendistroforelasticsearch.security.http;
 
 import java.nio.file.Path;
-import java.util.stream.Stream;
+import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -79,7 +79,11 @@ public class HTTPProxyAuthenticator implements HTTPAuthenticator {
 
             if (!Strings.isNullOrEmpty(rolesHeader) && !Strings.isNullOrEmpty((String) request.header(rolesHeader))) {
                 String roles = (String) request.header(rolesHeader);
-                backendRoles = Stream.of(roles.split(rolesSeparator)).map(String::trim).toArray(String[]::new);
+                backendRoles = Pattern.compile(rolesSeparator)
+                        .splitAsStream(roles)
+                        .map(String::trim)
+                        .filter(role -> !Strings.isNullOrEmpty(role))
+                        .toArray(String[]::new);
             }
             return new AuthCredentials((String) request.header(userHeader), backendRoles).markComplete();
         } else {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/http/HTTPProxyAuthenticator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/http/HTTPProxyAuthenticator.java
@@ -31,6 +31,7 @@
 package com.amazon.opendistroforelasticsearch.security.http;
 
 import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -77,7 +78,8 @@ public class HTTPProxyAuthenticator implements HTTPAuthenticator {
             String[] backendRoles = null;
 
             if (!Strings.isNullOrEmpty(rolesHeader) && !Strings.isNullOrEmpty((String) request.header(rolesHeader))) {
-                backendRoles = ((String) request.header(rolesHeader)).split(rolesSeparator);
+                String roles = (String) request.header(rolesHeader);
+                backendRoles = Stream.of(roles.split(rolesSeparator)).map(String::trim).toArray(String[]::new);
             }
             return new AuthCredentials((String) request.header(userHeader), backendRoles).markComplete();
         } else {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/http/HTTPProxyAuthenticator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/http/HTTPProxyAuthenticator.java
@@ -50,10 +50,12 @@ public class HTTPProxyAuthenticator implements HTTPAuthenticator {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
     private volatile Settings settings;
+    private final Pattern rolesSeparator;
 
     public HTTPProxyAuthenticator(Settings settings, final Path configPath) {
         super();
         this.settings = settings;
+        this.rolesSeparator =  Pattern.compile(settings.get("roles_separator", ","));
     }
 
     @Override
@@ -65,7 +67,6 @@ public class HTTPProxyAuthenticator implements HTTPAuthenticator {
         
         final String userHeader = settings.get("user_header");
         final String rolesHeader = settings.get("roles_header");
-        final String rolesSeparator = settings.get("roles_separator", ",");
         
         if(log.isDebugEnabled()) {
             log.debug("headers {}", request.getHeaders());
@@ -79,10 +80,10 @@ public class HTTPProxyAuthenticator implements HTTPAuthenticator {
 
             if (!Strings.isNullOrEmpty(rolesHeader) && !Strings.isNullOrEmpty((String) request.header(rolesHeader))) {
                 String roles = (String) request.header(rolesHeader);
-                backendRoles = Pattern.compile(rolesSeparator)
+                backendRoles = rolesSeparator
                         .splitAsStream(roles)
                         .map(String::trim)
-                        .filter(role -> !Strings.isNullOrEmpty(role))
+                        .filter(role -> !"".equals(role))
                         .toArray(String[]::new);
             }
             return new AuthCredentials((String) request.header(userHeader), backendRoles).markComplete();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/http/HTTPProxyAuthenticator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/http/HTTPProxyAuthenticator.java
@@ -83,7 +83,7 @@ public class HTTPProxyAuthenticator implements HTTPAuthenticator {
                 backendRoles = rolesSeparator
                         .splitAsStream(roles)
                         .map(String::trim)
-                        .filter(role -> !"".equals(role))
+                        .filter(Predicates.not(String::isEmpty))
                         .toArray(String[]::new);
             }
             return new AuthCredentials((String) request.header(userHeader), backendRoles).markComplete();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/http/proxy/HTTPExtendedProxyAuthenticatorTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/http/proxy/HTTPExtendedProxyAuthenticatorTest.java
@@ -29,8 +29,8 @@
  */
 package com.amazon.opendistroforelasticsearch.security.http.proxy;
 
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -125,7 +125,7 @@ public class HTTPExtendedProxyAuthenticatorTest {
     	headers.put("user", new ArrayList<>());
         headers.put("roles", new ArrayList<>());
         headers.get("user").add("aValidUser");
-        headers.get("roles").add("role1, role2");
+        headers.get("roles").add("role1, role2,\t");
         
         settings = Settings.builder().put(settings)
              .put("roles_header","roles")

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/http/proxy/HTTPExtendedProxyAuthenticatorTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/http/proxy/HTTPExtendedProxyAuthenticatorTest.java
@@ -36,7 +36,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +55,6 @@ import org.elasticsearch.rest.RestStatus;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.amazon.opendistroforelasticsearch.security.http.proxy.HTTPExtendedProxyAuthenticator;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.user.AuthCredentials;
 import com.google.common.collect.ImmutableSet;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/http/proxy/HTTPExtendedProxyAuthenticatorTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/http/proxy/HTTPExtendedProxyAuthenticatorTest.java
@@ -29,8 +29,6 @@
  */
 package com.amazon.opendistroforelasticsearch.security.http.proxy;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -38,6 +36,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +59,7 @@ import org.junit.Test;
 import com.amazon.opendistroforelasticsearch.security.http.proxy.HTTPExtendedProxyAuthenticator;
 import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.user.AuthCredentials;
+import com.google.common.collect.ImmutableSet;
 
 public class HTTPExtendedProxyAuthenticatorTest {
 
@@ -135,7 +135,7 @@ public class HTTPExtendedProxyAuthenticatorTest {
         AuthCredentials creds = authenticator.extractCredentials(new TestRestRequest(headers), context);
         assertNotNull(creds);
         assertEquals("aValidUser", creds.getUsername());
-        assertThat(creds.getBackendRoles(), contains("role1", "role2"));
+        assertEquals(ImmutableSet.of("role1", "role2"), creds.getBackendRoles());
         assertTrue(creds.isComplete());
     }
 


### PR DESCRIPTION
Fix missing trim when parsing roles in proxy authenticator


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
