### PR TITLE
Change CD workflow to use new staging bucket for artifacts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,11 +50,25 @@ jobs:
 
     - name: Upload Artifacts to S3
       run: |
-        s3_path=s3://artifacts.opendistroforelasticsearch.amazon.com/downloads
-        aws s3 cp artifacts/*.zip $s3_path/elasticsearch-plugins/opendistro-security/
-        aws s3 cp artifacts/*.deb $s3_path/debs/opendistro-security/
-        aws s3 cp artifacts/*.rpm $s3_path/rpms/opendistro-security/
-        aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths '/downloads/*'
+        zip=`ls artifacts/*.zip`
+        rpm=`ls artifacts/*.rpm`
+        deb=`ls artifacts/*.deb`
+
+        # Inject the build number before the suffix
+        zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+        rpm_outfile=`basename ${rpm%.rpm}-build-${GITHUB_RUN_NUMBER}.rpm`
+        deb_outfile=`basename ${deb%.deb}-build-${GITHUB_RUN_NUMBER}.deb`
+
+        s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshot/elasticsearch-plugins/security/"
+
+        echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
+        aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}
+
+        echo "Copying ${rpm} to ${s3_prefix}${rpm_outfile}"
+        aws s3 cp --quiet $rpm ${s3_prefix}${rpm_outfile}
+
+        echo "Copying ${deb} to ${s3_prefix}${deb_outfile}"
+        aws s3 cp --quiet $deb ${s3_prefix}${deb_outfile}
 
     - name: Upload Artifacts to Maven Central
       env:


### PR DESCRIPTION
*Description of changes:*
The infrastructure team is separating the production and staging locations into different AWS accounts. Plugins need to modify their workflows to publish to the new locations.

This PR changes the CD workflow to add a build number and write the zip, deb, and rpm plugin artifacts to staging.artifacts.opendistroforelasticsearch.amazon.com. The write to S3 currently fails (see https://github.com/camerski/security/actions/runs/305148456) because the secrets have not been updated; the secrets will be updated at the same time this PR is merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
