### PR TITLE
Demo config for plugins security and default alerting roles

### DIFF
--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -29,11 +29,11 @@ alerting_ack_alerts:
 alerting_full_access:
   reserved: true
   cluster_permissions:
-    - "cluster_monitor"
+    - 'cluster_monitor'
     - 'cluster:admin/opendistro/alerting/*'
   index_permissions:
     - index_patterns:
-    - '*'
+        - '*'
       allowed_actions:
         - 'indices_monitor'
         - 'indices:admin/aliases/get'

--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -10,30 +10,31 @@ kibana_read_only:
 security_rest_api_access:
   reserved: true
  
-# Allows users to view alerts
-alerting_view_alerts:
+# Allows users to view monitors, destinations and alerts
+alerting_read_access:
   reserved: true
-  index_permissions:
-    - index_patterns:
-      - ".opendistro-alerting-alert*"
-      allowed_actions:
-        - read 
+  cluster_permissions:
+    - 'cluster:admin/opendistro/alerting/alerts/get'
+    - 'cluster:admin/opendistro/alerting/destination/get'
+    - 'cluster:admin/opendistro/alerting/monitor/get'
+    - 'cluster:admin/opendistro/alerting/monitor/search'
 
 # Allows users to view and acknowledge alerts
-alerting_crud_alerts:
+alerting_ack_alerts:
   reserved: true
-  index_permissions:
-    - index_patterns:
-      - ".opendistro-alerting-alert*"
-      allowed_actions:
-       - crud 
+  cluster_permissions:
+    - 'cluster:admin/opendistro/alerting/alerts/*'
 
 # Allows users to use all alerting functionality
 alerting_full_access:
   reserved: true
+  cluster_permissions:
+    - "cluster_monitor"
+    - 'cluster:admin/opendistro/alerting/*'
   index_permissions:
     - index_patterns:
-      - ".opendistro-alerting-config"
-      - ".opendistro-alerting-alert*"
+    - '*'
       allowed_actions:
-        - crud 
+        - 'indices_monitor'
+        - 'indices:admin/aliases/get'
+        - 'indices:admin/mappings/get'

--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -372,6 +372,8 @@ echo "opendistro_security.audit.type: internal_elasticsearch" | $SUDO_CMD tee -a
 echo "opendistro_security.enable_snapshot_restore_privilege: true" | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 echo "opendistro_security.check_snapshot_restore_write_privileges: true" | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 echo 'opendistro_security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
+echo 'opendistro_security.system_indices.enabled: true' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
+echo 'opendistro_security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*"]' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 
 #cluster.routing.allocation.disk.threshold_enabled
 if $SUDO_CMD grep --quiet -i "^cluster.routing.allocation.disk.threshold_enabled" "$ES_CONF_FILE"; then


### PR DESCRIPTION
*Issue #, if available:*
 For https://github.com/opendistro-for-elasticsearch/alerting/issues/6

*Description of changes:*
1. Add alerting plugin config and alerts indices to `system_indices`
2. Add default alerting roles



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
