### PR TITLE
Demo Config : Adding AD Indices to system index and creating pre-defined roles

### DIFF
--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -40,15 +40,16 @@ alerting_full_access:
         - 'indices:admin/mappings/get'
 
 # Allow users to read Anomaly Detection detectors and results
-ad_read_access:
+anomaly_read_access:
   reserved: true
   cluster_permissions:
+    - 'cluster:admin/opendistro/ad/detector/info'
     - 'cluster:admin/opendistro/ad/detector/search'
     - 'cluster:admin/opendistro/ad/detectors/get'
     - 'cluster:admin/opendistro/ad/result/search'
 
 # Allows users to use all Anomaly Detection functionality
-ad_full_access:
+anomaly_full_access:
   reserved: true
   cluster_permissions:
     - 'cluster_monitor'

--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -38,3 +38,25 @@ alerting_full_access:
         - 'indices_monitor'
         - 'indices:admin/aliases/get'
         - 'indices:admin/mappings/get'
+
+# Allow users to read Anomaly Detection detectors and results
+ad_read_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/opendistro/ad/detector/search'
+    - 'cluster:admin/opendistro/ad/detectors/get'
+    - 'cluster:admin/opendistro/ad/result/search'
+
+# Allows users to use all Anomaly Detection functionality
+ad_full_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster_monitor'
+    - 'cluster:admin/opendistro/ad/*'
+  index_permissions:
+    - index_patterns:
+        - '*'
+      allowed_actions:
+        - 'indices_monitor'
+        - 'indices:admin/aliases/get'
+        - 'indices:admin/mappings/get'

--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -373,7 +373,7 @@ echo "opendistro_security.enable_snapshot_restore_privilege: true" | $SUDO_CMD t
 echo "opendistro_security.check_snapshot_restore_write_privileges: true" | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 echo 'opendistro_security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 echo 'opendistro_security.system_indices.enabled: true' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
-echo 'opendistro_security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*"]' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
+echo 'opendistro_security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results", ".opendistro-anomaly-detector*"]' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 
 #cluster.routing.allocation.disk.threshold_enabled
 if $SUDO_CMD grep --quiet -i "^cluster.routing.allocation.disk.threshold_enabled" "$ES_CONF_FILE"; then

--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -373,7 +373,7 @@ echo "opendistro_security.enable_snapshot_restore_privilege: true" | $SUDO_CMD t
 echo "opendistro_security.check_snapshot_restore_write_privileges: true" | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 echo 'opendistro_security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 echo 'opendistro_security.system_indices.enabled: true' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
-echo 'opendistro_security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results", ".opendistro-anomaly-detector*"]' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
+echo 'opendistro_security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*"]' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 
 #cluster.routing.allocation.disk.threshold_enabled
 if $SUDO_CMD grep --quiet -i "^cluster.routing.allocation.disk.threshold_enabled" "$ES_CONF_FILE"; then

--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -373,7 +373,7 @@ echo "opendistro_security.enable_snapshot_restore_privilege: true" | $SUDO_CMD t
 echo "opendistro_security.check_snapshot_restore_write_privileges: true" | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 echo 'opendistro_security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 echo 'opendistro_security.system_indices.enabled: true' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
-echo 'opendistro_security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*"]' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
+echo 'opendistro_security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state"]' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 
 #cluster.routing.allocation.disk.threshold_enabled
 if $SUDO_CMD grep --quiet -i "^cluster.routing.allocation.disk.threshold_enabled" "$ES_CONF_FILE"; then


### PR DESCRIPTION
*Issue https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/195*

*Description of changes:*
Moving AD indices to system index and defining pre-defined roles for Anomaly Detection plugin users.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
