### PR TITLE
Adding SSL dual mode support for SSLOnly

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -61,7 +61,6 @@ import com.amazon.opendistroforelasticsearch.security.configuration.OpenDistroSe
 import com.amazon.opendistroforelasticsearch.security.configuration.Salt;
 import com.amazon.opendistroforelasticsearch.security.ssl.rest.OpenDistroSecuritySSLReloadCertsAction;
 import com.amazon.opendistroforelasticsearch.security.ssl.rest.OpenDistroSecuritySSLCertsInfoAction;
-
 import com.amazon.opendistroforelasticsearch.security.ssl.transport.OpenDistroSSLConfig;
 import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.search.Weight;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -61,6 +61,8 @@ import com.amazon.opendistroforelasticsearch.security.configuration.OpenDistroSe
 import com.amazon.opendistroforelasticsearch.security.configuration.Salt;
 import com.amazon.opendistroforelasticsearch.security.ssl.rest.OpenDistroSecuritySSLReloadCertsAction;
 import com.amazon.opendistroforelasticsearch.security.ssl.rest.OpenDistroSecuritySSLCertsInfoAction;
+
+import com.amazon.opendistroforelasticsearch.security.ssl.transport.OpenDistroSSLConfig;
 import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.search.Weight;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -194,7 +196,6 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
     private volatile Client localClient;
     private final boolean disabled;
     private final boolean advancedModulesEnabled;
-    private final boolean sslOnly;
     private final List<String> demoCertHashes = new ArrayList<String>(3);
     private volatile OpenDistroSecurityFilter odsf;
     private volatile IndexResolverReplacer irr;
@@ -207,7 +208,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
     }
 
     private final SslExceptionHandler evaluateSslExceptionHandler() {
-        if (client || tribeNodeClient || disabled || sslOnly) {
+        if (client || tribeNodeClient || disabled || openDistroSSLConfig.isSslOnlyMode()) {
             return new SslExceptionHandler(){};
         }
 
@@ -218,10 +219,6 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
         return settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_DISABLED, false);
     }
     
-    private static boolean isSslOnlyMode(final Settings settings) {
-        return settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_SSL_ONLY, false);
-    }
-
     /**
      * SSL Cert Reload will be enabled only if security is not disabled and not in we are not using sslOnly mode.
      * @param settings Elastic configuration settings
@@ -241,14 +238,12 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
             this.tribeNodeClient = false;
             this.dlsFlsAvailable = false;
             this.advancedModulesEnabled = false;
-            this.sslOnly = false;
             this.sslCertReloadEnabled = false;
             log.warn("Open Distro Security plugin installed but disabled. This can expose your configuration (including passwords) to the public.");
             return;
         }
         
-        sslOnly = isSslOnlyMode(settings);
-        if(sslOnly) {
+        if (openDistroSSLConfig.isSslOnlyMode()) {
             this.tribeNodeClient = false;
             this.dlsFlsAvailable = false;
             this.advancedModulesEnabled = false;
@@ -452,7 +447,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
 
             handlers.addAll(super.getRestHandlers(settings, restController, clusterSettings, indexScopedSettings, settingsFilter, indexNameExpressionResolver, nodesInCluster));
 
-            if(!sslOnly) {
+            if(!openDistroSSLConfig.isSslOnlyMode()) {
                 handlers.add(new OpenDistroSecurityInfoAction(settings, restController, Objects.requireNonNull(evaluator), Objects.requireNonNull(threadPool)));
                 handlers.add(new KibanaInfoAction(settings, restController, Objects.requireNonNull(evaluator), Objects.requireNonNull(threadPool)));
                 handlers.add(new OpenDistroSecurityHealthAction(settings, restController, Objects.requireNonNull(backendRegistry)));
@@ -476,7 +471,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
     @Override
     public UnaryOperator<RestHandler> getRestHandlerWrapper(final ThreadContext threadContext) {
 
-        if(client || disabled || sslOnly) {
+        if(client || disabled || openDistroSSLConfig.isSslOnlyMode()) {
             return (rh) -> rh;
         }
 
@@ -486,7 +481,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> actions = new ArrayList<>(1);
-        if(!tribeNodeClient && !disabled && !sslOnly) {
+        if(!tribeNodeClient && !disabled && !openDistroSSLConfig.isSslOnlyMode()) {
             actions.add(new ActionHandler<>(ConfigUpdateAction.INSTANCE, TransportConfigUpdateAction.class));
             actions.add(new ActionHandler<>(WhoAmIAction.INSTANCE, TransportWhoAmIAction.class));
         }
@@ -497,7 +492,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
     public void onIndexModule(IndexModule indexModule) {
         //called for every index!
 
-        if (!disabled && !client && !sslOnly) {
+        if (!disabled && !client && !openDistroSSLConfig.isSslOnlyMode()) {
             log.debug("Handle dlsFlsAvailable: "+dlsFlsAvailable+"/auditLog="+auditLog.getClass()+" for onIndexModule() of index "+indexModule.getIndex().getName());
             if (dlsFlsAvailable) {
 
@@ -600,7 +595,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
     @Override
     public List<ActionFilter> getActionFilters() {
         List<ActionFilter> filters = new ArrayList<>(1);
-        if (!tribeNodeClient && !client && !disabled && !sslOnly) {
+        if (!tribeNodeClient && !client && !disabled && !openDistroSSLConfig.isSslOnlyMode()) {
             filters.add(Objects.requireNonNull(odsf));
         }
         return filters;
@@ -610,7 +605,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
     public List<TransportInterceptor> getTransportInterceptors(NamedWriteableRegistry namedWriteableRegistry, ThreadContext threadContext) {
         List<TransportInterceptor> interceptors = new ArrayList<TransportInterceptor>(1);
 
-        if (!client && !tribeNodeClient && !disabled && !sslOnly) {
+        if (!client && !tribeNodeClient && !disabled && !openDistroSSLConfig.isSslOnlyMode()) {
             interceptors.add(new TransportInterceptor() {
 
                 @Override
@@ -656,14 +651,14 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
             NamedWriteableRegistry namedWriteableRegistry, NetworkService networkService) {
         Map<String, Supplier<Transport>> transports = new HashMap<String, Supplier<Transport>>();
         
-        if(sslOnly) {
+        if(openDistroSSLConfig.isSslOnlyMode()) {
             return super.getTransports(settings, threadPool, pageCacheRecycler, circuitBreakerService, namedWriteableRegistry, networkService);
         }
         
         if (transportSSLEnabled) {
             transports.put("com.amazon.opendistroforelasticsearch.security.ssl.http.netty.OpenDistroSecuritySSLNettyTransport",
                     () -> new OpenDistroSecuritySSLNettyTransport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry,
-                            circuitBreakerService, odsks, evaluateSslExceptionHandler()));
+                            circuitBreakerService, odsks, evaluateSslExceptionHandler(), openDistroSSLConfig));
         }
         return transports;
     }
@@ -673,7 +668,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
             CircuitBreakerService circuitBreakerService, NamedWriteableRegistry namedWriteableRegistry,
             NamedXContentRegistry xContentRegistry, NetworkService networkService, Dispatcher dispatcher) {
 
-        if(sslOnly) {
+        if(openDistroSSLConfig.isSslOnlyMode()) {
             return super.getHttpTransports(settings, threadPool, bigArrays, circuitBreakerService, namedWriteableRegistry, xContentRegistry, networkService, dispatcher);
         }
         
@@ -705,7 +700,8 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
             ResourceWatcherService resourceWatcherService, ScriptService scriptService, NamedXContentRegistry xContentRegistry,
             Environment environment, NodeEnvironment nodeEnvironment, NamedWriteableRegistry namedWriteableRegistry) {
 
-        if(sslOnly) {
+        openDistroSSLConfig.registerClusterSettingsChangeListener(clusterService.getClusterSettings());
+        if(openDistroSSLConfig.isSslOnlyMode()) {
             return super.createComponents(localClient, clusterService, threadPool, resourceWatcherService, scriptService, xContentRegistry, environment, nodeEnvironment, namedWriteableRegistry);
         }
         
@@ -822,7 +818,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
 
         builder.put(super.additionalSettings());
 
-        if(!sslOnly){
+        if(!openDistroSSLConfig.isSslOnlyMode()){
           builder.put(NetworkModule.TRANSPORT_TYPE_KEY, "com.amazon.opendistroforelasticsearch.security.ssl.http.netty.OpenDistroSecuritySSLNettyTransport");
           builder.put(NetworkModule.HTTP_TYPE_KEY, "com.amazon.opendistroforelasticsearch.security.http.OpenDistroSecurityHttpServerTransport");
         }
@@ -835,12 +831,15 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
         
         settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_SSL_ONLY, false, Property.NodeScope, Property.Filtered));
 
+        // currently dual mode is supported only when ssl_only is enabled, but this stance would change in future
+        settings.add(OpenDistroSSLConfig.SSL_DUAL_MODE_SETTING);
+
         // Protected index settings
         settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ENABLED_KEY, ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ENABLED_DEFAULT, Property.NodeScope, Property.Filtered, Property.Final));
         settings.add(Setting.listSetting(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_KEY, ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_DEFAULT, Function.identity(), Property.NodeScope, Property.Filtered, Property.Final));
         settings.add(Setting.listSetting(ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ROLES_KEY, ConfigConstants.OPENDISTRO_SECURITY_PROTECTED_INDICES_ROLES_DEFAULT, Function.identity(), Property.NodeScope, Property.Filtered, Property.Final));
 
-        if(!sslOnly) {
+        if(!openDistroSSLConfig.isSslOnlyMode()) {
             settings.add(Setting.listSetting(ConfigConstants.OPENDISTRO_SECURITY_AUTHCZ_ADMIN_DN, Collections.emptyList(), Function.identity(), Property.NodeScope)); //not filtered here
     
             settings.add(Setting.simpleString(ConfigConstants.OPENDISTRO_SECURITY_CONFIG_INDEX_NAME, Property.NodeScope, Property.Filtered));
@@ -1005,7 +1004,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
     @Override
     public Collection<Class<? extends LifecycleComponent>> getGuiceServiceClasses() {
 
-        if (client || tribeNodeClient || disabled || sslOnly) {
+        if (client || tribeNodeClient || disabled || openDistroSSLConfig.isSslOnlyMode()) {
             return Collections.emptyList();
         }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/OpenDistroSecuritySSLPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/OpenDistroSecuritySSLPlugin.java
@@ -31,6 +31,7 @@
 package com.amazon.opendistroforelasticsearch.security.ssl;
 
 import com.amazon.opendistroforelasticsearch.security.DefaultObjectMapper;
+import com.amazon.opendistroforelasticsearch.security.ssl.transport.OpenDistroSSLConfig;
 import com.fasterxml.jackson.databind.InjectableValues;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.util.internal.PlatformDependent;
@@ -107,6 +108,7 @@ public class OpenDistroSecuritySSLPlugin extends Plugin implements ActionPlugin,
     protected PrincipalExtractor principalExtractor;
     protected final Path configPath;
     private final static SslExceptionHandler NOOP_SSL_EXCEPTION_HANDLER = new SslExceptionHandler() {};
+    protected final OpenDistroSSLConfig openDistroSSLConfig;
     
     public OpenDistroSecuritySSLPlugin(final Settings settings, final Path configPath) {
         this(settings, configPath, false);
@@ -121,6 +123,7 @@ public class OpenDistroSecuritySSLPlugin extends Plugin implements ActionPlugin,
             this.transportSSLEnabled = false;
             this.odsks = null;
             this.configPath = null;
+            openDistroSSLConfig = new OpenDistroSSLConfig(false, false);
             
             AccessController.doPrivileged(new PrivilegedAction<Object>() {
                 @Override
@@ -133,7 +136,7 @@ public class OpenDistroSecuritySSLPlugin extends Plugin implements ActionPlugin,
             
             return;
         }
-        
+        openDistroSSLConfig = new OpenDistroSSLConfig(settings);
         this.configPath = configPath;
         
         if(this.configPath != null) {
@@ -267,7 +270,8 @@ public class OpenDistroSecuritySSLPlugin extends Plugin implements ActionPlugin,
         Map<String, Supplier<Transport>> transports = new HashMap<String, Supplier<Transport>>();
         if (transportSSLEnabled) {
             transports.put("com.amazon.opendistroforelasticsearch.security.ssl.http.netty.OpenDistroSecuritySSLNettyTransport", 
-                    () -> new OpenDistroSecuritySSLNettyTransport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, odsks, NOOP_SSL_EXCEPTION_HANDLER));
+                    () -> new OpenDistroSecuritySSLNettyTransport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, odsks, NOOP_SSL_EXCEPTION_HANDLER,
+                        openDistroSSLConfig));
 
         }
         return transports;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/DualModeSSLHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/DualModeSSLHandler.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.opendistroforelasticsearch.security.ssl.transport;
+
+
+import com.amazon.opendistroforelasticsearch.security.ssl.OpenDistroSecurityKeyStore;
+import com.amazon.opendistroforelasticsearch.security.ssl.util.SSLConnectionTestUtil;
+import com.amazon.opendistroforelasticsearch.security.ssl.util.TLSUtil;
+import com.google.common.annotations.VisibleForTesting;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.ssl.SslHandler;
+import java.nio.charset.StandardCharsets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.net.ssl.SSLException;
+import java.util.List;
+
+/**
+ * Modifies the current pipeline dynamically to enable TLS
+ */
+public class DualModeSSLHandler extends ByteToMessageDecoder {
+
+    private static final Logger logger = LogManager.getLogger(DualModeSSLHandler.class);
+    private final OpenDistroSecurityKeyStore openDistroSecurityKeyStore;
+
+    private final SslHandler providedSSLHandler;
+
+    public DualModeSSLHandler(OpenDistroSecurityKeyStore openDistroSecurityKeyStore) {
+        this(openDistroSecurityKeyStore, null);
+    }
+
+    @VisibleForTesting
+    protected DualModeSSLHandler(OpenDistroSecurityKeyStore openDistroSecurityKeyStore, SslHandler providedSSLHandler) {
+        this.openDistroSecurityKeyStore = openDistroSecurityKeyStore;
+        this.providedSSLHandler = providedSSLHandler;
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+        // Will use the first six bytes to detect a protocol.
+        if (in.readableBytes() < 6) {
+            return;
+        }
+        int offset = in.readerIndex();
+        if (in.getCharSequence(offset, 6, StandardCharsets.UTF_8).equals(SSLConnectionTestUtil.DUAL_MODE_CLIENT_HELLO_MSG)) {
+            logger.debug("Received DualSSL Client Hello message");
+            ByteBuf responseBuffer = Unpooled.buffer(6);
+            responseBuffer.writeCharSequence(SSLConnectionTestUtil.DUAL_MODE_SERVER_HELLO_MSG, StandardCharsets.UTF_8);
+            ctx.writeAndFlush(responseBuffer).addListener(ChannelFutureListener.CLOSE);
+            return;
+        }
+
+        if (TLSUtil.isTLS(in)) {
+            logger.debug("Identified request as SSL request");
+            enableSsl(ctx);
+        } else {
+            logger.debug("Identified request as non SSL request, running in HTTP mode as dual mode is enabled");
+            ctx.pipeline().remove(this);
+        }
+    }
+
+    private void enableSsl(ChannelHandlerContext ctx) throws SSLException {
+        SslHandler sslHandler;
+        if (providedSSLHandler != null) {
+            sslHandler = providedSSLHandler;
+        } else {
+            sslHandler = new SslHandler(openDistroSecurityKeyStore.createServerTransportSSLEngine());
+        }
+        ChannelPipeline p = ctx.pipeline();
+        p.addAfter("port_unification_handler", "ssl_server", sslHandler);
+        p.remove(this);
+        logger.debug("Removed port unification handler and added SSL handler as incoming request is SSL");
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/OpenDistroSSLConfig.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/OpenDistroSSLConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.ssl.transport;
+
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+
+public class OpenDistroSSLConfig {
+
+    public static final Setting<Boolean> SSL_DUAL_MODE_SETTING = Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED,
+            false, Setting.Property.NodeScope, Setting.Property.Dynamic); // Not filtered
+
+    private static final Logger logger = LogManager.getLogger(OpenDistroSSLConfig.class);
+
+    private final boolean sslOnly;
+    private volatile boolean dualModeEnabled;
+
+    public OpenDistroSSLConfig(final boolean sslOnly, final boolean dualModeEnabled) {
+        this.sslOnly = sslOnly;
+        this.dualModeEnabled = dualModeEnabled;
+        if (this.dualModeEnabled && !this.sslOnly) {
+            logger.warn("opendistro_security_config.ssl_dual_mode_enabled is enabled but opendistro_security.ssl_only mode is disabled. "
+                + "SSL Dual mode is supported only when security plugin is in ssl_only mode");
+        }
+        logger.info("SSL dual mode is {}", isDualModeEnabled() ? "enabled" : "disabled");
+    }
+
+    public OpenDistroSSLConfig(final Settings settings) {
+        this(settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_SSL_ONLY, false),
+            settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED, false));
+    }
+
+    public void registerClusterSettingsChangeListener(final ClusterSettings clusterSettings) {
+        clusterSettings.addSettingsUpdateConsumer(SSL_DUAL_MODE_SETTING,
+            dualModeEnabledClusterSetting -> {
+                logger.info("Detected change in settings, cluster setting for SSL dual mode is {}", dualModeEnabledClusterSetting ? "enabled" : "disabled");
+                setDualModeEnabled(dualModeEnabledClusterSetting);
+            });
+    }
+
+    private void setDualModeEnabled(boolean dualModeEnabled) {
+        this.dualModeEnabled = dualModeEnabled;
+    }
+
+    public boolean isDualModeEnabled() {
+        // currently dual mode can be enabled only when SSLOnly is enabled. This stance can change in future.
+        return sslOnly && dualModeEnabled;
+    }
+
+    public boolean isSslOnlyMode() {
+        return sslOnly;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/util/SSLConnectionTestResult.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/util/SSLConnectionTestResult.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.ssl.util;
+
+/**
+ * Return codes for SSLConnectionTestUtil.testConnection()
+ */
+public enum SSLConnectionTestResult {
+    /**
+     * ES Ping to the server failed.
+     */
+    ES_PING_FAILED,
+    /**
+     * Server does not support SSL.
+     */
+    SSL_NOT_AVAILABLE,
+    /**
+     * Server supports SSL.
+     */
+    SSL_AVAILABLE
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/util/SSLConnectionTestUtil.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/util/SSLConnectionTestUtil.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.ssl.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Utility class to test if the server supports SSL connections.
+ * SSL Check will be done by sending an ES Ping to see if server is replying to pings.
+ * Following that a custom client hello message will be sent to the server, if the server
+ * side has OpenDistroPortUnificationHandler it will reply with server hello message.
+ */
+public class SSLConnectionTestUtil {
+
+    private static final Logger logger = LogManager.getLogger(SSLConnectionTestUtil.class);
+    public static final byte[] ES_PING_MSG = new byte[]{(byte) 'E', (byte) 'S', (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
+    public static final String DUAL_MODE_CLIENT_HELLO_MSG = "DUALCM";
+    public static final String DUAL_MODE_SERVER_HELLO_MSG = "DUALSM";
+    private static final int SOCKET_TIMEOUT_MILLIS = 10 * 1000;
+    private boolean esPingReplyReceived;
+    private boolean dualSSLProbeReplyReceived;
+    private final String host;
+    private final int port;
+    private Socket overriddenSocket = null;
+    private OutputStreamWriter testOutputStreamWriter = null;
+    private InputStreamReader testInputStreamReader = null;
+
+    public SSLConnectionTestUtil(final String host, final int port) {
+        this.host = host;
+        this.port = port;
+        esPingReplyReceived = false;
+        dualSSLProbeReplyReceived = false;
+    }
+
+    @VisibleForTesting
+    protected SSLConnectionTestUtil(final String host, final int port, final Socket overriddenSocket, final OutputStreamWriter testOutputStreamWriter,
+        final InputStreamReader testInputStreamReader) {
+        this.overriddenSocket = overriddenSocket;
+        this.testOutputStreamWriter = testOutputStreamWriter;
+        this.testInputStreamReader = testInputStreamReader;
+
+        this.host = host;
+        this.port = port;
+        esPingReplyReceived = false;
+        dualSSLProbeReplyReceived = false;
+    }
+
+    /**
+     * Test connection to server by performing the below steps:
+     * - Send Client Hello to check if the server replies with Server Hello which indicates that Server understands SSL
+     * - Send ES Ping to check if the server replies to the ES Ping message
+     *
+     * @return SSLConnectionTestResult i.e. ES_PING_FAILED or SSL_NOT_AVAILABLE or SSL_AVAILABLE
+     */
+    public SSLConnectionTestResult testConnection() {
+        if (sendDualSSLClientHello()) {
+            return SSLConnectionTestResult.SSL_AVAILABLE;
+        }
+
+        if (sendESPing()) {
+            return SSLConnectionTestResult.SSL_NOT_AVAILABLE;
+        }
+
+        return SSLConnectionTestResult.ES_PING_FAILED;
+    }
+
+    private boolean sendDualSSLClientHello() {
+        boolean dualSslSupported = false;
+        Socket socket = null;
+        try {
+            OutputStreamWriter outputStreamWriter;
+            InputStreamReader inputStreamReader;
+            if(overriddenSocket != null) {
+                socket = overriddenSocket;
+                outputStreamWriter = testOutputStreamWriter;
+                inputStreamReader = testInputStreamReader;
+            } else {
+                socket = new Socket(host, port);
+                outputStreamWriter = new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8);
+                inputStreamReader = new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8);
+            }
+
+            socket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
+            outputStreamWriter.write(DUAL_MODE_CLIENT_HELLO_MSG);
+            outputStreamWriter.flush();
+            logger.debug("Sent DualSSL Client Hello msg to {}", host);
+
+            StringBuilder sb = new StringBuilder();
+            int currentChar;
+            while ((currentChar = inputStreamReader.read()) != -1) {
+                sb.append((char) currentChar);
+            }
+
+            if (sb.toString().equals(DUAL_MODE_SERVER_HELLO_MSG)) {
+                logger.debug("Received DualSSL Server Hello msg from {}", host);
+                dualSslSupported = true;
+            }
+        } catch (IOException e) {
+            logger.debug("DualSSL client check failed for {}, exception {}", host, e.getMessage());
+        } finally {
+            logger.debug("Closing DualSSL check client socket for {}", host);
+            if (socket != null) {
+                try {
+                    socket.close();
+                } catch (IOException e) {
+                    logger.error("Exception occurred while closing DualSSL check client socket for {}. Exception: {}", host, e.getMessage());
+                }
+            }
+        }
+        logger.debug("dualSslClient check with server {}, server supports ssl = {}", host, dualSslSupported);
+        return dualSslSupported;
+    }
+
+    private boolean sendESPing() {
+        boolean pingSucceeded = false;
+        Socket socket = null;
+        try {
+            if(overriddenSocket != null) {
+                socket = overriddenSocket;
+            } else {
+                socket = new Socket(host, port);
+            }
+
+            socket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
+            OutputStream outputStream = socket.getOutputStream();
+            InputStream inputStream = socket.getInputStream();
+
+            logger.debug("Sending ES Ping to {}", host);
+            outputStream.write(ES_PING_MSG);
+            outputStream.flush();
+
+            int currentByte;
+            int byteBufIndex = 0;
+            byte[] response = new byte[6];
+            while ((byteBufIndex < 6) && ((currentByte = inputStream.read()) != -1)) {
+                response[byteBufIndex] = (byte) currentByte;
+                byteBufIndex++;
+            }
+            if (byteBufIndex == 6) {
+                logger.debug("Received reply for ES Ping. from {}", host);
+                pingSucceeded = true;
+                for(int i = 0; i < 6; i++) {
+                    if (response[i] != ES_PING_MSG[i]) {
+                        // Unexpected byte in response
+                        logger.error("Received unexpected byte in ES Ping reply from {}", host);
+                        pingSucceeded = false;
+                        break;
+                    }
+                }
+            }
+        } catch (IOException ex) {
+            logger.error("ES Ping failed for {}, exception: {}", host, ex.getMessage());
+        } finally {
+            logger.debug("Closing ES Ping client socket for connection to {}", host);
+            if (socket != null) {
+                try {
+                    socket.close();
+                } catch (IOException e) {
+                    logger.error("Exception occurred while closing socket for {}. Exception: {}", host, e.getMessage());
+                }
+            }
+        }
+
+        logger.debug("ES Ping check to server {} result = {}", host, pingSucceeded);
+        return pingSucceeded;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/util/TLSUtil.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/util/TLSUtil.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.opendistroforelasticsearch.security.ssl.util;
+
+import io.netty.buffer.ByteBuf;
+
+import java.nio.ByteOrder;
+
+
+public class TLSUtil {
+
+    private static final int SSL_CONTENT_TYPE_CHANGE_CIPHER_SPEC = 20;
+    private static final int SSL_CONTENT_TYPE_ALERT = 21;
+    private static final int SSL_CONTENT_TYPE_HANDSHAKE = 22;
+    private static final int SSL_CONTENT_TYPE_APPLICATION_DATA = 23;
+    private static final int SSL_CONTENT_TYPE_EXTENSION_HEARTBEAT = 24;
+    private static final int SSL_RECORD_HEADER_LENGTH = 5;
+
+    private TLSUtil() {
+
+    }
+
+    public static boolean isTLS(ByteBuf buffer) {
+        int packetLength = 0;
+        int offset = buffer.readerIndex();
+
+        // SSLv3 or TLS - Check ContentType
+        boolean tls;
+        switch (buffer.getUnsignedByte(offset)) {
+            case SSL_CONTENT_TYPE_CHANGE_CIPHER_SPEC:
+            case SSL_CONTENT_TYPE_ALERT:
+            case SSL_CONTENT_TYPE_HANDSHAKE:
+            case SSL_CONTENT_TYPE_APPLICATION_DATA:
+            case SSL_CONTENT_TYPE_EXTENSION_HEARTBEAT:
+                tls = true;
+                break;
+            default:
+                // SSLv2 or bad data
+                tls = false;
+        }
+
+        if (tls) {
+            // SSLv3 or TLS - Check ProtocolVersion
+            int majorVersion = buffer.getUnsignedByte(offset + 1);
+            if (majorVersion == 3) {
+                // SSLv3 or TLS
+                packetLength = unsignedShortBE(buffer, offset + 3) + SSL_RECORD_HEADER_LENGTH;
+                if (packetLength <= SSL_RECORD_HEADER_LENGTH) {
+                    // Neither SSLv3 or TLSv1 (i.e. SSLv2 or bad data)
+                    tls = false;
+                }
+            } else {
+                // Neither SSLv3 or TLSv1 (i.e. SSLv2 or bad data)
+                tls = false;
+            }
+        }
+
+        return tls;
+    }
+
+    private static int unsignedShortBE(ByteBuf buffer, int offset) {
+        return buffer.order() == ByteOrder.BIG_ENDIAN ?
+                buffer.getUnsignedShort(offset) : buffer.getUnsignedShortLE(offset);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
@@ -237,6 +237,7 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_COMPLIANCE_SALT_DEFAULT = "e1ukloTsQlOgPquJ";//16 chars
     public static final String OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_INTERNAL_CONFIG_ENABLED  = "opendistro_security.compliance.history.internal_config_enabled";
     public static final String OPENDISTRO_SECURITY_SSL_ONLY = "opendistro_security.ssl_only";
+    public static final String OPENDISTRO_SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED = "opendistro_security_config.ssl_dual_mode_enabled";
     public static final String OPENDISTRO_SECURITY_SSL_CERT_RELOAD_ENABLED = "opendistro_security.ssl_cert_reload_enabled";
     public static final String OPENDISTRO_SECURITY_DISABLE_ENVVAR_REPLACEMENT = "opendistro_security.disable_envvar_replacement";
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/EncryptionInTransitMigrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/EncryptionInTransitMigrationTests.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.opendistroforelasticsearch.security;
+
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import com.amazon.opendistroforelasticsearch.security.test.SingleClusterTest;
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper;
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EncryptionInTransitMigrationTests extends SingleClusterTest {
+
+    @Test
+    public void testSslOnlyModeDualModeEnabled() throws Exception {
+        testSslOnlyMode(true);
+    }
+
+    @Test
+    public void testSslOnlyModeDualModeDisabled() throws Exception {
+        testSslOnlyMode(false);
+    }
+
+    private void testSslOnlyMode(boolean dualModeEnabled) throws Exception {
+        final Settings settings = Settings.builder()
+            .put(ConfigConstants.OPENDISTRO_SECURITY_SSL_ONLY, true)
+            .put(ConfigConstants.OPENDISTRO_SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED, dualModeEnabled)
+            .build();
+        setupSslOnlyMode(settings);
+        final RestHelper rh = nonSslRestHelper();
+
+        HttpResponse res = rh.executeGetRequest("_opendistro/_security/sslinfo");
+        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+
+        res = rh.executePutRequest("/xyz/_doc/1","{\"a\":5}");
+        Assert.assertEquals(HttpStatus.SC_CREATED, res.getStatusCode());
+
+        res = rh.executeGetRequest("/_mappings");
+        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+
+        res = rh.executeGetRequest("/_search");
+        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+
+        if (dualModeEnabled) {
+            res = rh.executeGetRequest("_cluster/settings?flat_settings&include_defaults");
+            Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+            Assert.assertTrue(res.getBody().contains("\"opendistro_security_config.ssl_dual_mode_enabled\":\"true\""));
+
+            String disableDualModeClusterSetting = "{ \"persistent\": { \"" + ConfigConstants.OPENDISTRO_SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED + "\": false } }";
+            res = rh.executePutRequest("_cluster/settings", disableDualModeClusterSetting);
+            Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+            Assert.assertEquals("{\"acknowledged\":true,\"persistent\":{\"opendistro_security_config\":{\"ssl_dual_mode_enabled\":\"false\"}},\"transient\":{}}", res.getBody());
+
+
+            res = rh.executeGetRequest("_cluster/settings?flat_settings&include_defaults");
+            Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+            Assert.assertTrue(res.getBody().contains("\"opendistro_security_config.ssl_dual_mode_enabled\":\"false\""));
+
+            String enableDualModeClusterSetting = "{ \"persistent\": { \"" + ConfigConstants.OPENDISTRO_SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED + "\": true } }";
+            res = rh.executePutRequest("_cluster/settings", enableDualModeClusterSetting);
+            Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+            Assert.assertEquals("{\"acknowledged\":true,\"persistent\":{\"opendistro_security_config\":{\"ssl_dual_mode_enabled\":\"true\"}},\"transient\":{}}", res.getBody());
+
+
+            res = rh.executeGetRequest("_cluster/settings?flat_settings&include_defaults");
+            Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+            Assert.assertTrue(res.getBody().contains("\"opendistro_security_config.ssl_dual_mode_enabled\":\"true\""));
+
+            res = rh.executePutRequest("_cluster/settings", disableDualModeClusterSetting);
+            Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+            Assert.assertEquals("{\"acknowledged\":true,\"persistent\":{\"opendistro_security_config\":{\"ssl_dual_mode_enabled\":\"false\"}},\"transient\":{}}", res.getBody());
+
+
+            res = rh.executeGetRequest("_cluster/settings?flat_settings&include_defaults");
+            Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+            Assert.assertTrue(res.getBody().contains("\"opendistro_security_config.ssl_dual_mode_enabled\":\"false\""));
+        }
+    }
+
+    @Test
+    public void testSslOnlyModeDualModeWithNonSSLMasterNode() throws Exception {
+        final Settings settings = Settings.builder()
+            .put(ConfigConstants.OPENDISTRO_SECURITY_SSL_ONLY, true)
+            .put(ConfigConstants.OPENDISTRO_SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED, true)
+            .build();
+        setupSslOnlyModeWithMasterNodeWithoutSSL(settings);
+        final RestHelper rh = nonSslRestHelper();
+
+        HttpResponse res = rh.executeGetRequest("/_search");
+        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+    }
+
+    @Test
+    public void testSslOnlyModeDualModeWithNonSSLDataNode() throws Exception {
+        final Settings settings = Settings.builder()
+            .put(ConfigConstants.OPENDISTRO_SECURITY_SSL_ONLY, true)
+            .put(ConfigConstants.OPENDISTRO_SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED, true)
+            .build();
+        setupSslOnlyModeWithDataNodeWithoutSSL(settings);
+        final RestHelper rh = nonSslRestHelper();
+
+        HttpResponse res = rh.executeGetRequest("/_search");
+        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/DualModeSSLHandlerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/DualModeSSLHandlerTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.opendistroforelasticsearch.security.ssl.transport;
+
+import com.amazon.opendistroforelasticsearch.security.ssl.OpenDistroSecurityKeyStore;
+import com.amazon.opendistroforelasticsearch.security.ssl.util.SSLConnectionTestUtil;
+import com.amazon.opendistroforelasticsearch.security.ssl.util.TLSUtil;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.ssl.SslHandler;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class DualModeSSLHandlerTests {
+
+    public static final int TLS_MAJOR_VERSION = 3;
+    public static final int TLS_MINOR_VERSION = 0;
+
+    private OpenDistroSecurityKeyStore openDistroSecurityKeyStore;
+    private ChannelPipeline pipeline;
+    private ChannelHandlerContext ctx;
+    private SslHandler sslHandler;
+
+    @Before
+    public void setup() {
+        pipeline = Mockito.mock(ChannelPipeline.class);
+        ctx = Mockito.mock(ChannelHandlerContext.class);
+        Mockito.when(ctx.pipeline()).thenReturn(pipeline);
+
+        openDistroSecurityKeyStore = Mockito.mock(OpenDistroSecurityKeyStore.class);
+        sslHandler = Mockito.mock(SslHandler.class);
+    }
+
+    @Test
+    public void testInvalidMessage() throws Exception {
+        DualModeSSLHandler handler = new DualModeSSLHandler(openDistroSecurityKeyStore);
+
+        ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
+        handler.decode(ctx, alloc.directBuffer(4), null);
+        // ensure pipeline is not fetched and manipulated
+        Mockito.verify(ctx, Mockito.times(0)).pipeline();
+    }
+
+    @Test
+    public void testValidTLSMessage() throws Exception {
+        DualModeSSLHandler handler = new DualModeSSLHandler(openDistroSecurityKeyStore, sslHandler);
+
+        ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
+        ByteBuf buffer = alloc.directBuffer(6);
+        buffer.writeByte(20);
+        buffer.writeByte(TLS_MAJOR_VERSION);
+        buffer.writeByte(TLS_MINOR_VERSION);
+        buffer.writeByte(100);
+        buffer.writeByte(0);
+        buffer.writeByte(0);
+
+        handler.decode(ctx, buffer, null);
+        // ensure ssl handler is added
+        Mockito.verify(ctx, Mockito.times(1)).pipeline();
+        Mockito.verify(pipeline, Mockito.times(1))
+                .addAfter("port_unification_handler", "ssl_server", sslHandler);
+        Mockito.verify(pipeline,
+                Mockito.times(1)).remove(handler);
+    }
+
+    @Test
+    public void testNonTLSMessage() throws Exception {
+        DualModeSSLHandler handler = new DualModeSSLHandler(openDistroSecurityKeyStore, sslHandler);
+
+        ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
+        ByteBuf buffer = alloc.directBuffer(6);
+
+        for (int i = 0; i < 6; i++) {
+            buffer.writeByte(1);
+        }
+
+        handler.decode(ctx, buffer, null);
+        // ensure ssl handler is added
+        Mockito.verify(ctx, Mockito.times(1)).pipeline();
+        Mockito.verify(pipeline, Mockito.times(0))
+                .addAfter("port_unification_handler", "ssl_server", sslHandler);
+        Mockito.verify(pipeline,
+                Mockito.times(1)).remove(handler);
+    }
+
+    @Test
+    public void testDualModeClientHelloMessage() throws Exception {
+        ChannelFuture channelFuture = Mockito.mock(ChannelFuture.class);
+        Mockito.when(ctx.writeAndFlush(Mockito.any())).thenReturn(channelFuture);
+        Mockito.when(channelFuture.addListener(Mockito.any())).thenReturn(channelFuture);
+
+        ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
+        ByteBuf buffer = alloc.directBuffer(6);
+        buffer.writeCharSequence(SSLConnectionTestUtil.DUAL_MODE_CLIENT_HELLO_MSG, StandardCharsets.UTF_8);
+
+        DualModeSSLHandler handler = new DualModeSSLHandler(openDistroSecurityKeyStore, sslHandler);
+        List<Object> decodedObjs = new ArrayList<>();
+        handler.decode(ctx, buffer, decodedObjs);
+
+        ArgumentCaptor<ByteBuf> serverHelloReplyBuffer = ArgumentCaptor.forClass(ByteBuf.class);
+        Mockito.verify(ctx, Mockito.times(1)).writeAndFlush(serverHelloReplyBuffer.capture());
+
+        String actualReply = serverHelloReplyBuffer.getValue().getCharSequence(0, 6, StandardCharsets.UTF_8).toString();
+        Assert.assertEquals(SSLConnectionTestUtil.DUAL_MODE_SERVER_HELLO_MSG, actualReply);
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/util/SSLConnectionTestUtilTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/util/SSLConnectionTestUtilTests.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.opendistroforelasticsearch.security.ssl.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.net.Socket;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class SSLConnectionTestUtilTests {
+    private Socket socket;
+    private OutputStream outputStream;
+    private InputStream inputStream;
+    private OutputStreamWriter outputStreamWriter;
+    private InputStreamReader inputStreamReader;
+
+    @Before
+    public void setup() {
+        socket = Mockito.mock(Socket.class);
+        outputStream = Mockito.mock(OutputStream.class);
+        inputStream = Mockito.mock(InputStream.class);
+        outputStreamWriter = Mockito.mock(OutputStreamWriter.class);
+        inputStreamReader = Mockito.mock(InputStreamReader.class);
+    }
+
+    @Test
+    public void testConnectionSSLAvailable() throws Exception {
+        Mockito.doNothing().when(outputStreamWriter).write(Mockito.anyString());
+        Mockito.when(inputStreamReader.read())
+            .thenReturn((int)'D')
+            .thenReturn((int)'U')
+            .thenReturn((int)'A')
+            .thenReturn((int)'L')
+            .thenReturn((int)'S')
+            .thenReturn((int)'M')
+            .thenReturn(-1);
+        Mockito.doNothing().when(socket).close();
+
+        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
+        SSLConnectionTestResult result = connectionTestUtil.testConnection();
+
+        verifyClientHelloSend();
+        Mockito.verify(socket, Mockito.times(1)).close();
+        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.SSL_AVAILABLE, result);
+    }
+
+    @Test
+    public void testConnectionSSLNotAvailable() throws Exception {
+        setupMocksForClientHelloFailure();
+        setupMocksForEsPingSuccess();
+        Mockito.doNothing().when(socket).close();
+
+        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
+        SSLConnectionTestResult result = connectionTestUtil.testConnection();
+
+        verifyClientHelloSend();
+        verifyEsPingSend();
+        Mockito.verify(socket, Mockito.times(2)).close();
+        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.SSL_NOT_AVAILABLE, result);
+    }
+
+    @Test
+    public void testConnectionSSLNotAvailableIOException() throws Exception {
+        Mockito.doThrow(new IOException("Error while writing bytes to output stream"))
+            .when(outputStreamWriter)
+            .write(Mockito.anyString());
+        setupMocksForEsPingSuccess();
+        Mockito.doNothing().when(socket).close();
+
+        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
+        SSLConnectionTestResult result = connectionTestUtil.testConnection();
+
+        verifyClientHelloSend();
+        Mockito.verifyZeroInteractions(inputStreamReader);
+        verifyEsPingSend();
+        Mockito.verify(socket, Mockito.times(2)).close();
+        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.SSL_NOT_AVAILABLE, result);
+    }
+
+    @Test
+    public void testConnectionEsPingFailed() throws Exception {
+        setupMocksForClientHelloFailure();
+        Mockito.when(socket.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(socket.getInputStream()).thenReturn(inputStream);
+        Mockito.doNothing().when(outputStream).write(Mockito.any(byte[].class));
+        Mockito.when(inputStream.read())
+            .thenReturn(-1);
+        Mockito.doNothing().when(socket).close();
+
+        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
+        SSLConnectionTestResult result = connectionTestUtil.testConnection();
+
+        verifyClientHelloSend();
+        verifyEsPingSend();
+        Mockito.verify(socket, Mockito.times(2)).close();
+        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.ES_PING_FAILED, result);
+    }
+
+    @Test
+    public void testConnectionEsPingFailedInvalidReply() throws Exception {
+        setupMocksForClientHelloFailure();
+        Mockito.when(socket.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(socket.getInputStream()).thenReturn(inputStream);
+        Mockito.doNothing().when(outputStream).write(Mockito.any(byte[].class));
+        Mockito.when(inputStream.read())
+            .thenReturn((int)'E')
+            .thenReturn((int)'E')
+            .thenReturn(0xFF)
+            .thenReturn(0xFF)
+            .thenReturn(0xFF)
+            .thenReturn(0xFF);
+        Mockito.doNothing().when(socket).close();
+
+        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
+        SSLConnectionTestResult result = connectionTestUtil.testConnection();
+
+        verifyClientHelloSend();
+        verifyEsPingSend();
+        Mockito.verify(socket, Mockito.times(2)).close();
+        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.ES_PING_FAILED, result);
+    }
+
+    @Test
+    public void testConnectionEsPingFailedIOException() throws Exception {
+        setupMocksForClientHelloFailure();
+        Mockito.when(socket.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(socket.getInputStream()).thenReturn(inputStream);
+        Mockito.doThrow(new IOException("Error while writing bytes to output stream")).when(outputStream).write(Mockito.any(byte[].class));
+        Mockito.doNothing().when(socket).close();
+
+        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
+        SSLConnectionTestResult result = connectionTestUtil.testConnection();
+
+        verifyClientHelloSend();
+        verifyEsPingSend();
+        Mockito.verifyZeroInteractions(inputStream);
+        Mockito.verify(socket, Mockito.times(2)).close();
+        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.ES_PING_FAILED, result);
+    }
+
+    private void verifyClientHelloSend() throws IOException {
+        ArgumentCaptor<String> clientHelloMsgArgCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(outputStreamWriter,
+            Mockito.times(1))
+            .write(clientHelloMsgArgCaptor.capture());
+        String msgWritten = clientHelloMsgArgCaptor.getValue();
+        String expectedMsg = "DUALCM";
+        Assert.assertEquals("Unexpected Dual SSL Client Hello message written to socket", expectedMsg, msgWritten);
+    }
+
+    private void verifyEsPingSend() throws IOException {
+        ArgumentCaptor<byte[]> argumentCaptor = ArgumentCaptor.forClass(byte[].class);
+        Mockito.verify(outputStream,
+            Mockito.times(1))
+            .write(argumentCaptor.capture());
+        byte[] bytesWritten = argumentCaptor.getValue();
+        byte[] expectedBytes = new byte[]{'E','S',(byte)0xFF,(byte)0xFF,(byte)0xFF,(byte)0xFF};
+        for(int i = 0; i < bytesWritten.length; i++) {
+            Assert.assertEquals("Unexpected ES Ping bytes written to socket", expectedBytes[i], bytesWritten[i]);
+        }
+    }
+
+    private void setupMocksForClientHelloFailure() throws IOException {
+        Mockito.doNothing().when(outputStreamWriter).write(Mockito.anyString());
+        Mockito.when(inputStreamReader.read())
+            .thenReturn(-1);
+    }
+
+    private void setupMocksForEsPingSuccess() throws IOException {
+        Mockito.when(socket.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(socket.getInputStream()).thenReturn(inputStream);
+        Mockito.doNothing().when(outputStream).write(Mockito.any(byte[].class));
+        Mockito.when(inputStream.read())
+            .thenReturn((int)'E')
+            .thenReturn((int)'S')
+            .thenReturn(0xFF)
+            .thenReturn(0xFF)
+            .thenReturn(0xFF)
+            .thenReturn(0xFF);
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/util/TLSUtilTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/util/TLSUtilTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazon.opendistroforelasticsearch.security.ssl.util;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TLSUtilTests {
+
+    public static final int TLS_MAJOR_VERSION = 3;
+    public static final int TLS_MINOR_VERSION = 0;
+
+    @Before
+    public void setup() {
+
+    }
+
+    @Test
+    public void testSSLUtilSuccess() {
+        // byte 20 to 24 are ssl headers
+        for (int byteToSend = 20; byteToSend <= 24; byteToSend++) {
+            ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
+            ByteBuf buffer = alloc.directBuffer(5);
+            buffer.writeByte(byteToSend);
+            buffer.writeByte(TLS_MAJOR_VERSION);
+            buffer.writeByte(TLS_MINOR_VERSION);
+            buffer.writeByte(100);
+            Assert.assertTrue(TLSUtil.isTLS(buffer));
+        }
+
+    }
+
+    @Test
+    public void testSSLUtilWrongTLSVersion() {
+        // byte 20 to 24 are ssl headers
+        for (int byteToSend = 20; byteToSend <= 24; byteToSend++) {
+            ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
+            ByteBuf buffer = alloc.directBuffer(5);
+            buffer.writeByte(byteToSend);
+            //setting invalid TLS version 100
+            buffer.writeByte(100);
+            buffer.writeByte(TLS_MINOR_VERSION);
+            buffer.writeByte(100);
+            Assert.assertFalse(TLSUtil.isTLS(buffer));
+        }
+
+    }
+
+    @Test
+    public void testSSLUtilInvalidContentLength() {
+        // byte 20 to 24 are ssl headers
+        for (int byteToSend = 20; byteToSend <= 24; byteToSend++) {
+            ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
+            ByteBuf buffer = alloc.directBuffer(5);
+            buffer.writeByte(byteToSend);
+            buffer.writeByte(TLS_MAJOR_VERSION);
+            buffer.writeByte(TLS_MINOR_VERSION);
+            //setting content length as 0
+            buffer.writeByte(0);
+            Assert.assertFalse(TLSUtil.isTLS(buffer));
+        }
+
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/AbstractSecurityUnitTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/AbstractSecurityUnitTest.java
@@ -261,6 +261,19 @@ public abstract class AbstractSecurityUnitTest {
         };
     }
 
+    protected NodeSettingsSupplier minimumSecuritySettingsSslOnlyWithOneNodeNonSSL(Settings other, int nonSSLNodeNum) {
+
+        return new NodeSettingsSupplier() {
+            @Override
+            public Settings get(int i) {
+                if (i == nonSSLNodeNum) {
+                    return Settings.builder().build();
+                }
+                return minimumSecuritySettingsBuilder(i, true, false).put(other).build();
+            }
+        };
+    }
+
     protected void initialize(ClusterInfo info) {
         initialize(info, Settings.EMPTY, new DynamicSecurityConfig());
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/SingleClusterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/SingleClusterTest.java
@@ -42,6 +42,9 @@ import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelpe
 
 public abstract class SingleClusterTest extends AbstractSecurityUnitTest {
 
+    private static final int DEFAULT_MASTER_NODE_NUM = 3;
+    private static final int DEFAULT_FIRST_DATA_NODE_NUM = 2;
+
     protected ClusterHelper clusterHelper = new ClusterHelper("utest_n"+num.incrementAndGet()+"_f"+System.getProperty("forkno")+"_t"+System.nanoTime());
     protected ClusterInfo clusterInfo;
     private ClusterHelper remoteClusterHelper = withRemoteCluster ?
@@ -102,6 +105,18 @@ public abstract class SingleClusterTest extends AbstractSecurityUnitTest {
     protected void setupSslOnlyMode(Settings nodeOverride) throws Exception {
         Assert.assertNull("No cluster", clusterInfo);
         clusterInfo = clusterHelper.startCluster(minimumSecuritySettingsSslOnly(nodeOverride), ClusterConfiguration.DEFAULT);
+    }
+
+    protected void setupSslOnlyModeWithMasterNodeWithoutSSL(Settings nodeOverride) throws Exception {
+        Assert.assertNull("No cluster", clusterInfo);
+        clusterInfo = clusterHelper.startCluster(minimumSecuritySettingsSslOnlyWithOneNodeNonSSL(nodeOverride,
+                DEFAULT_MASTER_NODE_NUM), ClusterConfiguration.DEFAULT_MASTER_WITHOUT_SECURITY_PLUGIN);
+    }
+
+    protected void setupSslOnlyModeWithDataNodeWithoutSSL(Settings nodeOverride) throws Exception {
+        Assert.assertNull("No cluster", clusterInfo);
+        clusterInfo = clusterHelper.startCluster(minimumSecuritySettingsSslOnlyWithOneNodeNonSSL(nodeOverride,
+                DEFAULT_FIRST_DATA_NODE_NUM), ClusterConfiguration.DEFAULT_ONE_DATA_NODE_WITHOUT_SECURITY_PLUGIN);
     }
 
     protected RestHelper restHelper() {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/SingleClusterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/SingleClusterTest.java
@@ -42,8 +42,8 @@ import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelpe
 
 public abstract class SingleClusterTest extends AbstractSecurityUnitTest {
 
-    private static final int DEFAULT_MASTER_NODE_NUM = 3;
-    private static final int DEFAULT_FIRST_DATA_NODE_NUM = 2;
+    private static final int DEFAULT_MASTER_NODE_NUM = 0;
+    private static final int DEFAULT_FIRST_DATA_NODE_NUM = 1;
 
     protected ClusterHelper clusterHelper = new ClusterHelper("utest_n"+num.incrementAndGet()+"_f"+System.getProperty("forkno")+"_t"+System.nanoTime());
     protected ClusterInfo clusterInfo;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/cluster/ClusterConfiguration.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/cluster/ClusterConfiguration.java
@@ -54,6 +54,15 @@ public enum ClusterConfiguration {
     //3 nodes (1m, 2d)
     DEFAULT(new NodeSettings(true, false, false), new NodeSettings(false, true, false), new NodeSettings(false, true, false)),
 	
+	DEFAULT_MASTER_WITHOUT_SECURITY_PLUGIN(new NodeSettings(true, false, false)
+			.removePluginIfPresent(OpenDistroSecurityPlugin.class)
+			, new NodeSettings(false, true, false)
+			, new NodeSettings(false, true, false)),
+
+	DEFAULT_ONE_DATA_NODE_WITHOUT_SECURITY_PLUGIN(new NodeSettings(true, false, false)
+			, new NodeSettings(false, true, false).removePluginIfPresent(OpenDistroSecurityPlugin.class)
+			, new NodeSettings(false, true, false)),
+
     //1 node (1md)
 	SINGLENODE(new NodeSettings(true, true, false)),
     
@@ -106,6 +115,11 @@ public enum ClusterConfiguration {
             this(masterNode, dataNode, tribeNode);
             this.plugins.addAll(additionalPlugins);
         }
+
+        public NodeSettings removePluginIfPresent(Class<? extends Plugin> pluginToRemove){
+			this.plugins.remove(pluginToRemove);
+			return this;
+		}
 		
 		public Class<? extends Plugin>[] getPlugins() {
 		    return plugins.toArray(new Class[0] );


### PR DESCRIPTION
- Adding SSL dual mode support for SSLOnly

(cherry picked from commit 27f33fb)

Co-authored-by: Vengadanathan Srinivasan <vengadan@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
