### PR TITLE
Fix the way to store empty password in ES6

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -122,9 +122,10 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
 
         // if password is set, it takes precedence over hash
         String plainTextPassword = additionalSettingsBuilder.get("password");
-        if (plainTextPassword != null && plainTextPassword.length() > 0) {
+        if (plainTextPassword != null) {
             additionalSettingsBuilder.remove("password");
-            additionalSettingsBuilder.put("hash", hash(plainTextPassword.toCharArray()));
+            if (plainTextPassword.length() > 0)
+                additionalSettingsBuilder.put("hash", hash(plainTextPassword.toCharArray()));
         }
 
         // check if user exists


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The empty password stored in ES6 causes upgrade fail. This PR is to fix the storage machnism of empty password in ES6.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
