### PR TITLE
Update docs on snapshot restore settings

### DIFF
--- a/securityconfig/elasticsearch.yml.example
+++ b/securityconfig/elasticsearch.yml.example
@@ -188,17 +188,14 @@ opendistro_security.audit.type: internal_elasticsearch
 # constructor that takes an org.elasticsearch.common.settings.Settings
 #opendistro_security.cert.intercluster_request_evaluator_class: com.amazon.opendistroforelasticsearch.security.transport.DefaultInterClusterRequestEvaluator
 
-# Allow snapshot restore for normal users
-# By default only requests signed by an admin TLS certificate can do this
-# To enable snapshot restore for normal users set 'opendistro_security.enable_snapshot_restore_privilege: true'
-# The user who wants to restore a snapshot must have the 'cluster:admin/snapshot/restore' privilege and must also have
-# "indices:admin/create" and "indices:data/write/index" for the indices to be restores.
+# By default, normal users can restore snapshots if they have the priviliges 'cluster:admin/snapshot/restore', 
+# 'indices:admin/create', and 'indices:data/write/index' for the indices to be restored.
+# To disable snapshot restore for normal users set 'opendistro_security.enable_snapshot_restore_privilege: false'.
+# This makes it so that only snapshot restore requests signed by an admin TLS certificate are accepted.
 # A snapshot can only be restored when it does not contain global state and does not restore the '.opendistro_security' index
 # If 'opendistro_security.check_snapshot_restore_write_privileges: false' is set then the additional indices checks are omitted.
-
-# This makes it less secure.
 #opendistro_security.enable_snapshot_restore_privilege: true
-#opendistro_security.check_snapshot_restore_write_privileges: false
+#opendistro_security.check_snapshot_restore_write_privileges: true
 
 # Authentication cache timeout in minutes (A value of 0 disables caching, default is 60)
 #opendistro_security.cache.ttl_minutes: 60


### PR DESCRIPTION
*Description of changes:*
This commit updates the documentation for the snapshot restore settings in the example elasticsearch configuration file.
From what I have gathered from testing and [reading the code](https://github.com/opendistro-for-elasticsearch/security/blob/v1.11.0.0/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java#L112) I concluded that the docs were out of date. By default normal users _can_ restore snapshot if they have sufficient priviliges which is contrary to what the documentation said before this commit.

Thought that it might be worth an update as to not confuse other people when they are reading the example configuration for elasticsearch security plugin :slightly_smiling_face:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
