### PR TITLE
Fix empty password issue in upgrade from 6x to 7x

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v6/InternalUserV6.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v6/InternalUserV6.java
@@ -79,6 +79,11 @@ public class InternalUserV6 implements Hideable, Hashed {
         public void setHash(String hash) {
             this.hash = hash;
         }
+
+        public void setPassword(String password){
+          // no-op setter. Due to a bug in 6.x, empty "password" may be saved to the internalusers doc. Ignore it.
+        }
+        
         public boolean isReadonly() {
             return readonly;
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Unrecognized field "password" exception gets thrown out during migrating from 6.x to 7.x.
This PR is to fix the logic handling empty password in migration.

*Related PRs:*
Some of the review comments are in this old PR - https://github.com/opendistro-for-elasticsearch/security/pull/809


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
