### PR TITLE
Reject empty password in internal user creation

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
@@ -181,6 +181,15 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
 		rh.sendAdminCertificate = sendAdminCertificate;
 	}
 
+	protected void addUserWithPasswordAndHash(String username, String password, String hash, int status) throws Exception {
+		boolean sendAdminCertificate = rh.sendAdminCertificate;
+		rh.sendAdminCertificate = true;
+		HttpResponse response = rh.executePutRequest("/_opendistro/_security/api/internalusers/" + username, "{\"hash\": \"" + hash + "\", \"password\": \"" + password + "\"}",
+				new Header[0]);
+		Assert.assertEquals(status, response.getStatusCode());
+		rh.sendAdminCertificate = sendAdminCertificate;
+	}
+
 	protected void checkGeneralAccess(int status, String username, String password) throws Exception {
 		boolean sendAdminCertificate = rh.sendAdminCertificate;
 		rh.sendAdminCertificate = false;


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:*
Given that Kibana and ES don't allow login with empty password, it'd make sense to deny empty password in internal user creation.
This PR is to add the validation to deny empty password in internal user creation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
