### PR TITLE
Adding requested tenant to the thread context transient info for consumption

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilter.java
@@ -98,7 +98,7 @@ import com.amazon.opendistroforelasticsearch.security.user.User;
 
 import static com.amazon.opendistroforelasticsearch.security.OpenDistroSecurityPlugin.isActionTraceEnabled;
 import static com.amazon.opendistroforelasticsearch.security.OpenDistroSecurityPlugin.traceAction;
-import static com.amazon.opendistroforelasticsearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_USER_AND_ROLES;
+import static com.amazon.opendistroforelasticsearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT;
 
 public class OpenDistroSecurityFilter implements ActionFilter {
 
@@ -302,8 +302,8 @@ public class OpenDistroSecurityFilter implements ActionFilter {
                 log.debug(pres);
             }
 
-            if(threadContext.getTransient(OPENDISTRO_SECURITY_USER_AND_ROLES) == null) {
-                threadContext.putTransient(OPENDISTRO_SECURITY_USER_AND_ROLES, user.getUserRolesString());
+            if(threadContext.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT) == null) {
+                threadContext.putTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT, user.getUserInfoString());
             }
 
             if (pres.isAllowed()) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
@@ -99,7 +99,7 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_USER = OPENDISTRO_SECURITY_CONFIG_PREFIX+"user";
     public static final String OPENDISTRO_SECURITY_USER_HEADER = OPENDISTRO_SECURITY_CONFIG_PREFIX+"user_header";
 
-    public static final String OPENDISTRO_SECURITY_USER_AND_ROLES = OPENDISTRO_SECURITY_CONFIG_PREFIX + "user_and_roles";
+    public static final String OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT = OPENDISTRO_SECURITY_CONFIG_PREFIX + "user_info";
 
     public static final String OPENDISTRO_SECURITY_INJECTED_USER = "injected_user";
     public static final String OPENDISTRO_SECURITY_INJECTED_USER_HEADER = "injected_user_header";

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/user/User.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/user/User.java
@@ -40,6 +40,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableList;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -264,7 +266,12 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
         return this.openDistroSecurityRoles == null ? Collections.emptySet() : Collections.unmodifiableSet(this.openDistroSecurityRoles);
     }
 
-    public final String getUserRolesString() {
-        return name + "|" + String.join(",", getRoles()) + "|" + String.join(",", getOpenDistroSecurityRoles());
+    public final String getUserInfoString() {
+        final ImmutableList.Builder<String> builder = ImmutableList.builder();
+        builder.add(name, String.join(",", getRoles()),  String.join(",", getOpenDistroSecurityRoles()));
+        if (!Strings.isNullOrEmpty(requestedTenant)) {
+            builder.add(requestedTenant);
+        }
+        return String.join("|", builder.build());
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding requested tenant to the thread context transient info for consumption

Why this change is required?
When transport action is invoked, thread context has information related to user and roles. this change adds tenant along with user and roles to consume by plugins. This helps plugin getting user requested tenant for its operation (like filing data based on tenant) without making another "authinfo" call.

Tests:
mvn test tested on 7.9.1.
Validated that the common-utils:User.parse() does not break with this change


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
