### PR TITLE
Fix for java.io.OptionalDataException that is caused by changes to User object after it is put on thread context.

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilter.java
@@ -39,7 +39,6 @@ import com.amazon.opendistroforelasticsearch.security.auth.RolesInjector;
 import com.amazon.opendistroforelasticsearch.security.resolver.IndexResolverReplacer;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.amazon.opendistroforelasticsearch.security.auth.BackendRegistry;
 import org.apache.logging.log4j.LogManager;
@@ -73,7 +72,6 @@ import org.elasticsearch.action.support.ActionFilterChain;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.concurrent.ThreadContext.StoredContext;
@@ -100,7 +98,6 @@ import com.amazon.opendistroforelasticsearch.security.user.User;
 
 import static com.amazon.opendistroforelasticsearch.security.OpenDistroSecurityPlugin.isActionTraceEnabled;
 import static com.amazon.opendistroforelasticsearch.security.OpenDistroSecurityPlugin.traceAction;
-import static com.amazon.opendistroforelasticsearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT;
 
 public class OpenDistroSecurityFilter implements ActionFilter {
 
@@ -157,18 +154,6 @@ public class OpenDistroSecurityFilter implements ActionFilter {
 
     private static Set<String> alias2Name(Set<Alias> aliases) {
         return aliases.stream().map(a -> a.name()).collect(ImmutableSet.toImmutableSet());
-    }
-
-    private void setUserInfoThreadContext(User user) {
-        if (threadContext.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT) == null) {
-            final ImmutableList.Builder<String> builder = ImmutableList.builder();
-            builder.add(user.getName(), String.join(",", user.getRoles()),  String.join(",", user.getOpenDistroSecurityRoles()));
-            String requestedTenant = user.getRequestedTenant();
-            if (!Strings.isNullOrEmpty(requestedTenant)) {
-                builder.add(requestedTenant);
-            }
-            threadContext.putTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT, String.join("|", builder.build()));
-        }
     }
 
     private <Request extends ActionRequest, Response extends ActionResponse> void apply0(Task task, final String action, Request request,
@@ -314,8 +299,6 @@ public class OpenDistroSecurityFilter implements ActionFilter {
             if (log.isDebugEnabled()) {
                 log.debug(pres);
             }
-
-            setUserInfoThreadContext(user);
 
             if (pres.isAllowed()) {
                 auditLog.logGrantedPrivileges(action, request, task);


### PR DESCRIPTION
*Issue #, if available:*
```
org.elasticsearch.transport.RemoteTransportException: [][][indices:admin/aliases/get]
Caused by: org.elasticsearch.ElasticsearchException: java.io.OptionalDataException
	at com.amazon.opendistroforelasticsearch.security.support.Base64Helper.deserializeObject(Base64Helper.java:185) ~[?:?]
	at com.amazon.opendistroforelasticsearch.security.auditlog.impl.AbstractAuditLog.getUser(AbstractAuditLog.java:626) ~[?:?]
	at com.amazon.opendistroforelasticsearch.security.auditlog.impl.AbstractAuditLog.logMissingPrivileges(AbstractAuditLog.java:234) ~[?:?]
	at com.amazon.opendistroforelasticsearch.security.auditlog.impl.AuditLogImpl.logMissingPrivileges(AuditLogImpl.java:187) ~[?:?]
	at com.amazon.opendistroforelasticsearch.security.auditlog.AuditLogSslExceptionHandler.logError(AuditLogSslExceptionHandler.java:77) ~[?:?]
	at com.amazon.opendistroforelasticsearch.security.ssl.transport.OpenDistroSecuritySSLRequestHandler.messageReceived(OpenDistroSecuritySSLRequestHandler.java:158) ~[?:?]
	at com.amazon.opendistroforelasticsearch.security.OpenDistroSecurityPlugin$7$1.messageReceived(OpenDistroSecurityPlugin.java:626) ~[?:?]
	at com.amazonaws.elasticsearch.iam.IamTransportRequestHandler.messageReceived(IamTransportRequestHandler.java:55) ~[?:?]
	at com.amazonaws.elasticsearch.ccs.CrossClusterRequestInterceptor$CrossClusterRequestHandler.messageReceived(CrossClusterRequestInterceptor.java:133) ~[?:?]
	at com.amazon.opendistro.elasticsearch.performanceanalyzer.transport.PerformanceAnalyzerTransportRequestHandler.messageReceived(PerformanceAnalyzerTransportRequestHandler.java:48) ~[?:?]
```

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
