### PR TITLE
Fix AuthCredentials equality

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/user/AuthCredentials.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/user/AuthCredentials.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.elasticsearch.ElasticsearchSecurityException;
@@ -175,19 +176,17 @@ public final class AuthCredentials {
     public boolean equals(Object obj) {
         if (this == obj)
             return true;
-        if (obj == null)
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
-        if (getClass() != obj.getClass())
-            return false;
+        }
+
         AuthCredentials other = (AuthCredentials) obj;
-        if (internalPasswordHash == null || other.internalPasswordHash == null || !MessageDigest.isEqual(internalPasswordHash, other.internalPasswordHash))
-            return false;
-        if (username == null) {
-            if (other.username != null)
-                return false;
-        } else if (!username.equals(other.username))
-            return false;
-        return true;
+        return Objects.equals(username, other.username)
+            && Arrays.equals(password, other.password)
+            && Objects.equals(nativeCredentials, other.nativeCredentials)
+            && Objects.equals(backendRoles, other.backendRoles)
+            && MessageDigest.isEqual(internalPasswordHash, other.internalPasswordHash)
+            && Objects.equals(attributes, other.attributes);
     }
 
     @Override

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/cache/CachingTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/cache/CachingTest.java
@@ -58,7 +58,7 @@ public class CachingTest extends SingleClusterTest{
 
         Assert.assertEquals(3, DummyHTTPAuthenticator.getCount());
         Assert.assertEquals(1, DummyAuthorizer.getCount());
-        Assert.assertEquals(3, DummyAuthenticationBackend.getAuthCount());
+        Assert.assertEquals(1, DummyAuthenticationBackend.getAuthCount());
         Assert.assertEquals(0, DummyAuthenticationBackend.getExistsCount());
     }
 
@@ -103,7 +103,7 @@ public class CachingTest extends SingleClusterTest{
 
         Assert.assertEquals(4, DummyHTTPAuthenticator.getCount());
         Assert.assertEquals(3, DummyAuthorizer.getCount());
-        Assert.assertEquals(4, DummyAuthenticationBackend.getAuthCount());
+        Assert.assertEquals(1, DummyAuthenticationBackend.getAuthCount());
         Assert.assertEquals(2, DummyAuthenticationBackend.getExistsCount());
 
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/user/AuthCredentialsTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/user/AuthCredentialsTests.java
@@ -1,0 +1,32 @@
+package com.amazon.opendistroforelasticsearch.security.user;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AuthCredentialsTests {
+  @Test
+  public void testEquality() {
+    Assert.assertEquals(
+      new AuthCredentials("george", "admin"),
+      new AuthCredentials("george", "admin"));
+    Assert.assertNotEquals(
+      new AuthCredentials("george", "admin"),
+      new AuthCredentials("george", "not_admin"));
+    Assert.assertNotEquals(
+      new AuthCredentials("fred", "admin"),
+      new AuthCredentials("george", "admin"));
+
+    Assert.assertEquals(
+        new AuthCredentials("george", "secret".getBytes()),
+        new AuthCredentials("george", "secret".getBytes()));
+    Assert.assertNotEquals(
+        new AuthCredentials("george", "secret".getBytes()),
+        new AuthCredentials("george", "hunter2".getBytes()));
+
+    // If one AuthCredentials has a password and the other has a native credentials, they should
+    // not be equal.
+    Assert.assertNotEquals(
+        new AuthCredentials("george", "secret".getBytes()),
+        new AuthCredentials("george", "admin"));
+  }
+}


### PR DESCRIPTION
Fixes #873.

Description of changes:
This PR fixes the `AuthCredentials` class to correctly consider two `AuthCredentials` equal if they have the same username and both instances have null passwords. Before this PR, if both instances had null passwords, they would be considered not equal, causing them to never be cached. This fixes caching for backends using anonymous authentication.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
