### PR TITLE
Add a replacer to release-notes-drafter-config

### DIFF
--- a/.github/release-notes-drafter-config.yml
+++ b/.github/release-notes-drafter-config.yml
@@ -5,7 +5,7 @@ template: |
 
 # Setting the formatting and sorting for the release notes body
 name-template: Version (set version here)
-change-template: '* $TITLE [#$NUMBER](https://github.com/opendistro-for-elasticsearch/security/pull/$NUMBER)'
+change-template: '* $TITLE ([#$NUMBER](https://github.com/opendistro-for-elasticsearch/security/pull/$NUMBER))'
 sort-by: merged_at
 sort-direction: ascending
 replacers:

--- a/.github/release-notes-drafter-config.yml
+++ b/.github/release-notes-drafter-config.yml
@@ -8,6 +8,9 @@ name-template: Version (set version here)
 change-template: '* $TITLE [#$NUMBER](https://github.com/opendistro-for-elasticsearch/security/pull/$NUMBER)'
 sort-by: merged_at
 sort-direction: ascending
+replacers:
+  - search: "##"
+    replace: "###"
 
 # Organizing the tagged PRs into unified ODFE categories
 categories:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
ODFE release notes standards require the headers to be at level 3(`###`), but by default, release notes drafter generates headers at level2(`##`)
This PR is to add a replacer to replace level 2 headers with level 3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
