### PR TITLE
 Throwing ElasticsearchException if subject key is not found

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -120,7 +120,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
 
         if (subject == null) {
             log.error("No subject found in JWT token");
-            return null;
+            throw new ElasticsearchSecurityException("No subject found in JWT token", RestStatus.FORBIDDEN);
         }
 
         final String[] roles = extractRoles(claims);


### PR DESCRIPTION
*Issue #, if available:* N/A


*Description of changes:*
This PR contains 2 changes

* Throwing ElasticsearchException if subject == null. If subject is null that means we have not been able to find the username from the JWT token. Throwing an exception will make this more explicit

*  In HTTPSamlAuthenticator am using SAML roles_key and subject_key as the JWT roles_key and subject_key. This will ensure that while logging/retrieving subject_key and roles_key we are using the SAML key for SAML auth instead of the JWT key. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
