### PR TITLE
Using SAML subject_key and roles_key in the HTTPSamlAuthenticator

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
@@ -338,12 +338,12 @@ public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
 
         settingsBuilder.put(jwtSettings);
 
-        if (jwtSettings.get("roles_key") == null && settings.get("roles_key") != null) {
-            settingsBuilder.put("roles_key", "roles");
+        if (jwtSettings.get("roles_key") == null) {
+            settingsBuilder.put("roles_key", settings.get("roles_key", "roles"));
         }
 
         if (jwtSettings.get("subject_key") == null) {
-            settingsBuilder.put("subject_key", "sub");
+            settingsBuilder.put("subject_key", settings.get("subject_key", "sub"));
         }
 
         return settingsBuilder.build();


### PR DESCRIPTION
##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_): Enhancement
 
 
 2. __Github Issue # or roaddmap entry, if available:__: N/A



 3. __Description of changes:__
In HTTPSamlAuthenticator am using SAML roles_key and subject_key as the JWT roles_key and subject_key. This will ensure that while logging/retrieving subject_key and roles_key we are using the SAML key for SAML auth instead of the JWT key.


 4. __Why these changes are required?__ 
These will improve logging for SAML.


 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screenshot if avaialble_)



 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manaual testing_) 
 N/A
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide github issues# for each of them)
N/A


 8. __Is it backport from master branch?__ (_If yes, please add backport PR # and commits #_)
N/A



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
