### PR TITLE
Adding requested tenant to the thread context transient user info for consumption (#850)

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilter.java
@@ -98,7 +98,7 @@ import com.amazon.opendistroforelasticsearch.security.user.User;
 
 import static com.amazon.opendistroforelasticsearch.security.OpenDistroSecurityPlugin.isActionTraceEnabled;
 import static com.amazon.opendistroforelasticsearch.security.OpenDistroSecurityPlugin.traceAction;
-import static com.amazon.opendistroforelasticsearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_USER_AND_ROLES;
+import static com.amazon.opendistroforelasticsearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT;
 
 public class OpenDistroSecurityFilter implements ActionFilter {
 
@@ -302,8 +302,8 @@ public class OpenDistroSecurityFilter implements ActionFilter {
                 log.debug(pres);
             }
 
-            if(threadContext.getTransient(OPENDISTRO_SECURITY_USER_AND_ROLES) == null) {
-                threadContext.putTransient(OPENDISTRO_SECURITY_USER_AND_ROLES, user.getUserRolesString());
+            if(threadContext.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT) == null) {
+                threadContext.putTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT, user.getUserInfoString());
             }
 
             if (pres.isAllowed()) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilter.java
@@ -39,7 +39,6 @@ import com.amazon.opendistroforelasticsearch.security.auth.RolesInjector;
 import com.amazon.opendistroforelasticsearch.security.resolver.IndexResolverReplacer;
 import com.amazon.opendistroforelasticsearch.security.support.WildcardMatcher;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.amazon.opendistroforelasticsearch.security.auth.BackendRegistry;
 import org.apache.logging.log4j.LogManager;
@@ -73,7 +72,6 @@ import org.elasticsearch.action.support.ActionFilterChain;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.concurrent.ThreadContext.StoredContext;
@@ -100,7 +98,6 @@ import com.amazon.opendistroforelasticsearch.security.user.User;
 
 import static com.amazon.opendistroforelasticsearch.security.OpenDistroSecurityPlugin.isActionTraceEnabled;
 import static com.amazon.opendistroforelasticsearch.security.OpenDistroSecurityPlugin.traceAction;
-import static com.amazon.opendistroforelasticsearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT;
 
 public class OpenDistroSecurityFilter implements ActionFilter {
 
@@ -157,18 +154,6 @@ public class OpenDistroSecurityFilter implements ActionFilter {
 
     private static Set<String> alias2Name(Set<Alias> aliases) {
         return aliases.stream().map(a -> a.name()).collect(ImmutableSet.toImmutableSet());
-    }
-
-    private void setUserInfoThreadContext(User user) {
-        if (threadContext.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT) == null) {
-            final ImmutableList.Builder<String> builder = ImmutableList.builder();
-            builder.add(user.getName(), String.join(",", user.getRoles()),  String.join(",", user.getOpenDistroSecurityRoles()));
-            String requestedTenant = user.getRequestedTenant();
-            if (!Strings.isNullOrEmpty(requestedTenant)) {
-                builder.add(requestedTenant);
-            }
-            threadContext.putTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT, String.join("|", builder.build()));
-        }
     }
 
     private <Request extends ActionRequest, Response extends ActionResponse> void apply0(Task task, final String action, Request request,
@@ -314,8 +299,6 @@ public class OpenDistroSecurityFilter implements ActionFilter {
             if (log.isDebugEnabled()) {
                 log.debug(pres);
             }
-
-            setUserInfoThreadContext(user);
 
             if (pres.isAllowed()) {
                 auditLog.logGrantedPrivileges(action, request, task);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
@@ -99,7 +99,7 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_USER = OPENDISTRO_SECURITY_CONFIG_PREFIX+"user";
     public static final String OPENDISTRO_SECURITY_USER_HEADER = OPENDISTRO_SECURITY_CONFIG_PREFIX+"user_header";
 
-    public static final String OPENDISTRO_SECURITY_USER_AND_ROLES = OPENDISTRO_SECURITY_CONFIG_PREFIX + "user_and_roles";
+    public static final String OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT = OPENDISTRO_SECURITY_CONFIG_PREFIX + "user_info";
 
     public static final String OPENDISTRO_SECURITY_INJECTED_USER = "injected_user";
     public static final String OPENDISTRO_SECURITY_INJECTED_USER_HEADER = "injected_user_header";

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/user/User.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/user/User.java
@@ -40,8 +40,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.collect.ImmutableList;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -264,14 +262,5 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
     
     public final Set<String> getOpenDistroSecurityRoles() {
         return this.openDistroSecurityRoles == null ? Collections.emptySet() : Collections.unmodifiableSet(this.openDistroSecurityRoles);
-    }
-
-    public final String getUserInfoString() {
-        final ImmutableList.Builder<String> builder = ImmutableList.builder();
-        builder.add(name, String.join(",", getRoles()),  String.join(",", getOpenDistroSecurityRoles()));
-        if (!Strings.isNullOrEmpty(requestedTenant)) {
-            builder.add(requestedTenant);
-        }
-        return String.join("|", builder.build());
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/user/User.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/user/User.java
@@ -40,6 +40,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableList;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -264,7 +266,12 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
         return this.openDistroSecurityRoles == null ? Collections.emptySet() : Collections.unmodifiableSet(this.openDistroSecurityRoles);
     }
 
-    public final String getUserRolesString() {
-        return name + "|" + String.join(",", getRoles()) + "|" + String.join(",", getOpenDistroSecurityRoles());
+    public final String getUserInfoString() {
+        final ImmutableList.Builder<String> builder = ImmutableList.builder();
+        builder.add(name, String.join(",", getRoles()),  String.join(",", getOpenDistroSecurityRoles()));
+        if (!Strings.isNullOrEmpty(requestedTenant)) {
+            builder.add(requestedTenant);
+        }
+        return String.join("|", builder.build());
     }
 }


### PR DESCRIPTION
##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 _Enhancement
 
 2. __Github Issue # or roaddmap entry, if available:__
Cherry-pick of commit (#850, #864, #869, #877)


 3. __Description of changes:__
Cherry-pick of commit (#850, #864, #869, #877)
Adding requested tenant to the thread context transient user info
When plugin gets the transport call, additional tenant info will be part of thread context

 4. __Why these changes are required?__ 
This change is required to support tenant for plugin metadata (Currently Report plugin filters data based on user tenant)


 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screenshot if avaialble_)
Required for new plugin - Kibana Reports


 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manaual testing_) 
 common-utils unit testing for parsing thread context
Integration testing on 7.10
manual testing on 7.9
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide github issues# for each of them)
Changes of Vlad Rozov on top of this PR.


 8. __Is it backport from master branch?__ (_If yes, please add backport PR # and commits #_)
backport PR #850 , #864, #869, #877
cherry-pick commits #7131b6a, f3e474c, f382a82, b710ac7


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
