### PR TITLE
Add security configuration for Kibana Notebooks

### DIFF
--- a/securityconfig/elasticsearch.yml.example
+++ b/securityconfig/elasticsearch.yml.example
@@ -222,4 +222,4 @@ opendistro_security.audit.type: internal_elasticsearch
 # Enable system indices
 # opendistro_security.system_indices.enabled: true
 # Specify a list of indices to mark as system. These indices will only be visible / mutable by members of the above setting, in addition to needing permission to the index via a normal role.
-# opendistro_security.system_indices.indices: ['.opendistro-alerting-config', '.opendistro-ism-*', '.opendistro-reports-*', '.opendistro-notifications-*']
+# opendistro_security.system_indices.indices: ['.opendistro-alerting-config', '.opendistro-ism-*', '.opendistro-reports-*', '.opendistro-notifications-*', '.opendistro-notebooks']

--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -62,6 +62,23 @@ anomaly_full_access:
         - 'indices:admin/aliases/get'
         - 'indices:admin/mappings/get'
 
+# Allows users to read Notebooks
+notebooks_read_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/opendistro/notebooks/list'
+    - 'cluster:admin/opendistro/notebooks/get'
+
+# Allows users to all Notebooks functionality
+notebooks_full_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/opendistro/notebooks/create'
+    - 'cluster:admin/opendistro/notebooks/update'
+    - 'cluster:admin/opendistro/notebooks/delete'
+    - 'cluster:admin/opendistro/notebooks/get'
+    - 'cluster:admin/opendistro/notebooks/list'
+
 # Allows users to read and download Reports
 reports_instances_read_access:
   reserved: true

--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -373,7 +373,7 @@ echo "opendistro_security.enable_snapshot_restore_privilege: true" | $SUDO_CMD t
 echo "opendistro_security.check_snapshot_restore_write_privileges: true" | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 echo 'opendistro_security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 echo 'opendistro_security.system_indices.enabled: true' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
-echo 'opendistro_security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opendistro-notifications-*"]' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
+echo 'opendistro_security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks"]' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 
 #cluster.routing.allocation.disk.threshold_enabled
 if $SUDO_CMD grep --quiet -i "^cluster.routing.allocation.disk.threshold_enabled" "$ES_CONF_FILE"; then


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Added system index configuration for notebooks plugin
Added default roles configuration required for notebooks functionality
Updated demo config and example with above system index configurations

The changes are similar to #836 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.