### PR TITLE
Change CD workflow to use new staging bucket for artifacts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,12 @@
 name: CD
 
 on:
+  # push:
+  #   tags:
+  #     - 'v*'
   push:
-    tags:
-      - 'v*'
+    branches:
+      - "release-workflow-patch"
 
 jobs:
   build:
@@ -44,50 +47,64 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
     - name: Upload Artifacts to S3
       run: |
-        s3_path=s3://artifacts.opendistroforelasticsearch.amazon.com/downloads
-        aws s3 cp artifacts/*.zip $s3_path/elasticsearch-plugins/opendistro-security/
-        aws s3 cp artifacts/*.deb $s3_path/debs/opendistro-security/
-        aws s3 cp artifacts/*.rpm $s3_path/rpms/opendistro-security/
-        aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths '/downloads/*'
+        zip=`ls artifacts/*.zip`
+        rpm=`ls artifacts/*.rpm`
+        deb=`ls artifacts/*.deb`
 
-    - name: Upload Artifacts to Maven Central
-      env:
-        SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
-        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-      run: |
-        gpg --batch --import --no-tty <(echo -e "${{ secrets.PGP_PRIVATE_KEY }}")
-        mvn -B deploy -Padvanced -Prelease -DskipTests -Dgpg.passphrase=${{ secrets.PGP_PASSPHRASE }}
+        # Inject the build number before the suffix
+        zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+        rpm_outfile=`basename ${rpm%.rpm}-build-${GITHUB_RUN_NUMBER}.rpm`
+        deb_outfile=`basename ${deb%.deb}-build-${GITHUB_RUN_NUMBER}.deb`
 
-    - name: Create Github Draft Release
-      id: create_release
-      uses: actions/create-release@v1.0.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ env.TAG_VERSION }}
-        draft: true
-        prerelease: false
+        s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/elasticsearch-plugins/security/"
 
-    - name: Upload Release Asset
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_name: artifacts.zip
-        asset_path: artifacts.zip
-        asset_content_type: application/zip
+        echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
+        aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}
 
-    - name: Upload Workflow Artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: artifacts
-        path: artifacts/
+        echo "Copying ${rpm} to ${s3_prefix}${rpm_outfile}"
+        aws s3 cp --quiet $rpm ${s3_prefix}${rpm_outfile}
+
+        echo "Copying ${deb} to ${s3_prefix}${deb_outfile}"
+        aws s3 cp --quiet $deb ${s3_prefix}${deb_outfile}
+
+    # - name: Upload Artifacts to Maven Central
+    #   env:
+    #     SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+    #     SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+    #   run: |
+    #     gpg --batch --import --no-tty <(echo -e "${{ secrets.PGP_PRIVATE_KEY }}")
+    #     mvn -B deploy -Padvanced -Prelease -DskipTests -Dgpg.passphrase=${{ secrets.PGP_PASSPHRASE }}
+
+    # - name: Create Github Draft Release
+    #   id: create_release
+    #   uses: actions/create-release@v1.0.0
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     tag_name: ${{ github.ref }}
+    #     release_name: Release ${{ env.TAG_VERSION }}
+    #     draft: true
+    #     prerelease: false
+
+    # - name: Upload Release Asset
+    #   id: upload-release-asset
+    #   uses: actions/upload-release-asset@v1.0.1
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+    #     asset_name: artifacts.zip
+    #     asset_path: artifacts.zip
+    #     asset_content_type: application/zip
+
+    # - name: Upload Workflow Artifacts
+    #   uses: actions/upload-artifact@v1
+    #   with:
+    #     name: artifacts
+    #     path: artifacts/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,12 +1,9 @@
 name: CD
 
 on:
-  # push:
-  #   tags:
-  #     - 'v*'
   push:
-    branches:
-      - "release-workflow-patch"
+    tags:
+      - 'v*'
 
 jobs:
   build:
@@ -73,38 +70,38 @@ jobs:
         echo "Copying ${deb} to ${s3_prefix}${deb_outfile}"
         aws s3 cp --quiet $deb ${s3_prefix}${deb_outfile}
 
-    # - name: Upload Artifacts to Maven Central
-    #   env:
-    #     SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
-    #     SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-    #   run: |
-    #     gpg --batch --import --no-tty <(echo -e "${{ secrets.PGP_PRIVATE_KEY }}")
-    #     mvn -B deploy -Padvanced -Prelease -DskipTests -Dgpg.passphrase=${{ secrets.PGP_PASSPHRASE }}
+    - name: Upload Artifacts to Maven Central
+      env:
+        SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      run: |
+        gpg --batch --import --no-tty <(echo -e "${{ secrets.PGP_PRIVATE_KEY }}")
+        mvn -B deploy -Padvanced -Prelease -DskipTests -Dgpg.passphrase=${{ secrets.PGP_PASSPHRASE }}
 
-    # - name: Create Github Draft Release
-    #   id: create_release
-    #   uses: actions/create-release@v1.0.0
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     tag_name: ${{ github.ref }}
-    #     release_name: Release ${{ env.TAG_VERSION }}
-    #     draft: true
-    #     prerelease: false
+    - name: Create Github Draft Release
+      id: create_release
+      uses: actions/create-release@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ env.TAG_VERSION }}
+        draft: true
+        prerelease: false
 
-    # - name: Upload Release Asset
-    #   id: upload-release-asset
-    #   uses: actions/upload-release-asset@v1.0.1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-    #     asset_name: artifacts.zip
-    #     asset_path: artifacts.zip
-    #     asset_content_type: application/zip
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_name: artifacts.zip
+        asset_path: artifacts.zip
+        asset_content_type: application/zip
 
-    # - name: Upload Workflow Artifacts
-    #   uses: actions/upload-artifact@v1
-    #   with:
-    #     name: artifacts
-    #     path: artifacts/
+    - name: Upload Workflow Artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: artifacts
+        path: artifacts/


### PR DESCRIPTION
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
Maintenance
 
 
 2. __Github Issue # or road-map entry, if available:__



 3. __Description of changes:__
The infrastructure team is separating the production and staging locations into different AWS accounts. Plugins need to modify their workflows to publish to the new locations. This PR changes the CD workflow to add a build number and write the zip, deb, and rpm plugin artifacts to staging.artifacts.opendistroforelasticsearch.amazon.com.


 4. __Why these changes are required?__  To adapt new release process

 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)
Github build number is added in the artifact name. Detailed discussion in previous [pull request](https://github.com/opendistro-for-elasticsearch/security/pull/767)


 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 https://github.com/gaiksaya/security/actions/runs/478877866 Tested using the same AWS user permissions as used by this workflow
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)
Please change the artifact name (zip file name) to follow the standard guidelines before merging this PR. Also do not merge until asked as we would need to coordinate the merge with changes in opendistro-build repo


 8. __Is it backport from master branch?__ (_If yes, please add backport PR # and commits #_) No



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
