### PR TITLE
Rename security plugin artifacts from opendistro_security to opendistro-security

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build
       run: |
         mvn -B clean package -Padvanced -DskipTests
-        artifact_zip=`ls $(pwd)/target/releases/opendistro_security-*.zip | grep -v admin-standalone`
+        artifact_zip=`ls $(pwd)/target/releases/opendistro-security-*.zip | grep -v admin-standalone`
         ./gradlew build buildDeb buildRpm --no-daemon -ParchivePath=$artifact_zip -Dbuild.snapshot=false
         mkdir artifacts
         cp $artifact_zip artifacts/

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ mvn clean test
 
 ```
 mvn clean package -Padvanced -DskipTests
-artifact_zip=`ls $(pwd)/target/releases/opendistro_security-*.zip | grep -v admin-standalone`
+artifact_zip=`ls $(pwd)/target/releases/opendistro-security-*.zip | grep -v admin-standalone`
 ./gradlew build buildDeb buildRpm --no-daemon -ParchivePath=$artifact_zip -Dbuild.snapshot=false
 ```
 

--- a/dev/scan_veracode.sh
+++ b/dev/scan_veracode.sh
@@ -21,7 +21,7 @@ echo "Sandbox Id: $SANDBOXID"
 
 echo "Build Security ..."
 mvn clean package -Pveracode -DskipTests > /dev/null 2>&1
-PLUGIN_FILE=($DIR/../target/veracode/opendistro_security*.zip)
+PLUGIN_FILE=($DIR/../target/veracode/opendistro-security*.zip)
 
 FILESIZE=$(wc -c <"$PLUGIN_FILE")
 echo ""

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazon.opendistroforelasticsearch</groupId>
-    <artifactId>opendistro_security</artifactId>
+    <artifactId>opendistro-security</artifactId>
     <packaging>jar</packaging>
     <version>1.12.0.0</version>
     <name>Open Distro Security for Elasticsearch</name>
@@ -885,7 +885,7 @@
                                 <fileSet>
                                     <directory>${project.build.directory}/releases/</directory>
                                     <includes>
-                                        <include>opendistro_security-${version}.zip</include>
+                                        <include>opendistro-security-${version}.zip</include>
                                     </includes>
                                 </fileSet>
                             </fileSets>


### PR DESCRIPTION
##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 Maintenance
 
 
 2. __Github Issue # or road-map entry, if available:__



 3. __Description of changes:__
Rename .zip file from opendistro_security to opendistro-security to comply with [ODFE artifacts naming convention](https://quip-amazon.com/gmuHA2uDtWHV/ODFE-artifact-naming-convention)


 4. __Why these changes are required?__ 
The [naming convention tracker ](https://quip-amazon.com/7fg8AqP9aMzM/ODFE-artifact-naming-convention-tracker#s:QFO9CAXScUB;QFO9CAPb1Xh) requires security plugin to rename the zip file.



 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)
Old name: opendistro_security-1.12.0.0.zip
New name: opendistro-security-1.12.0.0.zip


 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 UT and MT
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)



 8. __Is it backport from master branch?__ (_If yes, please add backport PR # and commits #_)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
