### PR TITLE
Revert "Using SAML subject_key and roles_key in the HTTPSamlAuthentic…

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
@@ -338,12 +338,12 @@ public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
 
         settingsBuilder.put(jwtSettings);
 
-        if (jwtSettings.get("roles_key") == null) {
-            settingsBuilder.put("roles_key", settings.get("roles_key", "roles"));
+        if (jwtSettings.get("roles_key") == null && settings.get("roles_key") != null) {
+            settingsBuilder.put("roles_key", "roles");
         }
 
         if (jwtSettings.get("subject_key") == null) {
-            settingsBuilder.put("subject_key", settings.get("subject_key", "sub"));
+            settingsBuilder.put("subject_key", "sub");
         }
 
         return settingsBuilder.build();


### PR DESCRIPTION
…ator"

This reverts commit 59d12de396b160dac469b5e10c10c617fd2a4111.


##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 Bug fix
 
 
 2. __Github Issue # or road-map entry, if available:__



 3. __Description of changes:__
We made a change to default JWT subject_key to SAML subject_key if SAML subject_key is present. 

However JWT keys have specific values and cannot always take up SAML key values. This is why we are reverting this fix.


 4. __Why these changes are required?__ 



 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)



 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 Tested on local environment. 
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)



 8. __Is it backport from master branch?__ (_If yes, please add backport PR # and commits #_)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
