### PR TITLE
Fix for "java.lang.IllegalArgumentException: The array of keys must not be null" for "_cat/health" requests

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
@@ -294,7 +294,8 @@ public class IndexResolverReplacer {
             final IndicesOptions indicesOptions = indicesOptionsFrom(localRequest);
             final boolean enableCrossClusterResolution = localRequest instanceof FieldCapabilitiesRequest || localRequest instanceof SearchRequest;
             // skip the whole thing if we have seen this exact resolveIndexPatterns request
-            if (alreadyResolved.add(new MultiKey(indicesOptions, enableCrossClusterResolution, new MultiKey(original, false)))) {
+            if (alreadyResolved.add(new MultiKey(indicesOptions, enableCrossClusterResolution,
+                    (original != null) ? new MultiKey(original, false) : null))) {
                 resolveIndexPatterns(localRequest.getClass().getSimpleName(), indicesOptions, enableCrossClusterResolution, original);
             }
             return IndicesProvider.NOOP;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/IntegrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/IntegrationTests.java
@@ -887,4 +887,13 @@ public class IntegrationTests extends SingleClusterTest {
         Assert.assertEquals(201, jsonNode.get("items").get(2).get("index").get("status").intValue());
         Assert.assertEquals(403, jsonNode.get("items").get(3).get("delete").get("status").intValue());
     }
+
+    @Test
+    public void testMonitorHealth() throws Exception {
+
+        setup(Settings.EMPTY, new DynamicSecurityConfig(), Settings.EMPTY);
+
+        RestHelper rh = nonSslRestHelper();
+        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_cat/health",encodeBasicHeader("picard", "picard")).getStatusCode());
+    }
 }


### PR DESCRIPTION


##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 bug fix
 
 
 2. __Github Issue # or road-map entry, if available:__
#1042


 3. __Description of changes:__



 4. __Why these changes are required?__ 



 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)



 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)



 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)





By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
