### PR TITLE
Bump version to 1.13.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 buildDir = 'gradle-build'
 
 ext {
-    opendistroVersion = '1.13.0'
+    opendistroVersion = '1.13.1'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 

--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -3,7 +3,7 @@
 description=Provide access control related features for Elasticsearch 7
 #
 # 'version': plugin's version
-version=1.13.0.0
+version=1.13.1.0
 #
 # 'name': the plugin name
 name=opendistro_security

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <groupId>com.amazon.opendistroforelasticsearch</groupId>
     <artifactId>opendistro_security</artifactId>
     <packaging>jar</packaging>
-    <version>1.13.0.0</version>
+    <version>1.13.1.0</version>
     <name>Open Distro Security for Elasticsearch</name>
     <description>Open Distro For Elasticsearch Security</description>
     <url>https://github.com/opendistro-for-elasticsearch/security</url>
@@ -103,7 +103,7 @@
         <url>https://github.com/opendistro-for-elasticsearch/security</url>
         <connection>scm:git:git@github.com:opendistro-for-elasticsearch/security.git</connection>
         <developerConnection>scm:git:git@github.com:opendistro-for-elasticsearch/security.git</developerConnection>
-        <tag>1.13.0.0</tag>
+        <tag>1.13.1.0</tag>
     </scm>
 
     <issueManagement>

--- a/release-notes/opendistro-for-elasticsearch-security.release-notes-1.13.1.0.md
+++ b/release-notes/opendistro-for-elasticsearch-security.release-notes-1.13.1.0.md
@@ -1,0 +1,11 @@
+## 2021-03-02 Version 1.13.1.0
+
+Compatible with Elasticsearch 7.10.2
+
+### Bug fixes
+
+* Fix for "java.lang.IllegalArgumentException: The array of keys must not be null" for "_cat/health" requests ([#1048](https://github.com/opendistro-for-elasticsearch/security/pull/1048))
+
+### Maintenance
+
+* Bump version to 1.13.1.0 ([#1054](https://github.com/opendistro-for-elasticsearch/security/pull/1054))


### PR DESCRIPTION
##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 Maintenance
 
 
 2. __Github Issue # or road-map entry, if available:__



 3. __Description of changes:__
Bump version to 1.13.1.0


 4. __Why these changes are required?__ 
Release 1.13.1.0


 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)
No changes in behavior


 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 UT
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)



 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)





By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
