### PR TITLE
Correcting setupSslOnlyMode to use AbstractSecurityUnitTest.hasCustom…

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/SSLTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/ssl/SSLTest.java
@@ -954,7 +954,7 @@ public class SSLTest extends SingleClusterTest {
 
             .build();
 
-        setupSslOnlyMode(settings, true);
+        setupSslOnlyMode(settings);
 
         RestHelper rh = restHelper();
         rh.enableHTTPClientSSL = true;
@@ -1031,7 +1031,7 @@ public class SSLTest extends SingleClusterTest {
             .put(SSLConfigConstants.OPENDISTRO_SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH, FileHelper. getAbsoluteFilePathFromClassPath("ssl/root-ca.pem"))
             .build();
 
-        setupSslOnlyMode(settings, true);
+        setupSslOnlyMode(settings);
 
         RestHelper rh = restHelper();
         rh.enableHTTPClientSSL = true;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/SingleClusterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/SingleClusterTest.java
@@ -103,12 +103,8 @@ public abstract class SingleClusterTest extends AbstractSecurityUnitTest {
     }
 
     protected void setupSslOnlyMode(Settings nodeOverride) throws Exception {
-        setupSslOnlyMode(nodeOverride, false);
-    }
-
-    protected void setupSslOnlyMode(Settings nodeOverride, boolean hasCustomTransportSettings) throws Exception {
         Assert.assertNull("No cluster", clusterInfo);
-        clusterInfo = clusterHelper.startCluster(minimumSecuritySettingsSslOnly(nodeOverride, hasCustomTransportSettings), ClusterConfiguration.DEFAULT);
+        clusterInfo = clusterHelper.startCluster(minimumSecuritySettingsSslOnly(nodeOverride), ClusterConfiguration.DEFAULT);
     }
 
     protected void setupSslOnlyModeWithMasterNodeWithoutSSL(Settings nodeOverride) throws Exception {


### PR DESCRIPTION
…TransportSettings()


##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
Test fix
 
 2. __Github Issue # or road-map entry, if available:__
N/A


 3. __Description of changes:__
The setupSslOnlyMode helper method was incorrectly assuming that the hasCustomTransportSettings would always be false. Making this change to use AbstractSecurityUnitTest.hasCustomTransportSettings() helper. 

I have also modified AbstractSecurityUnitTest.hasCustomTransportSettings() to return false if OPENDISTRO_SECURITY_SSL_TRANSPORT_EXTENDED_KEY_USAGE_ENABLED flag is defined in the settings


 4. __Why these changes are required?__ 
See description.


 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)



 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)



 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)





By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
