### PR TITLE
Check and create multi-tenant index with alias for Update and Delete requests. Try to find a name for the multi-tenant index if index/alias with ".kibana_..._#" already exists

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/PrivilegesInterceptorImpl.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/PrivilegesInterceptorImpl.java
@@ -15,9 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.security.configuration;
 
-import java.util.Arrays;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
@@ -28,6 +26,7 @@ import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.IndicesRequest.Replaceable;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsIndexRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
@@ -61,7 +60,6 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
 
     private static final String USER_TENANT = "__user__";
     private static final String EMPTY_STRING = "";
-    private static final String KIBANA_INDEX_SUFFIX = "_1";
     private static final Map<String, Object> KIBANA_INDEX_SETTINGS = ImmutableMap.of(
             IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1,
             IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1"
@@ -186,26 +184,43 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
         return CONTINUE_EVALUATION_REPLACE_RESULT;
     }
 
-    private CreateIndexRequest newCreateIndexRequestIfAbsent(final String name) {
-        final Map<String, IndexAbstraction> indicesLookup = clusterService.state().getMetadata().getIndicesLookup();
-        final String concreteName = name.concat(KIBANA_INDEX_SUFFIX);
-        if (Arrays.stream(new String[]{name, concreteName})
-                .map(s -> indicesLookup.get(s))
-                .filter(Objects::nonNull)
-                .peek(ia -> log.debug("{} {} already exists", ia.getType(), ia.getName()))
-                .findFirst()
-                .isPresent()) {
-            return null;
-        } else {
-            return new CreateIndexRequest(concreteName)
-                    .alias(new Alias(name))
-                    .settings(KIBANA_INDEX_SETTINGS);
+    private String getConcreteIndexName(String name, Map<String, IndexAbstraction> indicesLookup) {
+        for (int i = 1; i < Integer.MAX_VALUE; i++) {
+            String concreteName = name.concat("_" + i);
+            if (indicesLookup.get(concreteName) == null) {
+                return concreteName;
+            }
         }
+        log.warn("Can not find a suitable name for kibana multi-tenant index {}", name);
+        return null;
+
     }
 
-    private CreateIndexRequest replaceIndex(final ActionRequest request, final String oldIndexName, final String newIndexName, final String action) {
+    private CreateIndexRequestBuilder newCreateIndexRequestBuilderIfAbsent(final String name) {
+        final Map<String, IndexAbstraction> indicesLookup = clusterService.state().getMetadata().getIndicesLookup();
+        IndexAbstraction indexAbstraction = indicesLookup.get(name);
+        if (indexAbstraction != null) {
+            if (indexAbstraction.getType() == IndexAbstraction.Type.ALIAS) {
+                log.debug("Alias {} already exists", name);
+            } else {
+                log.warn("Can not create kibana multi-tenant alias {} as an index with the same name already exists", name);
+            }
+            return null;
+        }
+        String concreteName = getConcreteIndexName(name, indicesLookup);
+        if (concreteName != null) {
+            return client.admin().indices()
+                .prepareCreate(concreteName)
+                .addAlias(new Alias(name))
+                .setSettings(KIBANA_INDEX_SETTINGS)
+                .setCause("auto(multi-tenant)");
+        }
+        return null;
+    }
+
+    private CreateIndexRequestBuilder replaceIndex(final ActionRequest request, final String oldIndexName, final String newIndexName, final String action) {
         boolean kibOk = false;
-        CreateIndexRequest createIndexRequest = null;
+        CreateIndexRequestBuilder createIndexRequestBuilder = null;
 
         if (log.isDebugEnabled()) {
             log.debug("{} index will be replaced with {} in this {} request", oldIndexName, newIndexName, request.getClass().getName());
@@ -219,27 +234,35 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
 
         // CreateIndexRequest
         if (request instanceof CreateIndexRequest) {
-            // use new name for alias and suffixed index name
-            ((CreateIndexRequest) request).index(newIndexName.concat(KIBANA_INDEX_SUFFIX)).alias(new Alias(newIndexName));
+            String concreteName = getConcreteIndexName(newIndexName, clusterService.state().getMetadata().getIndicesLookup());
+            if (concreteName != null) {
+                // use new name for alias and suffixed index name
+                ((CreateIndexRequest) request).index(concreteName).alias(new Alias(newIndexName));
+            } else {
+                ((CreateIndexRequest) request).index(newIndexName);
+            }
             kibOk = true;
         } else if (request instanceof BulkRequest) {
-
-            for (DocWriteRequest<?> ar : ((BulkRequest) request).requests()) {
+            BulkRequest bulkRequest = (BulkRequest) request;
+            for (DocWriteRequest<?> ar : bulkRequest.requests()) {
 
                 if (ar instanceof DeleteRequest) {
                     ((DeleteRequest) ar).index(newIndexName);
                 }
 
                 if (ar instanceof IndexRequest) {
-                    if (createIndexRequest == null) {
-                        createIndexRequest = newCreateIndexRequestIfAbsent(newIndexName);
-                    }
                     ((IndexRequest) ar).index(newIndexName);
                 }
 
                 if (ar instanceof UpdateRequest) {
                     ((UpdateRequest) ar).index(newIndexName);
                 }
+            }
+
+            // Please see comment for DeleteRequest below. Multi-tenant index may be auto created for any type of
+            // DocWriteRequest
+            if (!bulkRequest.requests().isEmpty()) {
+                createIndexRequestBuilder = newCreateIndexRequestBuilderIfAbsent(newIndexName);
             }
 
             kibOk = true;
@@ -269,13 +292,19 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
             kibOk = true;
         } else if (request instanceof UpdateRequest) {
             ((UpdateRequest) request).index(newIndexName);
+            createIndexRequestBuilder = newCreateIndexRequestBuilderIfAbsent(newIndexName);
             kibOk = true;
         } else if (request instanceof IndexRequest) {
-            createIndexRequest = newCreateIndexRequestIfAbsent(newIndexName);
+            createIndexRequestBuilder = newCreateIndexRequestBuilderIfAbsent(newIndexName);
             ((IndexRequest) request).index(newIndexName);
             kibOk = true;
         } else if (request instanceof DeleteRequest) {
             ((DeleteRequest) request).index(newIndexName);
+            // Usually only IndexRequest and UpdateRequest auto create index if it does not exist,
+            // but custom DeleteRequest can also auto create index (see TransportBulkAction.doInternalExecute()).
+            // It should be OK to create the index in a rare cases where it would not be created otherwise to minimize
+            // the risk of auto create that will create the tenant index without the alias.
+            createIndexRequestBuilder = newCreateIndexRequestBuilderIfAbsent(newIndexName);
             kibOk = true;
         } else if (request instanceof SingleShardRequest) {
             ((SingleShardRequest<?>) request).index(newIndexName);
@@ -299,7 +328,7 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
         if (!kibOk) {
             log.warn("Dont know what to do (2) with {}", request.getClass());
         }
-        return createIndexRequest;
+        return createIndexRequestBuilder;
     }
 
     private String toUserIndexName(final String originalKibanaIndex, final String tenant) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
@@ -301,7 +301,7 @@ public class PrivilegesEvaluator {
                                 auditLog.logMissingPrivileges(action0, request, task);
                             } else {
                                 presponse.allowed = true;
-                                presponse.request = replaceResult.createIndexRequest;
+                                presponse.createIndexRequestBuilder = replaceResult.createIndexRequestBuilder;
                             }
                             return presponse;
                         }
@@ -383,7 +383,7 @@ public class PrivilegesEvaluator {
                     auditLog.logMissingPrivileges(action0, request, task);
                 } else {
                     presponse.allowed = true;
-                    presponse.request = replaceResult.createIndexRequest;
+                    presponse.createIndexRequestBuilder = replaceResult.createIndexRequestBuilder;
                 }
                 return presponse;
             }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluatorResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluatorResponse.java
@@ -30,7 +30,7 @@
 
 package com.amazon.opendistroforelasticsearch.security.privileges;
 
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -43,7 +43,7 @@ public class PrivilegesEvaluatorResponse {
     Map<String,Set<String>> maskedFields;
     Map<String,Set<String>> queries;
     PrivilegesEvaluatorResponseState state = PrivilegesEvaluatorResponseState.PENDING;
-    CreateIndexRequest request;
+    CreateIndexRequestBuilder createIndexRequestBuilder;
     
     public boolean isAllowed() {
         return allowed;
@@ -64,8 +64,8 @@ public class PrivilegesEvaluatorResponse {
         return queries;
     }
 
-    public CreateIndexRequest getRequest() {
-        return request;
+    public CreateIndexRequestBuilder getCreateIndexRequestBuilder() {
+        return createIndexRequestBuilder;
     }
     
     public PrivilegesEvaluatorResponse markComplete() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesInterceptor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesInterceptor.java
@@ -33,7 +33,7 @@ package com.amazon.opendistroforelasticsearch.security.privileges;
 import java.util.Map;
 
 import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -49,20 +49,20 @@ public class PrivilegesInterceptor {
     public static class ReplaceResult {
         final boolean continueEvaluation;
         final boolean accessDenied;
-        final CreateIndexRequest createIndexRequest;
+        final CreateIndexRequestBuilder createIndexRequestBuilder;
 
-        private ReplaceResult(boolean continueEvaluation, boolean accessDenied, CreateIndexRequest createIndexRequest) {
+        private ReplaceResult(boolean continueEvaluation, boolean accessDenied, CreateIndexRequestBuilder createIndexRequestBuilder) {
             this.continueEvaluation = continueEvaluation;
             this.accessDenied = accessDenied;
-            this.createIndexRequest = createIndexRequest;
+            this.createIndexRequestBuilder = createIndexRequestBuilder;
         }
     }
 
     public static final ReplaceResult CONTINUE_EVALUATION_REPLACE_RESULT = new ReplaceResult(true, false, null);
     public static final ReplaceResult ACCESS_DENIED_REPLACE_RESULT = new ReplaceResult(false, true, null);
     public static final ReplaceResult ACCESS_GRANTED_REPLACE_RESULT = new ReplaceResult(false, false, null);
-    protected static ReplaceResult newAccessGrantedReplaceResult(CreateIndexRequest createIndexRequest) {
-        return new ReplaceResult(false, false, createIndexRequest);
+    protected static ReplaceResult newAccessGrantedReplaceResult(CreateIndexRequestBuilder createIndexRequestBuilder) {
+        return new ReplaceResult(false, false, createIndexRequestBuilder);
     }
 
     protected final IndexNameExpressionResolver resolver;


### PR DESCRIPTION
##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 Enhancement
 
 
 2. __Github Issue # or road-map entry, if available:__



 3. __Description of changes:__
 Include Update and Delete requests into the type of requests for which it is necessary to check if it is necessary to explicitly request mutli-tenant index creation with alias to avoid index being auto-created. 


 4. __Why these changes are required?__ 
By using Kibana API (not UI) it is possible to trigger Update and Delete requests that will create multi-tenant index without an alias and may cause Kibana migration logic to break.


 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)



 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)



 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)





By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
