### PR TITLE
 Remove code setting the value for cluster.routing.allocation.disk.threshold_enabled

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/cluster/ClusterHelper.java
@@ -360,7 +360,6 @@ public final class ClusterHelper {
                 .put("transport.tcp.port", tcpPort)
                 .put("http.port", httpPort)
                 //.put("http.enabled", true)
-                .put("cluster.routing.allocation.disk.threshold_enabled", false)
                 .put("http.cors.enabled", true)
                 .put("path.home", "./target");
     }

--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -375,13 +375,6 @@ echo 'opendistro_security.restapi.roles_enabled: ["all_access", "security_rest_a
 echo 'opendistro_security.system_indices.enabled: true' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 echo 'opendistro_security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".opendistro-asynchronous-search-response*"]' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
 
-#cluster.routing.allocation.disk.threshold_enabled
-if $SUDO_CMD grep --quiet -i "^cluster.routing.allocation.disk.threshold_enabled" "$ES_CONF_FILE"; then
-	: #already present
-else
-    echo 'cluster.routing.allocation.disk.threshold_enabled: false' | $SUDO_CMD tee -a "$ES_CONF_FILE" > /dev/null
-fi
-
 #network.host
 if $SUDO_CMD grep --quiet -i "^network.host" "$ES_CONF_FILE"; then
 	: #already present


### PR DESCRIPTION
Co-Authored-By: Vincenzo De Naro Papa <vincenzo.denaropapa@gmail.com>


##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 Maintenance
 
 
 2. __Github Issue # or road-map entry, if available:__
#208


 3. __Description of changes:__
Remove sample code adding excessive change to ES cluster configuration
And remove such setting in test code to reflect such behavior


 4. __Why these changes are required?__ 
 Reduce confusion and prevent altering configuration that is unrelated to the plugin


 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)
Old behavior: `cluster.routing.allocation.disk.threshold_enabled` is forced to `false` after running `install_demo_configuration.sh`
New behavior: such configuration is left unchanged, either default value (`true`) or otherwise configured value will be taken


 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
  Unit Test, CI tests
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)



 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)
 No




By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
