### PR TITLE
Backport to opendistro-1.0

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilter.java
@@ -317,6 +317,13 @@ public class OpenDistroSecurityFilter implements ActionFilter {
                 listener.onFailure(new ElasticsearchSecurityException("no permissions for " + pres.getMissingPrivileges()+" and "+user, RestStatus.FORBIDDEN));
                 return;
             }
+        } catch (ElasticsearchException e) {
+            if (task != null) {
+                log.debug("Failed to apply filter. Task id: {} ({}). Action: {}", task.getId(), task.getDescription(), action, e);
+            } else {
+                log.debug("Failed to apply filter. Action: {}", action, e);
+            }
+            listener.onFailure(e);
         } catch (Throwable e) {
             log.error("Unexpected exception "+e, e);
             listener.onFailure(new ElasticsearchSecurityException("Unexpected exception " + action, RestStatus.INTERNAL_SERVER_ERROR));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/IndexIntegrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/IndexIntegrationTests.java
@@ -30,6 +30,7 @@
 
 package com.amazon.opendistroforelasticsearch.security;
 
+import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
@@ -454,6 +455,17 @@ public class IndexIntegrationTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("*kibana/_search?pretty", encodeBasicHeader("aliastest", "nagilum")).getStatusCode());
         Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest(".ki*ana/_search?pretty", encodeBasicHeader("aliastest", "nagilum")).getStatusCode());
         Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest(".kibana/_search?pretty", encodeBasicHeader("aliastest", "nagilum")).getStatusCode());
+    }
+
+    @Test
+    public void testIndexResolveInvalidIndexName() throws Exception {
+        setup();
+        final RestHelper rh = nonSslRestHelper();
+
+        // invalid_index_name_exception should be thrown and responded when invalid index name is mentioned in requests.
+        HttpResponse res = rh.executeGetRequest(URLEncoder.encode("_##pdt_data/_search", "UTF-8"), encodeBasicHeader("ccsresolv", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, res.getStatusCode());
+        Assert.assertTrue(res.getBody().contains("invalid_index_name_exception"));
     }
     
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/sink/WebhookAuditLogTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/auditlog/sink/WebhookAuditLogTest.java
@@ -446,11 +446,11 @@ public class WebhookAuditLogTest {
 
 	@Test
     public void httpsTestPemDefault() throws Exception {
-
+        final int port = 8088;
         TestHttpHandler handler = new TestHttpHandler();
 
         server = ServerBootstrap.bootstrap()
-                .setListenerPort(8084)
+                .setListenerPort(port)
                 .setServerInfo("Test/1.1")
                 .setSslContext(createSSLContext())
                 .registerHandler("*", handler)
@@ -460,7 +460,7 @@ public class WebhookAuditLogTest {
         AuditMessage msg = MockAuditMessageFactory.validAuditMessage();
         LoggingSink fallback =  new LoggingSink("test", Settings.EMPTY, null, null);
 
-        String url = "https://localhost:8084/endpoint";
+        String url = "https://localhost:" + port + "/endpoint";
 
         // test default with filepath
         handler.reset();


### PR DESCRIPTION
##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 Bug fix
 
 
 2. __Github Issue # or road-map entry, if available:__
#718 


 3. __Description of changes:__



 4. __Why these changes are required?__ 
When an index with invalid name is mentioned, instead of returning `invalid_index_name_exception` security plugin throws `security_exception`, which misleads users.


 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)
**Old behavior:** When an index with invalid name is mentioned, security plugin throws `security_exception`
**New bahavior** Returning `invalid_index_name_exception`


 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 UT
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)



 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)
**PR:** #865 
**commits:** 7c5dbb947e2c2ecb3fa51a267b968556428a3cff




By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
