### PR TITLE
[Fix][Usage][Hasher] wrong file reference hash.sh

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/tools/Hasher.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/tools/Hasher.java
@@ -74,7 +74,7 @@ public class Hasher {
             }  
         } catch (final Exception exp) {
             System.err.println("Parsing failed.  Reason: " + exp.getMessage());
-            formatter.printHelp("hasher.sh", options, true);
+            formatter.printHelp("hash.sh", options, true);
             System.exit(-1);
         }
     }


### PR DESCRIPTION
##  opendistro-for-elasticsearch/security pull request intake form

change the Java helper for cli reference for hash.sh

helper for this function is set to display "usage: hasher.sh [-env <name environment variable>] [-p <password>]" 
while it refers to hash.sh
https://github.com/opendistro-for-elasticsearch/security/blob/main/tools/hash.sh

 
 1. __Category:__ Bug fix
 
 
 
 2. __Github Issue # or road-map entry, if available:__



 3. __Description of changes:__
change the Java helper for cli reference for hash.sh that was previously reference to hasher.sh


 4. __Why these changes are required?__ 
misleading usage helper for the hash.sh cli


 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)

![image](https://user-images.githubusercontent.com/690878/111590176-14f7f180-87c6-11eb-83dd-80736498e74f.png)


 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)



 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)





By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
