### PR TITLE
Fix resolve api permission

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
@@ -387,16 +387,16 @@ public class PrivilegesEvaluator {
         }
 
         if (dnfofEnabled
-                && (action0.startsWith("indices:data/read/")
-                || action0.startsWith("indices:admin/mappings/fields/get")
-                || action0.equals("indices:admin/shards/search_shards"))) {
+            && (action0.startsWith("indices:data/read/")
+            || action0.startsWith("indices:admin/mappings/fields/get")
+            || action0.equals("indices:admin/shards/search_shards")
+            || action0.equals("indices:admin/resolve/index"))) {
 
             if(requestedResolved.getAllIndices().isEmpty()) {
                 presponse.missingPrivileges.clear();
                 presponse.allowed = true;
                 return presponse;
             }
-
 
             Set<String> reduced = securityRoles.reduce(requestedResolved, user, allIndexPermsRequiredA, resolver, clusterService);
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
@@ -372,7 +372,8 @@ public class PrivilegesEvaluator {
             final PrivilegesInterceptor.ReplaceResult replaceResult = privilegesInterceptor.replaceKibanaIndex(request, action0, user, dcm, requestedResolved, mapTenants(user, mappedRoles));
 
             if (isDebugEnabled) {
-                log.debug("Result from privileges interceptor: {}", replaceResult);
+                log.debug("Result from privileges interceptor: continueEvaluation: {}, accessDenied: {}, createIndexRequestBuilder: {}",
+                        replaceResult.continueEvaluation, replaceResult.accessDenied, replaceResult.createIndexRequestBuilder);
             }
 
             if (!replaceResult.continueEvaluation) {
@@ -386,11 +387,11 @@ public class PrivilegesEvaluator {
             }
         }
 
-        if (dnfofEnabled
+        if (action0.equals("indices:admin/resolve/index") ||
+            (dnfofEnabled
             && (action0.startsWith("indices:data/read/")
             || action0.startsWith("indices:admin/mappings/fields/get")
-            || action0.equals("indices:admin/shards/search_shards")
-            || action0.equals("indices:admin/resolve/index"))) {
+            || action0.equals("indices:admin/shards/search_shards")))) {
 
             if(requestedResolved.getAllIndices().isEmpty()) {
                 presponse.missingPrivileges.clear();
@@ -430,14 +431,12 @@ public class PrivilegesEvaluator {
                 return presponse;
             }
 
-
             if(irr.replace(request, true, reduced.toArray(new String[0]))) {
                 presponse.missingPrivileges.clear();
                 presponse.allowed = true;
                 return presponse;
             }
         }
-
 
         //not bulk, mget, etc request here
         boolean permGiven = false;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/PrivilegesEvaluator.java
@@ -372,8 +372,7 @@ public class PrivilegesEvaluator {
             final PrivilegesInterceptor.ReplaceResult replaceResult = privilegesInterceptor.replaceKibanaIndex(request, action0, user, dcm, requestedResolved, mapTenants(user, mappedRoles));
 
             if (isDebugEnabled) {
-                log.debug("Result from privileges interceptor: continueEvaluation: {}, accessDenied: {}, createIndexRequestBuilder: {}",
-                        replaceResult.continueEvaluation, replaceResult.accessDenied, replaceResult.createIndexRequestBuilder);
+                log.debug("Result from privileges interceptor: {}", replaceResult);
             }
 
             if (!replaceResult.continueEvaluation) {


### PR DESCRIPTION
##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 Bug fix
 
 
 2. __Github Issue # or road-map entry, if available:__
https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/issues/598
https://github.com/opendistro-for-elasticsearch/security/issues/893


 3. __Description of changes:__
Apply the logic replacing returned query as if `"do_not_fail_on_forbidden": true` is always turned on `_resolve` endpoint


 4. __Why these changes are required?__ 
Starting from version 7.9, Kibana starts using `_resolve` endpoint to retrieve indices avalible to users for rendering index pattern creation page


 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)
Kibana failed to allow user to create indix pattern that matches existing valid indices, as per described in ticket: https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/issues/598


 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 manual test navigating to index pattern creation
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)
- Research how kibana used to work with search api that does not raise such issue
- Add full support to `_resolve` end point, as if it were a `_search` call, to security plugin, include unit tests that covers it


 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)





By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
